### PR TITLE
Bold author usernames

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -27,8 +27,8 @@
 		</div>
 		<form class="new-post-form" @submit.prevent="createPost">
 			<div class="author currentUser">
-				{{ currentUser.displayName }}
-				<span class="social-id">{{ socialId }}</span>
+				<span class="post-author">{{ currentUser.displayName }}</span>
+				<span class="post-author-id">{{ socialId }}</span>
 			</div>
 			<vue-tribute :options="tributeOptions">
 				<!-- eslint-disable-next-line vue/valid-v-model -->
@@ -85,6 +85,7 @@
 		z-index: 100;
 		margin-bottom: 10px;
 	}
+
 	.new-post-author {
 		padding: 5px;
 	}
@@ -100,8 +101,12 @@
 		min-height: 70px;
 	}
 
-	.author .social-id {
-		opacity: .5;
+	.post-author {
+		font-weight: bold;
+	}
+
+	.post-author-id {
+		opacity: .7;
 	}
 
 	[contenteditable=true]:empty:before{

--- a/src/components/TimelineEntry.vue
+++ b/src/components/TimelineEntry.vue
@@ -77,6 +77,10 @@ export default {
 		margin-top: 0;
 	}
 
+	.post-author {
+		font-weight: bold;
+	}
+
 	.post-author-id {
 		opacity: .7;
 	}

--- a/src/components/UserEntry.vue
+++ b/src/components/UserEntry.vue
@@ -92,6 +92,10 @@ export default {
 		flex-shrink: 0;
 	}
 
+	.post-author {
+		font-weight: bold;
+	}
+
 	.entry-content {
 		display: flex;
 		align-items: flex-start;


### PR DESCRIPTION
On the screenshot at https://github.com/nextcloud-gmbh/social/blob/168655fba0deebfa4b13a8e80ce6484520631e79/img/screenshot.png the focus was clearly missing:
![](https://raw.githubusercontent.com/nextcloud-gmbh/social/168655fba0deebfa4b13a8e80ce6484520631e79/img/screenshot.png?token=AA4dhvhbY7DUzOOAnEBL1fXqVp2SV5e_ks5cEBQIwA%3D%3D)

So I bolded the usernames and it works quite well. Afterwards I also checked and Twitter and Mastodon do the same 😅

Please review @juliushaertl @daita, especially as I had this only running locally without following others yet.
![social username bold](https://user-images.githubusercontent.com/925062/49468667-dbbe3200-f805-11e8-989a-8ced4f9037ca.png)
