### PR TITLE
Remove avatar tooltips, since the name is always displayed besides it

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -23,7 +23,8 @@
 <template>
 	<div class="new-post" data-id="">
 		<div class="new-post-author">
-			<avatar :user="currentUser.uid" :display-name="currentUser.displayName" :size="32" />
+			<avatar :user="currentUser.uid" :display-name="currentUser.displayName" :disable-tooltip="true"
+				:size="32" />
 		</div>
 		<form class="new-post-form" @submit.prevent="createPost">
 			<div class="author currentUser">

--- a/src/components/ProfileInfo.vue
+++ b/src/components/ProfileInfo.vue
@@ -23,7 +23,7 @@
 <template>
 	<div v-if="uid && accountInfo" class="user-profile">
 		<div class="user-profile--info">
-			<avatar :user="uid" :display-name="displayName" :size="128" />
+			<avatar :user="uid" :disable-tooltip="true" :size="128" />
 			<h2>{{ displayName }}</h2>
 			<p>{{ accountInfo.account }}</p>
 			<p v-if="accountInfo.website">Website: <a :href="accountInfo.website.value">{{ accountInfo.website.value }}</a></p>

--- a/src/components/TimelineEntry.vue
+++ b/src/components/TimelineEntry.vue
@@ -3,12 +3,12 @@
 		<div class="entry-content">
 			<div v-if="item.actor_info" class="post-avatar">
 				<avatar v-if="item.local" :size="32" :user="item.actor_info.preferredUsername"
-					:display-name="item.actor_info.account" />
-				<avatar v-else :size="32" :url="avatarUrl" />
+					:display-name="item.actor_info.account" :disable-tooltip="true"
+				/>
+				<avatar v-else :size="32" :url="avatarUrl"
+					:disable-tooltip="true" />
 			</div>
 			<div class="post-content">
-				{{ item.account_info }}
-
 				<div class="post-author-wrapper">
 					<router-link v-if="item.actor_info && item.local" :to="{ name: 'profile', params: { account: item.actor_info.preferredUsername }}">
 						<span class="post-author">{{ item.actor_info.preferredUsername }}</span>

--- a/src/components/UserEntry.vue
+++ b/src/components/UserEntry.vue
@@ -24,7 +24,8 @@
 	<div v-if="item" class="user-entry">
 		<div class="entry-content">
 			<div class="user-avatar">
-				<avatar v-if="item.local" :size="32" :user="item.preferredUsername" />
+				<avatar v-if="item.local" :size="32" :user="item.preferredUsername"
+					:disable-tooltip="true" />
 				<avatar v-else :url="avatarUrl" />
 			</div>
 			<div class="user-details">


### PR DESCRIPTION
Remove all avatar tooltips

(fixes #130)
