### PR TITLE
Run well-known check after setup

### DIFF
--- a/lib/Controller/NavigationController.php
+++ b/lib/Controller/NavigationController.php
@@ -148,9 +148,6 @@ class NavigationController extends Controller {
 			]
 		];
 
-		$checks = $this->checkService->checkDefault();
-		$data['serverData']['checks'] = $checks;
-
 		try {
 			$data['serverData']['cloudAddress'] = $this->configService->getCloudAddress();
 		} catch (SocialAppConfigException $e) {
@@ -169,6 +166,11 @@ class NavigationController extends Controller {
 					}
 				}
 			}
+		}
+
+		if ($data['serverData']['isAdmin']) {
+			$checks = $this->checkService->checkDefault();
+			$data['serverData']['checks'] = $checks;
 		}
 
 		/*


### PR DESCRIPTION
Fixes  message saying that '.well-known is wrongly configured' is displayed on the first launch of the app. A simple refresh fix this. 

from #153