### PR TITLE
adding route and content to the Notification Stream

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -65,6 +65,7 @@ return [
 		['name' => 'SocialPub#displayPost', 'url' => '/@{username}/{postId}', 'verb' => 'GET'],
 
 		['name' => 'Local#streamHome', 'url' => '/api/v1/stream/home', 'verb' => 'GET'],
+		['name' => 'Local#streamNotifications', 'url' => '/api/v1/stream/notifications', 'verb' => 'GET'],
 		['name' => 'Local#streamTimeline', 'url' => '/api/v1/stream/timeline', 'verb' => 'GET'],
 		['name' => 'Local#streamFederated', 'url' => '/api/v1/stream/federated', 'verb' => 'GET'],
 		['name' => 'Local#streamDirect', 'url' => '/api/v1/stream/direct', 'verb' => 'GET'],

--- a/lib/Controller/LocalController.php
+++ b/lib/Controller/LocalController.php
@@ -217,6 +217,31 @@ class LocalController extends Controller {
 	}
 
 
+
+
+	/**
+	 * @NoCSRFRequired
+	 * @NoAdminRequired
+	 * @NoSubAdminRequired
+	 *
+	 * @param int $since
+	 * @param int $limit
+	 *
+	 * @return DataResponse
+	 */
+	public function streamNotifications($since = 0, int $limit = 5): DataResponse {
+		try {
+			$this->initViewer(true);
+			$posts = $this->noteService->getStreamNotifications($this->viewer, $since, $limit);
+
+			return $this->success($posts);
+		} catch (Exception $e) {
+			return $this->fail($e);
+		}
+	}
+
+
+
 	/**
 	 * // TODO: Delete the NoCSRF check
 	 *

--- a/lib/Db/NotesRequest.php
+++ b/lib/Db/NotesRequest.php
@@ -187,11 +187,11 @@ class NotesRequest extends NotesRequestBuilder {
 
 	/**
 	 * Should returns:
-	 *  - Public/Unlisted/Followers-only post where current $actor is tagged,
-	 *  - Events:
-	 *    - people liking or re-posting your posts
-	 *    - someone wants to follow you
-	 *    - someone is following you
+	 *  * Public/Unlisted/Followers-only post where current $actor is tagged,
+	 *  - Events: (not yet)
+	 *    - people liking or re-posting your posts (not yet)
+	 *    - someone wants to follow you (not yet)
+	 *    - someone is following you (not yet)
 	 *
 	 * @param Person $actor
 	 * @param int $since
@@ -220,7 +220,7 @@ class NotesRequest extends NotesRequestBuilder {
 	/**
 	 * Should returns:
 	 *  * public message from actorId.
-	 *  - to followers-only if follower is logged.
+	 *  - to followers-only if follower is logged. (not yet (check ?))
 	 *
 	 * @param string $actorId
 	 * @param int $since
@@ -249,7 +249,7 @@ class NotesRequest extends NotesRequestBuilder {
 	/**
 	 * Should returns:
 	 *  * Private message.
-	 *  - group messages.
+	 *  - group messages. (not yet)
 	 *
 	 * @param Person $actor
 	 * @param int $since
@@ -280,7 +280,7 @@ class NotesRequest extends NotesRequestBuilder {
 
 	/**
 	 * Should returns:
-	 *  - All local public/federated posts
+	 *  * All local public/federated posts
 	 *
 	 * @param int $since
 	 * @param int $limit

--- a/lib/Service/ActivityPub/NoteService.php
+++ b/lib/Service/ActivityPub/NoteService.php
@@ -362,6 +362,18 @@ class NoteService implements ICoreService {
 
 
 	/**
+	 * @param Person $actor
+	 * @param int $since
+	 * @param int $limit
+	 *
+	 * @return Note[]
+	 */
+	public function getStreamNotifications(Person $actor, int $since = 0, int $limit = 5): array {
+		return $this->notesRequest->getStreamNotifications($actor, $since, $limit);
+	}
+
+
+	/**
 	 * @param string $actorId
 	 * @param int $since
 	 * @param int $limit


### PR DESCRIPTION
First throw about #85 - Notification Stream.

This first version of the stream should returns:
- Public post from other users where the current user is tagged,
- Unlisted post from other users where the current user is tagged,
- Followers-only post from other users where the current user is tagged.


