### PR TITLE
Some data are only for internal use.

### DIFF
--- a/lib/Model/ActivityPub/Activity/Accept.php
+++ b/lib/Model/ActivityPub/Activity/Accept.php
@@ -71,11 +71,7 @@ class Accept extends ACore implements JsonSerializable {
 	 * @return array
 	 */
 	public function jsonSerialize(): array {
-		return array_merge(
-			parent::jsonSerialize(),
-			[
-			]
-		);
+		return parent::jsonSerialize();
 	}
 
 }

--- a/lib/Model/ActivityPub/Activity/Create.php
+++ b/lib/Model/ActivityPub/Activity/Create.php
@@ -71,11 +71,7 @@ class Create extends ACore implements JsonSerializable {
 	 * @return array
 	 */
 	public function jsonSerialize(): array {
-		return array_merge(
-			parent::jsonSerialize(),
-			[
-			]
-		);
+		return parent::jsonSerialize();
 	}
 
 }

--- a/lib/Model/ActivityPub/Activity/Delete.php
+++ b/lib/Model/ActivityPub/Activity/Delete.php
@@ -71,11 +71,7 @@ class Delete extends ACore implements JsonSerializable {
 	 * @return array
 	 */
 	public function jsonSerialize(): array {
-		return array_merge(
-			parent::jsonSerialize(),
-			[
-			]
-		);
+		return parent::jsonSerialize();
 	}
 
 }

--- a/lib/Model/ActivityPub/Activity/Reject.php
+++ b/lib/Model/ActivityPub/Activity/Reject.php
@@ -71,11 +71,7 @@ class Reject extends ACore implements JsonSerializable {
 	 * @return array
 	 */
 	public function jsonSerialize(): array {
-		return array_merge(
-			parent::jsonSerialize(),
-			[
-			]
-		);
+		return parent::jsonSerialize();
 	}
 
 }

--- a/lib/Model/ActivityPub/Activity/Undo.php
+++ b/lib/Model/ActivityPub/Activity/Undo.php
@@ -70,11 +70,7 @@ class Undo extends ACore implements JsonSerializable {
 	 * @return array
 	 */
 	public function jsonSerialize(): array {
-		return array_merge(
-			parent::jsonSerialize(),
-			[
-			]
-		);
+		return parent::jsonSerialize();
 	}
 
 }

--- a/lib/Model/ActivityPub/Follow.php
+++ b/lib/Model/ActivityPub/Follow.php
@@ -128,10 +128,7 @@ class Follow extends ACore implements JsonSerializable {
 	 * @return array
 	 */
 	public function jsonSerialize(): array {
-		$result = array_merge(
-			parent::jsonSerialize(),
-			[]
-		);
+		$result = parent::jsonSerialize();
 
 		if ($this->isCompleteDetails()) {
 			array_merge(

--- a/lib/Model/ActivityPub/Follow.php
+++ b/lib/Model/ActivityPub/Follow.php
@@ -128,13 +128,22 @@ class Follow extends ACore implements JsonSerializable {
 	 * @return array
 	 */
 	public function jsonSerialize(): array {
-		return array_merge(
+		$result = array_merge(
 			parent::jsonSerialize(),
-			[
-				'follow_id' => $this->getFollowId(),
-				'accepted'  => $this->isAccepted()
-			]
+			[]
 		);
+
+		if ($this->isCompleteDetails()) {
+			array_merge(
+				$result,
+				[
+					'follow_id' => $this->getFollowId(),
+					'accepted'  => $this->isAccepted()
+				]
+			);
+		}
+
+		return $result;
 	}
 
 }

--- a/lib/Model/ActivityPub/Image.php
+++ b/lib/Model/ActivityPub/Image.php
@@ -72,11 +72,7 @@ class Image extends Document implements JsonSerializable {
 	 * @return array
 	 */
 	public function jsonSerialize(): array {
-		return array_merge(
-			parent::jsonSerialize(),
-			[
-			]
-		);
+		return parent::jsonSerialize();
 	}
 
 }

--- a/lib/Model/ActivityPub/Tombstone.php
+++ b/lib/Model/ActivityPub/Tombstone.php
@@ -70,11 +70,7 @@ class Tombstone extends ACore implements JsonSerializable {
 	 * @return array
 	 */
 	public function jsonSerialize(): array {
-		return array_merge(
-			parent::jsonSerialize(),
-			[
-			]
-		);
+		return parent::jsonSerialize();
 	}
 
 }


### PR DESCRIPTION
There is no need to send follow_id and accepted that are locally generated data when communicating to remote instance of ActivityPub