### PR TITLE
include the getAccount within the try/catch

### DIFF
--- a/lib/Service/ActorService.php
+++ b/lib/Service/ActorService.php
@@ -294,6 +294,9 @@ class ActorService {
 				$actor->setName($displayNameProperty->getValue());
 			}
 		} catch (Exception $e) {
+			$this->miscService->log(
+				'Issue while trying to updateCacheLocalActorName: ' . $e->getMessage(), 1
+			);
 		}
 	}
 

--- a/lib/Service/ActorService.php
+++ b/lib/Service/ActorService.php
@@ -45,7 +45,6 @@ use OCA\Social\Model\ActivityPub\Person;
 use OCA\Social\Service\ActivityPub\DocumentService;
 use OCA\Social\Service\ActivityPub\PersonService;
 use OCP\Accounts\IAccountManager;
-use OCP\Accounts\PropertyDoesNotExistException;
 use OCP\IUserManager;
 
 
@@ -287,14 +286,14 @@ class ActorService {
 	 */
 	private function updateCacheLocalActorName(Person &$actor) {
 		$user = $this->userManager->get($actor->getUserId());
-		$account = $this->accountManager->getAccount($user);
 
 		try {
+			$account = $this->accountManager->getAccount($user);
 			$displayNameProperty = $account->getProperty(IAccountManager::PROPERTY_DISPLAYNAME);
 			if ($displayNameProperty->getScope() === IAccountManager::VISIBILITY_PUBLIC) {
 				$actor->setName($displayNameProperty->getValue());
 			}
-		} catch (PropertyDoesNotExistException $e) {
+		} catch (Exception $e) {
 		}
 	}
 


### PR DESCRIPTION
It seems that getAccount() can returns an exception as PROPERTY_AVATAR might have a missing key ('verified')