### PR TITLE
checking origin of the object

### DIFF
--- a/lib/Interfaces/Activity/UndoInterface.php
+++ b/lib/Interfaces/Activity/UndoInterface.php
@@ -63,11 +63,12 @@ class UndoInterface implements IActivityPubInterface {
 		if (!$item->gotObject()) {
 			return;
 		}
+
 		$object = $item->getObject();
 
 		try {
-			$service = AP::$activityPub->getInterfaceForItem($item->getObject());
-			$service->activity($item, $object);
+			$interface = AP::$activityPub->getInterfaceForItem($item->getObject());
+			$interface->activity($item, $object);
 		} catch (UnknownItemException $e) {
 		}
 	}

--- a/lib/Interfaces/Actor/PersonInterface.php
+++ b/lib/Interfaces/Actor/PersonInterface.php
@@ -127,7 +127,7 @@ class PersonInterface implements IActivityPubInterface {
 	public function activity(Acore $activity, ACore $item) {
 		/** @var Person $item */
 		if ($activity->getType() === Update::TYPE) {
-//			$this->miscService->log('### UPDATE PERSON !' . json_encode($item));
+			// TODO - check time and update.
 		}
 	}
 

--- a/lib/Interfaces/Object/NoteInterface.php
+++ b/lib/Interfaces/Object/NoteInterface.php
@@ -38,6 +38,7 @@ use OCA\Social\Exceptions\NoteNotFoundException;
 use OCA\Social\Interfaces\IActivityPubInterface;
 use OCA\Social\Model\ActivityPub\ACore;
 use OCA\Social\Model\ActivityPub\Activity\Create;
+use OCA\Social\Model\ActivityPub\Activity\Update;
 use OCA\Social\Model\ActivityPub\Object\Note;
 use OCA\Social\Service\ConfigService;
 use OCA\Social\Service\CurlService;
@@ -128,9 +129,18 @@ class NoteInterface implements IActivityPubInterface {
 		/** @var Note $item */
 
 		if ($activity->getType() === Create::TYPE) {
+			$activity->checkOrigin($item->getId());
 			$activity->checkOrigin($item->getAttributedTo());
 			$this->save($item);
 		}
+
+		if ($activity->getType() === Update::TYPE) {
+			$activity->checkOrigin($item->getId());
+			$activity->checkOrigin($item->getAttributedTo());
+			// TODO - check time and update.
+//			$this->save($item);
+		}
+
 	}
 
 

--- a/lib/Service/ImportService.php
+++ b/lib/Service/ImportService.php
@@ -35,6 +35,7 @@ use daita\MySmallPhpTools\Traits\TArrayTools;
 use Exception;
 use OCA\Social\AP;
 use OCA\Social\Exceptions\ActivityPubFormatException;
+use OCA\Social\Exceptions\InvalidOriginException;
 use OCA\Social\Exceptions\RedundancyLimitException;
 use OCA\Social\Exceptions\SocialAppConfigException;
 use OCA\Social\Exceptions\UnknownItemException;
@@ -88,10 +89,12 @@ class ImportService {
 	 * @param ACore $activity
 	 *
 	 * @throws UnknownItemException
+	 * @throws InvalidOriginException
 	 */
 	public function parseIncomingRequest(ACore $activity) {
-		$interface = AP::$activityPub->getInterfaceForItem($activity);
+		$activity->checkOrigin($activity->getId());
 
+		$interface = AP::$activityPub->getInterfaceForItem($activity);
 		try {
 			$interface->processIncomingRequest($activity);
 		} catch (Exception $e) {


### PR DESCRIPTION
On Activity (incoming request, top level activitypub item), force a check on the origin of the id.

When propagated, each type of child object will manage its own origin check