### PR TITLE
Only send one search request at a time to the server

### DIFF
--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -79,6 +79,9 @@ export default {
 	},
 	methods: {
 		search(val) {
+			if (this.loading) {
+				return
+			}
 			this.loading = true
 			const re = /@((\w+)(@[\w.]+)?)/g
 			if (val.match(re)) {


### PR DESCRIPTION
This will make sure we don't send a request for every keystroke, just after the previous request has finished. The search is debounced with a delay of 500ms anyway so it should be fine now @daita 