### PR TITLE
Using signature date as 'creation' date

### DIFF
--- a/lib/Controller/ActivityPubController.php
+++ b/lib/Controller/ActivityPubController.php
@@ -166,11 +166,12 @@ class ActivityPubController extends Controller {
 			$body = file_get_contents('php://input');
 			$this->miscService->log('[<<] shared-inbox: ' . $body, 1);
 
-			$origin = $this->signatureService->checkRequest($this->request);
+			$requestTime = 0;
+			$origin = $this->signatureService->checkRequest($this->request, $requestTime);
 
 			$activity = $this->importService->importFromJson($body);
 			if (!$this->signatureService->checkObject($activity)) {
-				$activity->setOrigin($origin, SignatureService::ORIGIN_HEADER);
+				$activity->setOrigin($origin, SignatureService::ORIGIN_HEADER, $requestTime);
 			}
 
 			try {
@@ -204,14 +205,15 @@ class ActivityPubController extends Controller {
 			$body = file_get_contents('php://input');
 			$this->miscService->log('[<<] inbox: ' . $body, 1);
 
-			$origin = $this->signatureService->checkRequest($this->request);
+			$requestTime = 0;
+			$origin = $this->signatureService->checkRequest($this->request, $requestTime);
 
 			// TODO - check the recipient <-> username
 //			$actor = $this->actorService->getActor($username);
 
 			$activity = $this->importService->importFromJson($body);
 			if (!$this->signatureService->checkObject($activity)) {
-				$activity->setOrigin($origin, SignatureService::ORIGIN_HEADER);
+				$activity->setOrigin($origin, SignatureService::ORIGIN_HEADER, $requestTime);
 			}
 
 			try {

--- a/lib/Db/CacheActorsRequest.php
+++ b/lib/Db/CacheActorsRequest.php
@@ -64,6 +64,14 @@ class CacheActorsRequest extends CacheActorsRequestBuilder {
 	 * @param Person $actor
 	 */
 	public function save(Person $actor) {
+
+		if ($actor->getCreation() > 0) {
+			$dTime = new DateTime();
+			$dTime->setTimestamp($actor->getCreation());
+		} else {
+			$dTime = new DateTime('now');
+		}
+
 		$qb = $this->getCacheActorsInsertSql();
 		$qb->setValue('id', $qb->createNamedParameter($actor->getId()))
 		   ->setValue('account', $qb->createNamedParameter($actor->getAccount()))
@@ -86,7 +94,7 @@ class CacheActorsRequest extends CacheActorsRequestBuilder {
 		   ->setValue('details', $qb->createNamedParameter(json_encode($actor->getDetails())))
 		   ->setValue(
 			   'creation',
-			   $qb->createNamedParameter(new DateTime('now'), IQueryBuilder::PARAM_DATE)
+			   $qb->createNamedParameter($dTime, IQueryBuilder::PARAM_DATE)
 		   );
 
 		if ($actor->gotIcon()) {
@@ -108,16 +116,25 @@ class CacheActorsRequest extends CacheActorsRequestBuilder {
 	 * @param Person $actor
 	 */
 	public function update(Person $actor) {
+
+		if ($actor->getCreation() > 0) {
+			$dTime = new DateTime();
+			$dTime->setTimestamp($actor->getCreation());
+		} else {
+			$dTime = new DateTime('now');
+		}
+
 		$qb = $this->getCacheActorsUpdateSql();
-		$qb->set('account', $qb->createNamedParameter($actor->getAccount()))
-		   ->set('following', $qb->createNamedParameter($actor->getFollowing()))
+		$qb->set('following', $qb->createNamedParameter($actor->getFollowing()))
 		   ->set('followers', $qb->createNamedParameter($actor->getFollowers()))
 		   ->set('inbox', $qb->createNamedParameter($actor->getInbox()))
 		   ->set('shared_inbox', $qb->createNamedParameter($actor->getSharedInbox()))
 		   ->set('outbox', $qb->createNamedParameter($actor->getOutbox()))
 		   ->set('featured', $qb->createNamedParameter($actor->getFeatured()))
 		   ->set('url', $qb->createNamedParameter($actor->getUrl()))
-		   ->set('preferred_username', $qb->createNamedParameter($actor->getPreferredUsername()))
+		   ->set(
+			   'preferred_username', $qb->createNamedParameter($actor->getPreferredUsername())
+		   )
 		   ->set('name', $qb->createNamedParameter($actor->getName()))
 		   ->set('summary', $qb->createNamedParameter($actor->getSummary()))
 		   ->set('public_key', $qb->createNamedParameter($actor->getPublicKey()))
@@ -125,7 +142,7 @@ class CacheActorsRequest extends CacheActorsRequestBuilder {
 		   ->set('details', $qb->createNamedParameter(json_encode($actor->getDetails())))
 		   ->set(
 			   'creation',
-			   $qb->createNamedParameter(new DateTime('now'), IQueryBuilder::PARAM_DATE)
+			   $qb->createNamedParameter($dTime, IQueryBuilder::PARAM_DATE)
 		   );
 
 		if ($actor->gotIcon()) {
@@ -134,10 +151,10 @@ class CacheActorsRequest extends CacheActorsRequestBuilder {
 		} else {
 			$iconId = $actor->getIconId();
 		}
+
 		$qb->set('icon_id', $qb->createNamedParameter($iconId));
 
 		$this->limitToIdString($qb, $actor->getId());
-
 		$qb->execute();
 	}
 

--- a/lib/Interfaces/Actor/PersonInterface.php
+++ b/lib/Interfaces/Actor/PersonInterface.php
@@ -136,11 +136,25 @@ class PersonInterface implements IActivityPubInterface {
 	/**
 	 * @param ACore $activity
 	 * @param ACore $item
+	 *
+	 * @throws InvalidOriginException
 	 */
 	public function activity(Acore $activity, ACore $item) {
 		/** @var Person $item */
+
 		if ($activity->getType() === Update::TYPE) {
-			// TODO - check time and update.
+			$activity->checkOrigin($item->getId());
+			$item->setCreation($activity->getOriginCreationTime());
+
+			try {
+				$current = $this->cacheActorsRequest->getFromId($item->getId());
+				if ($current->getCreation() < $activity->getOriginCreationTime()) {
+					$this->cacheActorsRequest->update($item);
+				}
+			} catch (CacheActorDoesNotExistException $e) {
+				$this->cacheActorsRequest->save($item);
+			}
+
 		}
 	}
 

--- a/lib/Model/ActivityPub/Item.php
+++ b/lib/Model/ActivityPub/Item.php
@@ -106,6 +106,9 @@ class Item {
 	/** @var int */
 	private $originSource = 0;
 
+	/** @var int */
+	private $originCreationTime = 0;
+
 
 	/**
 	 * @return string
@@ -443,15 +446,26 @@ class Item {
 	}
 
 	/**
+	 * @return int
+	 */
+	public function getOriginCreationTime(): int {
+		return $this->originCreationTime;
+	}
+
+
+	/**
 	 * @param string $origin
 	 *
 	 * @param int $source
 	 *
+	 * @param int $creationTime
+	 *
 	 * @return Item
 	 */
-	public function setOrigin(string $origin, int $source): Item {
+	public function setOrigin(string $origin, int $source, int $creationTime): Item {
 		$this->origin = $origin;
 		$this->originSource = $source;
+		$this->originCreationTime = $creationTime;
 
 		return $this;
 	}

--- a/lib/Service/SignatureService.php
+++ b/lib/Service/SignatureService.php
@@ -161,6 +161,8 @@ class SignatureService {
 	/**
 	 * @param IRequest $request
 	 *
+	 * @param int $time
+	 *
 	 * @return string
 	 * @throws InvalidOriginException
 	 * @throws InvalidResourceException
@@ -174,11 +176,12 @@ class SignatureService {
 	 * @throws SocialAppConfigException
 	 * @throws ItemUnknownException
 	 */
-	public function checkRequest(IRequest $request): string {
+	public function checkRequest(IRequest $request, int &$time = 0): string {
 		$dTime = new DateTime($request->getHeader('date'));
 		$dTime->format(self::DATE_FORMAT);
+		$time = $dTime->getTimestamp();
 
-		if ($dTime->getTimestamp() < (time() - self::DATE_DELAY)) {
+		if ($time < (time() - self::DATE_DELAY)) {
 			throw new SignatureException('object is too old');
 		}
 
@@ -222,8 +225,12 @@ class SignatureService {
 				return false;
 			}
 
+			$dTime = new DateTime($signature->getCreated());
+			$dTime->format(self::DATE_FORMAT);
+			$time = $dTime->getTimestamp();
+
 			$object->setOrigin(
-				$this->getKeyOrigin($actorId), SignatureService::ORIGIN_SIGNATURE
+				$this->getKeyOrigin($actorId), SignatureService::ORIGIN_SIGNATURE, $time
 			);
 
 			return true;

--- a/lib/Service/SignatureService.php
+++ b/lib/Service/SignatureService.php
@@ -226,7 +226,6 @@ class SignatureService {
 			}
 
 			$dTime = new DateTime($signature->getCreated());
-			$dTime->format(self::DATE_FORMAT);
 			$time = $dTime->getTimestamp();
 
 			$object->setOrigin(


### PR DESCRIPTION
Feature #219

We keep the current time when requesting for data of a Perso.
On incoming request, we assign the date used in the signature (request and/or object signing)
On update from remote instance (incoming request Update/Person), we use this signature as date and compare if current Person in cache is older than the request.