### PR TITLE
removing trail slash in the id of the Person

### DIFF
--- a/lib/webfinger.php
+++ b/lib/webfinger.php
@@ -61,15 +61,20 @@ try {
 	exit;
 }
 
+$href =
+	$urlGenerator->linkToRouteAbsolute('social.ActivityPub.actorAlias', ['username' => $username]);
+
+if (substr($href, -1) === '/') {
+	$href = substr($href, 0, -1);
+}
+
 $finger = [
 	'subject' => $subject,
 	'links'   => [
 		[
 			'rel'  => 'self',
 			'type' => 'application/activity+json',
-			'href' => $urlGenerator->linkToRouteAbsolute(
-				'social.ActivityPub.actorAlias', ['username' => $username]
-			)
+			'href' => $href
 		]
 	]
 ];


### PR DESCRIPTION
There is some issue when the id end up with a trailing slash.

We'll keep the route, but the webfinger will remove the ending slash