### PR TITLE
[huge] rewrite of the exceptions while requesting remote instance

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/daita/my-small-php-tools.git",
-                "reference": "29754f18951856a22c0fd5fc388b6162ea98fe8a"
+                "reference": "0baac1f399b257b00fdc2eafb754396ffa1892f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/daita/my-small-php-tools/zipball/29754f18951856a22c0fd5fc388b6162ea98fe8a",
-                "reference": "29754f18951856a22c0fd5fc388b6162ea98fe8a",
+                "url": "https://api.github.com/repos/daita/my-small-php-tools/zipball/0baac1f399b257b00fdc2eafb754396ffa1892f4",
+                "reference": "0baac1f399b257b00fdc2eafb754396ffa1892f4",
                 "shasum": ""
             },
             "require": {
@@ -40,7 +40,7 @@
                 }
             ],
             "description": "My small PHP Tools",
-            "time": "2018-12-18T00:38:01+00:00"
+            "time": "2018-12-27T11:14:55+00:00"
         },
         {
             "name": "digitalbazaar/json-ld",

--- a/lib/AP.php
+++ b/lib/AP.php
@@ -34,7 +34,7 @@ namespace OCA\Social;
 use daita\MySmallPhpTools\Traits\TArrayTools;
 use OCA\Social\Exceptions\RedundancyLimitException;
 use OCA\Social\Exceptions\SocialAppConfigException;
-use OCA\Social\Exceptions\UnknownItemException;
+use OCA\Social\Exceptions\ItemUnknownException;
 use OCA\Social\Interfaces\Activity\AcceptInterface;
 use OCA\Social\Interfaces\Activity\AddInterface;
 use OCA\Social\Interfaces\Activity\BlockInterface;
@@ -174,7 +174,7 @@ class AP {
 	 * @return ACore
 	 * @throws RedundancyLimitException
 	 * @throws SocialAppConfigException
-	 * @throws UnknownItemException
+	 * @throws ItemUnknownException
 	 */
 	public function getItemFromData(array $data, $parent = null, int $level = 0): ACore {
 		if (++$level > self::REDUNDANCY_LIMIT) {
@@ -189,14 +189,14 @@ class AP {
 		try {
 			$object = $this->getItemFromData($this->getArray('object', $data, []), $item, $level);
 			$item->setObject($object);
-		} catch (UnknownItemException $e) {
+		} catch (ItemUnknownException $e) {
 		}
 
 		try {
 			/** @var Document $icon */
 			$icon = $this->getItemFromData($this->getArray('icon', $data, []), $item, $level);
 			$item->setIcon($icon);
-		} catch (UnknownItemException $e) {
+		} catch (ItemUnknownException $e) {
 		}
 
 		return $item;
@@ -208,7 +208,7 @@ class AP {
 	 *
 	 * @return ACore
 	 * @throws SocialAppConfigException
-	 * @throws UnknownItemException
+	 * @throws ItemUnknownException
 	 */
 	public function getSimpleItemFromData(array $data): Acore {
 		$item = $this->getItemFromType($this->get('type', $data, ''));
@@ -223,7 +223,7 @@ class AP {
 	 * @param string $type
 	 *
 	 * @return ACore
-	 * @throws UnknownItemException
+	 * @throws ItemUnknownException
 	 */
 	public function getItemFromType(string $type) {
 		switch ($type) {
@@ -273,7 +273,7 @@ class AP {
 				return new Update();
 
 			default:
-				throw new UnknownItemException();
+				throw new ItemUnknownException();
 		}
 	}
 
@@ -282,7 +282,7 @@ class AP {
 	 * @param ACore $activity
 	 *
 	 * @return IActivityPubInterface
-	 * @throws UnknownItemException
+	 * @throws ItemUnknownException
 	 */
 	public function getInterfaceForItem(Acore $activity): IActivityPubInterface {
 		return $this->getInterfaceFromType($activity->getType());
@@ -293,7 +293,7 @@ class AP {
 	 * @param string $type
 	 *
 	 * @return IActivityPubInterface
-	 * @throws UnknownItemException
+	 * @throws ItemUnknownException
 	 */
 	public function getInterfaceFromType(string $type): IActivityPubInterface {
 		switch ($type) {
@@ -350,7 +350,7 @@ class AP {
 				break;
 
 			default:
-				throw new UnknownItemException();
+				throw new ItemUnknownException();
 		}
 
 		return $service;

--- a/lib/Command/QueueProcess.php
+++ b/lib/Command/QueueProcess.php
@@ -32,7 +32,6 @@ namespace OCA\Social\Command;
 
 
 use OC\Core\Command\Base;
-use OCA\Social\Exceptions\RequestException;
 use OCA\Social\Exceptions\SocialAppConfigException;
 use OCA\Social\Service\ActivityService;
 use OCA\Social\Service\ConfigService;
@@ -113,7 +112,6 @@ class QueueProcess extends Base {
 			$output->write('.');
 			try {
 				$this->activityService->manageRequest($request);
-			} catch (RequestException $e) {
 			} catch (SocialAppConfigException $e) {
 			}
 		}

--- a/lib/Controller/ActivityPubController.php
+++ b/lib/Controller/ActivityPubController.php
@@ -35,7 +35,8 @@ use Exception;
 use OC\AppFramework\Http;
 use OCA\Social\AppInfo\Application;
 use OCA\Social\Exceptions\SignatureIsGoneException;
-use OCA\Social\Exceptions\UnknownItemException;
+use OCA\Social\Exceptions\ItemUnknownException;
+use OCA\Social\Exceptions\UrlCloudException;
 use OCA\Social\Service\CacheActorService;
 use OCA\Social\Service\FollowService;
 use OCA\Social\Service\ImportService;
@@ -112,6 +113,7 @@ class ActivityPubController extends Controller {
 	 * @param string $username
 	 *
 	 * @return Response
+	 * @throws UrlCloudException
 	 */
 	public function actor(string $username): Response {
 		if (!$this->checkSourceActivityStreams()) {
@@ -143,6 +145,7 @@ class ActivityPubController extends Controller {
 	 * @param string $username
 	 *
 	 * @return Response
+	 * @throws UrlCloudException
 	 */
 	public function actorAlias(string $username): Response {
 		return $this->actor($username);
@@ -172,7 +175,7 @@ class ActivityPubController extends Controller {
 
 			try {
 				$this->importService->parseIncomingRequest($activity);
-			} catch (UnknownItemException $e) {
+			} catch (ItemUnknownException $e) {
 			}
 
 			return $this->success([]);
@@ -213,7 +216,7 @@ class ActivityPubController extends Controller {
 
 			try {
 				$this->importService->parseIncomingRequest($activity);
-			} catch (UnknownItemException $e) {
+			} catch (ItemUnknownException $e) {
 			}
 
 			return $this->success([]);
@@ -249,6 +252,7 @@ class ActivityPubController extends Controller {
 	 * @param string $username
 	 *
 	 * @return Response
+	 * @throws UrlCloudException
 	 */
 	public function followers(string $username): Response {
 
@@ -278,6 +282,7 @@ class ActivityPubController extends Controller {
 	 * @param string $username
 	 *
 	 * @return Response
+	 * @throws UrlCloudException
 	 */
 	public function following(string $username): Response {
 		if (!$this->checkSourceActivityStreams()) {

--- a/lib/Controller/QueueController.php
+++ b/lib/Controller/QueueController.php
@@ -32,7 +32,6 @@ namespace OCA\Social\Controller;
 
 use daita\MySmallPhpTools\Traits\TAsync;
 use OCA\Social\AppInfo\Application;
-use OCA\Social\Exceptions\RequestException;
 use OCA\Social\Exceptions\SocialAppConfigException;
 use OCA\Social\Model\RequestQueue;
 use OCA\Social\Service\ActivityService;
@@ -99,7 +98,6 @@ class QueueController extends Controller {
 				$request->setTimeout(ActivityService::TIMEOUT_ASYNC);
 				try {
 					$this->activityService->manageRequest($request);
-				} catch (RequestException $e) {
 				} catch (SocialAppConfigException $e) {
 				}
 			}

--- a/lib/Controller/SocialPubController.php
+++ b/lib/Controller/SocialPubController.php
@@ -34,6 +34,7 @@ use daita\MySmallPhpTools\Traits\Nextcloud\TNCDataResponse;
 
 use OCA\Social\AppInfo\Application;
 use OCA\Social\Exceptions\CacheActorDoesNotExistException;
+use OCA\Social\Exceptions\UrlCloudException;
 use OCA\Social\Service\AccountService;
 use OCA\Social\Service\CacheActorService;
 use OCA\Social\Service\FollowService;
@@ -117,6 +118,7 @@ class SocialPubController extends Controller {
 		$page = new PublicTemplateResponse(Application::APP_NAME, 'main', $data);
 		$page->setStatus($status);
 		$page->setHeaderTitle($this->l10n->t('Social'));
+
 		return $page;
 	}
 
@@ -131,6 +133,7 @@ class SocialPubController extends Controller {
 	 * @param string $username
 	 *
 	 * @return Response
+	 * @throws UrlCloudException
 	 */
 	public function actor(string $username): Response {
 		return $this->renderPage($username);
@@ -147,6 +150,7 @@ class SocialPubController extends Controller {
 	 * @param string $username
 	 *
 	 * @return TemplateResponse
+	 * @throws UrlCloudException
 	 */
 	public function followers(string $username): Response {
 		return $this->renderPage($username);
@@ -163,6 +167,7 @@ class SocialPubController extends Controller {
 	 * @param string $username
 	 *
 	 * @return TemplateResponse
+	 * @throws UrlCloudException
 	 */
 	public function following(string $username): Response {
 		return $this->renderPage($username);

--- a/lib/Cron/Queue.php
+++ b/lib/Cron/Queue.php
@@ -33,7 +33,6 @@ namespace OCA\Social\Cron;
 
 use OC\BackgroundJob\TimedJob;
 use OCA\Social\AppInfo\Application;
-use OCA\Social\Exceptions\RequestException;
 use OCA\Social\Exceptions\SocialAppConfigException;
 use OCA\Social\Service\ActivityService;
 use OCA\Social\Service\MiscService;
@@ -94,7 +93,6 @@ class Queue extends TimedJob {
 			$request->setTimeout(ActivityService::TIMEOUT_SERVICE);
 			try {
 				$this->activityService->manageRequest($request);
-			} catch (RequestException $e) {
 			} catch (SocialAppConfigException $e) {
 			}
 		}

--- a/lib/Db/CacheDocumentsRequest.php
+++ b/lib/Db/CacheDocumentsRequest.php
@@ -173,5 +173,16 @@ class CacheDocumentsRequest extends CacheDocumentsRequestBuilder {
 		$qb->execute();
 	}
 
+
+	/**
+	 * @param string $id
+	 */
+	public function deleteById(string $id) {
+		$qb = $this->getCacheDocumentsDeleteSql();
+		$this->limitToIdString($qb, $id);
+
+		$qb->execute();
+	}
+
 }
 

--- a/lib/Db/RequestQueueRequest.php
+++ b/lib/Db/RequestQueueRequest.php
@@ -32,7 +32,6 @@ namespace OCA\Social\Db;
 
 
 use DateTime;
-use Exception;
 use OCA\Social\Exceptions\QueueStatusException;
 use OCA\Social\Model\RequestQueue;
 use OCP\DB\QueryBuilder\IQueryBuilder;
@@ -50,8 +49,6 @@ class RequestQueueRequest extends RequestQueueRequestBuilder {
 	 * create a new Queue in the database.
 	 *
 	 * @param RequestQueue[] $queues
-	 *
-	 * @throws Exception
 	 */
 	public function multiple(array $queues) {
 		foreach ($queues as $queue) {
@@ -64,8 +61,6 @@ class RequestQueueRequest extends RequestQueueRequestBuilder {
 	 * create a new Queue in the database.
 	 *
 	 * @param RequestQueue $queue
-	 *
-	 * @throws Exception
 	 */
 	public function create(RequestQueue $queue) {
 		$qb = $this->getQueueInsertSql();

--- a/lib/Exceptions/CacheContentSizeException.php
+++ b/lib/Exceptions/CacheContentSizeException.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace OCA\Social\Exceptions;
-
-class CacheContentSizeException extends \Exception {
-
-}
-

--- a/lib/Exceptions/ItemUnknownException.php
+++ b/lib/Exceptions/ItemUnknownException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace OCA\Social\Exceptions;
+
+class ItemUnknownException extends \Exception {
+
+}
+

--- a/lib/Exceptions/Request410Exception.php
+++ b/lib/Exceptions/Request410Exception.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace OCA\Social\Exceptions;
-
-class Request410Exception extends \Exception {
-
-}
-

--- a/lib/Exceptions/RequestContentException.php
+++ b/lib/Exceptions/RequestContentException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace OCA\Social\Exceptions;
+
+class RequestContentException extends \Exception {
+
+}
+

--- a/lib/Exceptions/RequestException.php
+++ b/lib/Exceptions/RequestException.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace OCA\Social\Exceptions;
-
-class RequestException extends \Exception {
-
-}
-

--- a/lib/Exceptions/RequestNetworkException.php
+++ b/lib/Exceptions/RequestNetworkException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace OCA\Social\Exceptions;
+
+class RequestNetworkException extends \Exception {
+
+}
+

--- a/lib/Exceptions/RequestResultSizeException.php
+++ b/lib/Exceptions/RequestResultSizeException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace OCA\Social\Exceptions;
+
+class RequestResultSizeException extends \Exception {
+
+}
+

--- a/lib/Exceptions/RequestServerException.php
+++ b/lib/Exceptions/RequestServerException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace OCA\Social\Exceptions;
+
+class RequestServerException extends \Exception {
+
+}
+

--- a/lib/Exceptions/RetrieveAccountFormatException.php
+++ b/lib/Exceptions/RetrieveAccountFormatException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace OCA\Social\Exceptions;
+
+class RetrieveAccountFormatException extends \Exception {
+
+}
+

--- a/lib/Exceptions/ServiceAccountAlreadyExistException.php
+++ b/lib/Exceptions/ServiceAccountAlreadyExistException.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace OCA\Social\Exceptions;
-
-class ServiceAccountAlreadyExistException extends \Exception {
-
-}
-

--- a/lib/Exceptions/UnknownItemException.php
+++ b/lib/Exceptions/UnknownItemException.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace OCA\Social\Exceptions;
-
-class UnknownItemException extends \Exception {
-
-}
-

--- a/lib/Exceptions/WebfingerException.php
+++ b/lib/Exceptions/WebfingerException.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace OCA\Social\Exceptions;
-
-class WebfingerException extends \Exception {
-
-}
-

--- a/lib/Interfaces/Activity/AcceptInterface.php
+++ b/lib/Interfaces/Activity/AcceptInterface.php
@@ -33,7 +33,7 @@ namespace OCA\Social\Interfaces\Activity;
 
 use OCA\Social\AP;
 use OCA\Social\Exceptions\ItemNotFoundException;
-use OCA\Social\Exceptions\UnknownItemException;
+use OCA\Social\Exceptions\ItemUnknownException;
 use OCA\Social\Interfaces\IActivityPubInterface;
 use OCA\Social\Model\ActivityPub\ACore;
 use OCA\Social\Service\MiscService;
@@ -68,7 +68,7 @@ class AcceptInterface implements IActivityPubInterface {
 		try {
 			$service = AP::$activityPub->getInterfaceForItem($item->getObject());
 			$service->activity($item, $object);
-		} catch (UnknownItemException $e) {
+		} catch (ItemUnknownException $e) {
 		}
 	}
 

--- a/lib/Interfaces/Activity/AddInterface.php
+++ b/lib/Interfaces/Activity/AddInterface.php
@@ -33,7 +33,7 @@ namespace OCA\Social\Interfaces\Activity;
 
 use OCA\Social\AP;
 use OCA\Social\Exceptions\ItemNotFoundException;
-use OCA\Social\Exceptions\UnknownItemException;
+use OCA\Social\Exceptions\ItemUnknownException;
 use OCA\Social\Interfaces\IActivityPubInterface;
 use OCA\Social\Model\ActivityPub\ACore;
 use OCA\Social\Service\MiscService;
@@ -68,7 +68,7 @@ class AddInterface implements IActivityPubInterface {
 		try {
 			$service = AP::$activityPub->getInterfaceForItem($item->getObject());
 			$service->activity($item, $object);
-		} catch (UnknownItemException $e) {
+		} catch (ItemUnknownException $e) {
 		}
 	}
 

--- a/lib/Interfaces/Activity/BlockInterface.php
+++ b/lib/Interfaces/Activity/BlockInterface.php
@@ -33,7 +33,7 @@ namespace OCA\Social\Interfaces\Activity;
 
 use OCA\Social\AP;
 use OCA\Social\Exceptions\ItemNotFoundException;
-use OCA\Social\Exceptions\UnknownItemException;
+use OCA\Social\Exceptions\ItemUnknownException;
 use OCA\Social\Interfaces\IActivityPubInterface;
 use OCA\Social\Model\ActivityPub\ACore;
 use OCA\Social\Service\MiscService;
@@ -68,7 +68,7 @@ class BlockInterface implements IActivityPubInterface {
 		try {
 			$service = AP::$activityPub->getInterfaceForItem($item->getObject());
 			$service->activity($item, $object);
-		} catch (UnknownItemException $e) {
+		} catch (ItemUnknownException $e) {
 		}
 	}
 

--- a/lib/Interfaces/Activity/CreateInterface.php
+++ b/lib/Interfaces/Activity/CreateInterface.php
@@ -33,7 +33,7 @@ namespace OCA\Social\Interfaces\Activity;
 
 use OCA\Social\AP;
 use OCA\Social\Exceptions\ItemNotFoundException;
-use OCA\Social\Exceptions\UnknownItemException;
+use OCA\Social\Exceptions\ItemUnknownException;
 use OCA\Social\Interfaces\IActivityPubInterface;
 use OCA\Social\Model\ActivityPub\ACore;
 use OCA\Social\Service\MiscService;
@@ -68,7 +68,7 @@ class CreateInterface implements IActivityPubInterface {
 		try {
 			$service = AP::$activityPub->getInterfaceForItem($item->getObject());
 			$service->activity($item, $object);
-		} catch (UnknownItemException $e) {
+		} catch (ItemUnknownException $e) {
 		}
 	}
 

--- a/lib/Interfaces/Activity/DeleteInterface.php
+++ b/lib/Interfaces/Activity/DeleteInterface.php
@@ -33,7 +33,7 @@ namespace OCA\Social\Interfaces\Activity;
 
 use OCA\Social\AP;
 use OCA\Social\Exceptions\ItemNotFoundException;
-use OCA\Social\Exceptions\UnknownItemException;
+use OCA\Social\Exceptions\ItemUnknownException;
 use OCA\Social\Interfaces\IActivityPubInterface;
 use OCA\Social\Model\ActivityPub\ACore;
 use OCA\Social\Service\MiscService;
@@ -75,7 +75,7 @@ class DeleteInterface implements IActivityPubInterface {
 		try {
 			$interface = AP::$activityPub->getInterfaceForItem($object);
 			$interface->delete($object);
-		} catch (UnknownItemException $e) {
+		} catch (ItemUnknownException $e) {
 		}
 	}
 

--- a/lib/Interfaces/Activity/FollowInterface.php
+++ b/lib/Interfaces/Activity/FollowInterface.php
@@ -39,10 +39,12 @@ use OCA\Social\Exceptions\InvalidOriginException;
 use OCA\Social\Exceptions\InvalidResourceException;
 use OCA\Social\Exceptions\ItemNotFoundException;
 use OCA\Social\Exceptions\RedundancyLimitException;
-use OCA\Social\Exceptions\Request410Exception;
-use OCA\Social\Exceptions\RequestException;
+use OCA\Social\Exceptions\RequestContentException;
+use OCA\Social\Exceptions\RequestNetworkException;
+use OCA\Social\Exceptions\RequestResultSizeException;
+use OCA\Social\Exceptions\RequestServerException;
 use OCA\Social\Exceptions\SocialAppConfigException;
-use OCA\Social\Exceptions\UnknownItemException;
+use OCA\Social\Exceptions\ItemUnknownException;
 use OCA\Social\Interfaces\IActivityPubInterface;
 use OCA\Social\Model\ActivityPub\ACore;
 use OCA\Social\Model\ActivityPub\Activity\Accept;
@@ -138,11 +140,13 @@ class FollowInterface implements IActivityPubInterface {
 	 * @throws InvalidOriginException
 	 * @throws InvalidResourceException
 	 * @throws MalformedArrayException
-	 * @throws Request410Exception
-	 * @throws RequestException
-	 * @throws SocialAppConfigException
 	 * @throws RedundancyLimitException
-	 * @throws UnknownItemException
+	 * @throws SocialAppConfigException
+	 * @throws ItemUnknownException
+	 * @throws RequestContentException
+	 * @throws RequestNetworkException
+	 * @throws RequestResultSizeException
+	 * @throws RequestServerException
 	 */
 	public function processIncomingRequest(ACore $follow) {
 		/** @var Follow $follow */

--- a/lib/Interfaces/Activity/LikeInterface.php
+++ b/lib/Interfaces/Activity/LikeInterface.php
@@ -33,7 +33,7 @@ namespace OCA\Social\Interfaces\Activity;
 
 use OCA\Social\AP;
 use OCA\Social\Exceptions\ItemNotFoundException;
-use OCA\Social\Exceptions\UnknownItemException;
+use OCA\Social\Exceptions\ItemUnknownException;
 use OCA\Social\Interfaces\IActivityPubInterface;
 use OCA\Social\Model\ActivityPub\ACore;
 use OCA\Social\Service\MiscService;
@@ -68,7 +68,7 @@ class LikeInterface implements IActivityPubInterface {
 		try {
 			$service = AP::$activityPub->getInterfaceForItem($item->getObject());
 			$service->activity($item, $object);
-		} catch (UnknownItemException $e) {
+		} catch (ItemUnknownException $e) {
 		}
 	}
 

--- a/lib/Interfaces/Activity/RejectInterface.php
+++ b/lib/Interfaces/Activity/RejectInterface.php
@@ -33,7 +33,7 @@ namespace OCA\Social\Interfaces\Activity;
 
 use OCA\Social\AP;
 use OCA\Social\Exceptions\ItemNotFoundException;
-use OCA\Social\Exceptions\UnknownItemException;
+use OCA\Social\Exceptions\ItemUnknownException;
 use OCA\Social\Interfaces\IActivityPubInterface;
 use OCA\Social\Model\ActivityPub\ACore;
 use OCA\Social\Service\MiscService;
@@ -68,7 +68,7 @@ class RejectInterface implements IActivityPubInterface {
 		try {
 			$service = AP::$activityPub->getInterfaceForItem($item->getObject());
 			$service->activity($item, $object);
-		} catch (UnknownItemException $e) {
+		} catch (ItemUnknownException $e) {
 		}
 	}
 

--- a/lib/Interfaces/Activity/RemoveInterface.php
+++ b/lib/Interfaces/Activity/RemoveInterface.php
@@ -33,7 +33,7 @@ namespace OCA\Social\Interfaces\Activity;
 
 use OCA\Social\AP;
 use OCA\Social\Exceptions\ItemNotFoundException;
-use OCA\Social\Exceptions\UnknownItemException;
+use OCA\Social\Exceptions\ItemUnknownException;
 use OCA\Social\Interfaces\IActivityPubInterface;
 use OCA\Social\Model\ActivityPub\ACore;
 use OCA\Social\Service\MiscService;
@@ -68,7 +68,7 @@ class RemoveInterface implements IActivityPubInterface {
 		try {
 			$service = AP::$activityPub->getInterfaceForItem($item->getObject());
 			$service->activity($item, $object);
-		} catch (UnknownItemException $e) {
+		} catch (ItemUnknownException $e) {
 		}
 	}
 

--- a/lib/Interfaces/Activity/UndoInterface.php
+++ b/lib/Interfaces/Activity/UndoInterface.php
@@ -33,7 +33,7 @@ namespace OCA\Social\Interfaces\Activity;
 
 use OCA\Social\AP;
 use OCA\Social\Exceptions\ItemNotFoundException;
-use OCA\Social\Exceptions\UnknownItemException;
+use OCA\Social\Exceptions\ItemUnknownException;
 use OCA\Social\Interfaces\IActivityPubInterface;
 use OCA\Social\Model\ActivityPub\ACore;
 use OCA\Social\Service\MiscService;
@@ -69,7 +69,7 @@ class UndoInterface implements IActivityPubInterface {
 		try {
 			$interface = AP::$activityPub->getInterfaceForItem($item->getObject());
 			$interface->activity($item, $object);
-		} catch (UnknownItemException $e) {
+		} catch (ItemUnknownException $e) {
 		}
 	}
 

--- a/lib/Interfaces/Activity/UpdateInterface.php
+++ b/lib/Interfaces/Activity/UpdateInterface.php
@@ -33,7 +33,7 @@ namespace OCA\Social\Interfaces\Activity;
 
 use OCA\Social\AP;
 use OCA\Social\Exceptions\ItemNotFoundException;
-use OCA\Social\Exceptions\UnknownItemException;
+use OCA\Social\Exceptions\ItemUnknownException;
 use OCA\Social\Interfaces\IActivityPubInterface;
 use OCA\Social\Model\ActivityPub\ACore;
 use OCA\Social\Service\MiscService;
@@ -68,7 +68,7 @@ class UpdateInterface implements IActivityPubInterface {
 		try {
 			$service = AP::$activityPub->getInterfaceForItem($item->getObject());
 			$service->activity($item, $object);
-		} catch (UnknownItemException $e) {
+		} catch (ItemUnknownException $e) {
 		}
 	}
 

--- a/lib/Model/ActivityPub/Actor/Person.php
+++ b/lib/Model/ActivityPub/Actor/Person.php
@@ -32,7 +32,6 @@ namespace OCA\Social\Model\ActivityPub\Actor;
 
 
 use JsonSerializable;
-use OCA\Social\Exceptions\InvalidResourceEntryException;
 use OCA\Social\Exceptions\UrlCloudException;
 use OCA\Social\Model\ActivityPub\ACore;
 use OCA\Social\Model\ActivityPub\Object\Image;

--- a/lib/Model/ActivityPub/Object/Image.php
+++ b/lib/Model/ActivityPub/Object/Image.php
@@ -32,7 +32,6 @@ namespace OCA\Social\Model\ActivityPub\Object;
 
 
 use JsonSerializable;
-use OCA\Social\Exceptions\InvalidResourceEntryException;
 use OCA\Social\Exceptions\UrlCloudException;
 use OCA\Social\Model\ActivityPub\ACore;
 

--- a/lib/Service/CacheActorService.php
+++ b/lib/Service/CacheActorService.php
@@ -39,10 +39,13 @@ use OCA\Social\Exceptions\CacheActorDoesNotExistException;
 use OCA\Social\Exceptions\InvalidOriginException;
 use OCA\Social\Exceptions\InvalidResourceException;
 use OCA\Social\Exceptions\RedundancyLimitException;
-use OCA\Social\Exceptions\Request410Exception;
-use OCA\Social\Exceptions\RequestException;
+use OCA\Social\Exceptions\RequestContentException;
+use OCA\Social\Exceptions\RetrieveAccountFormatException;
+use OCA\Social\Exceptions\RequestNetworkException;
+use OCA\Social\Exceptions\RequestResultSizeException;
+use OCA\Social\Exceptions\RequestServerException;
 use OCA\Social\Exceptions\SocialAppConfigException;
-use OCA\Social\Exceptions\UnknownItemException;
+use OCA\Social\Exceptions\ItemUnknownException;
 use OCA\Social\Model\ActivityPub\Actor\Person;
 
 
@@ -107,14 +110,16 @@ class CacheActorService {
 	 * @param bool $refresh
 	 *
 	 * @return Person
+	 * @throws InvalidOriginException
 	 * @throws InvalidResourceException
 	 * @throws MalformedArrayException
-	 * @throws Request410Exception
-	 * @throws RequestException
-	 * @throws SocialAppConfigException
 	 * @throws RedundancyLimitException
-	 * @throws UnknownItemException
-	 * @throws InvalidOriginException
+	 * @throws RequestContentException
+	 * @throws RequestNetworkException
+	 * @throws RequestResultSizeException
+	 * @throws RequestServerException
+	 * @throws SocialAppConfigException
+	 * @throws ItemUnknownException
 	 */
 	public function getFromId(string $id, bool $refresh = false): Person {
 
@@ -173,14 +178,17 @@ class CacheActorService {
 	 *
 	 * @return Person
 	 * @throws CacheActorDoesNotExistException
+	 * @throws InvalidOriginException
 	 * @throws InvalidResourceException
 	 * @throws MalformedArrayException
 	 * @throws RedundancyLimitException
-	 * @throws Request410Exception
-	 * @throws RequestException
+	 * @throws RequestContentException
+	 * @throws RetrieveAccountFormatException
+	 * @throws RequestNetworkException
+	 * @throws RequestResultSizeException
+	 * @throws RequestServerException
 	 * @throws SocialAppConfigException
-	 * @throws UnknownItemException
-	 * @throws InvalidOriginException
+	 * @throws ItemUnknownException
 	 */
 	public function getFromAccount(string $account, bool $retrieve = true): Person {
 
@@ -258,7 +266,7 @@ class CacheActorService {
 		try {
 			$interface = AP::$activityPub->getInterfaceFromType(Person::TYPE);
 			$interface->save($actor);
-		} catch (UnknownItemException $e) {
+		} catch (ItemUnknownException $e) {
 		}
 	}
 }

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -64,7 +64,7 @@ class ConfigService {
 	public $defaults = [
 		self::SOCIAL_ADDRESS  => '',
 		self::SOCIAL_SERVICE  => 1,
-		self::SOCIAL_MAX_SIZE => 25
+		self::SOCIAL_MAX_SIZE => 10
 	];
 
 	/** @var string */

--- a/lib/Service/FollowService.php
+++ b/lib/Service/FollowService.php
@@ -39,10 +39,13 @@ use OCA\Social\Exceptions\FollowSameAccountException;
 use OCA\Social\Exceptions\InvalidOriginException;
 use OCA\Social\Exceptions\InvalidResourceException;
 use OCA\Social\Exceptions\RedundancyLimitException;
-use OCA\Social\Exceptions\Request410Exception;
-use OCA\Social\Exceptions\RequestException;
+use OCA\Social\Exceptions\RequestContentException;
+use OCA\Social\Exceptions\RetrieveAccountFormatException;
+use OCA\Social\Exceptions\RequestNetworkException;
+use OCA\Social\Exceptions\RequestResultSizeException;
+use OCA\Social\Exceptions\RequestServerException;
 use OCA\Social\Exceptions\SocialAppConfigException;
-use OCA\Social\Exceptions\UnknownItemException;
+use OCA\Social\Exceptions\ItemUnknownException;
 use OCA\Social\Exceptions\UrlCloudException;
 use OCA\Social\Model\ActivityPub\Activity\Follow;
 use OCA\Social\Model\ActivityPub\Activity\Undo;
@@ -117,16 +120,18 @@ class FollowService {
 	 *
 	 * @throws CacheActorDoesNotExistException
 	 * @throws FollowSameAccountException
+	 * @throws InvalidOriginException
 	 * @throws InvalidResourceException
 	 * @throws MalformedArrayException
 	 * @throws RedundancyLimitException
-	 * @throws Request410Exception
-	 * @throws RequestException
+	 * @throws RetrieveAccountFormatException
 	 * @throws SocialAppConfigException
+	 * @throws ItemUnknownException
 	 * @throws UrlCloudException
-	 * @throws UnknownItemException
-	 * @throws InvalidOriginException
-	 * @throws \Exception
+	 * @throws RequestContentException
+	 * @throws RequestNetworkException
+	 * @throws RequestResultSizeException
+	 * @throws RequestServerException
 	 */
 	public function followAccount(Person $actor, string $account) {
 		$remoteActor = $this->cacheActorService->getFromAccount($account);
@@ -163,14 +168,17 @@ class FollowService {
 	 * @param string $account
 	 *
 	 * @throws CacheActorDoesNotExistException
+	 * @throws InvalidOriginException
 	 * @throws InvalidResourceException
 	 * @throws MalformedArrayException
 	 * @throws RedundancyLimitException
-	 * @throws Request410Exception
-	 * @throws RequestException
+	 * @throws RequestContentException
+	 * @throws RetrieveAccountFormatException
+	 * @throws RequestNetworkException
+	 * @throws RequestResultSizeException
+	 * @throws RequestServerException
 	 * @throws SocialAppConfigException
-	 * @throws UnknownItemException
-	 * @throws \Exception
+	 * @throws ItemUnknownException
 	 */
 	public function unfollowAccount(Person $actor, string $account) {
 		$remoteActor = $this->cacheActorService->getFromAccount($account);

--- a/lib/Service/ImportService.php
+++ b/lib/Service/ImportService.php
@@ -38,7 +38,7 @@ use OCA\Social\Exceptions\ActivityPubFormatException;
 use OCA\Social\Exceptions\InvalidOriginException;
 use OCA\Social\Exceptions\RedundancyLimitException;
 use OCA\Social\Exceptions\SocialAppConfigException;
-use OCA\Social\Exceptions\UnknownItemException;
+use OCA\Social\Exceptions\ItemUnknownException;
 use OCA\Social\Model\ActivityPub\ACore;
 
 
@@ -74,7 +74,7 @@ class ImportService {
 	 * @throws ActivityPubFormatException
 	 * @throws RedundancyLimitException
 	 * @throws SocialAppConfigException
-	 * @throws UnknownItemException
+	 * @throws ItemUnknownException
 	 */
 	public function importFromJson(string $json): ACore {
 		$data = json_decode($json, true);
@@ -85,10 +85,11 @@ class ImportService {
 		return AP::$activityPub->getItemFromData($data);
 	}
 
+
 	/**
 	 * @param ACore $activity
 	 *
-	 * @throws UnknownItemException
+	 * @throws ItemUnknownException
 	 * @throws InvalidOriginException
 	 */
 	public function parseIncomingRequest(ACore $activity) {

--- a/lib/Service/NoteService.php
+++ b/lib/Service/NoteService.php
@@ -37,14 +37,16 @@ use OCA\Social\Db\NotesRequest;
 use OCA\Social\Exceptions\AccountAlreadyExistsException;
 use OCA\Social\Exceptions\ActorDoesNotExistException;
 use OCA\Social\Exceptions\InvalidOriginException;
+use OCA\Social\Exceptions\InvalidResourceException;
+use OCA\Social\Exceptions\ItemUnknownException;
 use OCA\Social\Exceptions\NoteNotFoundException;
 use OCA\Social\Exceptions\RedundancyLimitException;
+use OCA\Social\Exceptions\RequestContentException;
+use OCA\Social\Exceptions\RequestNetworkException;
+use OCA\Social\Exceptions\RequestResultSizeException;
+use OCA\Social\Exceptions\RequestServerException;
 use OCA\Social\Exceptions\SocialAppConfigException;
-use OCA\Social\Exceptions\UnknownItemException;
 use OCA\Social\Exceptions\UrlCloudException;
-use OCA\Social\Exceptions\InvalidResourceException;
-use OCA\Social\Exceptions\Request410Exception;
-use OCA\Social\Exceptions\RequestException;
 use OCA\Social\Model\ActivityPub\ACore;
 use OCA\Social\Model\ActivityPub\Actor\Person;
 use OCA\Social\Model\ActivityPub\Object\Note;
@@ -252,10 +254,12 @@ class NoteService {
 	 * @throws MalformedArrayException
 	 * @throws NoteNotFoundException
 	 * @throws RedundancyLimitException
-	 * @throws Request410Exception
-	 * @throws RequestException
+	 * @throws RequestContentException
+	 * @throws RequestNetworkException
+	 * @throws RequestResultSizeException
+	 * @throws RequestServerException
 	 * @throws SocialAppConfigException
-	 * @throws UnknownItemException
+	 * @throws ItemUnknownException
 	 */
 	public function replyTo(Note $note, string $replyTo) {
 		if ($replyTo === '') {
@@ -386,15 +390,17 @@ class NoteService {
 	 * @param $noteId
 	 *
 	 * @return Person
+	 * @throws InvalidOriginException
 	 * @throws InvalidResourceException
 	 * @throws MalformedArrayException
 	 * @throws NoteNotFoundException
-	 * @throws Request410Exception
-	 * @throws RequestException
-	 * @throws SocialAppConfigException
-	 * @throws InvalidOriginException
 	 * @throws RedundancyLimitException
-	 * @throws UnknownItemException
+	 * @throws SocialAppConfigException
+	 * @throws ItemUnknownException
+	 * @throws RequestContentException
+	 * @throws RequestNetworkException
+	 * @throws RequestResultSizeException
+	 * @throws RequestServerException
 	 */
 	public function getAuthorFromPostId($noteId) {
 		$note = $this->notesRequest->getNoteById($noteId);

--- a/lib/Service/QueueService.php
+++ b/lib/Service/QueueService.php
@@ -32,7 +32,6 @@ namespace OCA\Social\Service;
 
 
 use daita\MySmallPhpTools\Traits\TArrayTools;
-use Exception;
 use OCA\Social\Db\RequestQueueRequest;
 use OCA\Social\Exceptions\EmptyQueueException;
 use OCA\Social\Exceptions\NoHighPriorityRequestException;
@@ -81,7 +80,6 @@ class QueueService {
 	 * @param string $author
 	 *
 	 * @return string
-	 * @throws Exception
 	 */
 	public function generateRequestQueue(array $instancePaths, ACore $item, string $author
 	): string {
@@ -197,14 +195,15 @@ class QueueService {
 	/**
 	 * @param RequestQueue $queue
 	 * @param bool $success
-	 *
-	 * @throws QueueStatusException
 	 */
 	public function endRequest(RequestQueue $queue, bool $success) {
-		if ($success === true) {
-			$this->requestQueueRequest->setAsSuccess($queue);
-		} else {
-			$this->requestQueueRequest->setAsFailure($queue);
+		try {
+			if ($success === true) {
+				$this->requestQueueRequest->setAsSuccess($queue);
+			} else {
+				$this->requestQueueRequest->setAsFailure($queue);
+			}
+		} catch (QueueStatusException $e) {
 		}
 	}
 

--- a/lib/Service/SignatureService.php
+++ b/lib/Service/SignatureService.php
@@ -41,12 +41,14 @@ use OCA\Social\Exceptions\InvalidOriginException;
 use OCA\Social\Exceptions\InvalidResourceException;
 use OCA\Social\Exceptions\LinkedDataSignatureMissingException;
 use OCA\Social\Exceptions\RedundancyLimitException;
-use OCA\Social\Exceptions\Request410Exception;
-use OCA\Social\Exceptions\RequestException;
+use OCA\Social\Exceptions\RequestContentException;
+use OCA\Social\Exceptions\RequestNetworkException;
+use OCA\Social\Exceptions\RequestResultSizeException;
+use OCA\Social\Exceptions\RequestServerException;
 use OCA\Social\Exceptions\SignatureException;
 use OCA\Social\Exceptions\SignatureIsGoneException;
 use OCA\Social\Exceptions\SocialAppConfigException;
-use OCA\Social\Exceptions\UnknownItemException;
+use OCA\Social\Exceptions\ItemUnknownException;
 use OCA\Social\Model\ActivityPub\ACore;
 use OCA\Social\Model\ActivityPub\Actor\Person;
 use OCA\Social\Model\LinkedDataSignature;
@@ -164,11 +166,13 @@ class SignatureService {
 	 * @throws InvalidResourceException
 	 * @throws MalformedArrayException
 	 * @throws RedundancyLimitException
-	 * @throws RequestException
+	 * @throws RequestNetworkException
+	 * @throws RequestResultSizeException
+	 * @throws RequestServerException
 	 * @throws SignatureException
 	 * @throws SignatureIsGoneException
 	 * @throws SocialAppConfigException
-	 * @throws UnknownItemException
+	 * @throws ItemUnknownException
 	 */
 	public function checkRequest(IRequest $request): string {
 		$dTime = new DateTime($request->getHeader('date'));
@@ -180,7 +184,7 @@ class SignatureService {
 
 		try {
 			$origin = $this->checkRequestSignature($request);
-		} catch (Request410Exception $e) {
+		} catch (RequestContentException $e) {
 			throw new SignatureIsGoneException();
 		}
 
@@ -196,10 +200,12 @@ class SignatureService {
 	 * @throws InvalidResourceException
 	 * @throws MalformedArrayException
 	 * @throws RedundancyLimitException
-	 * @throws Request410Exception
-	 * @throws RequestException
+	 * @throws RequestContentException
+	 * @throws RequestNetworkException
+	 * @throws RequestResultSizeException
+	 * @throws RequestServerException
 	 * @throws SocialAppConfigException
-	 * @throws UnknownItemException
+	 * @throws ItemUnknownException
 	 */
 	public function checkObject(ACore $object): bool {
 		try {
@@ -250,11 +256,13 @@ class SignatureService {
 	 * @throws InvalidResourceException
 	 * @throws MalformedArrayException
 	 * @throws RedundancyLimitException
-	 * @throws Request410Exception
-	 * @throws RequestException
+	 * @throws RequestNetworkException
+	 * @throws RequestServerException
 	 * @throws SignatureException
 	 * @throws SocialAppConfigException
-	 * @throws UnknownItemException
+	 * @throws ItemUnknownException
+	 * @throws RequestContentException
+	 * @throws RequestResultSizeException
 	 */
 	private function checkRequestSignature(IRequest $request): string {
 		$signatureHeader = $request->getHeader('Signature');
@@ -334,14 +342,16 @@ class SignatureService {
 	 * @param $keyId
 	 *
 	 * @return string
+	 * @throws InvalidOriginException
 	 * @throws InvalidResourceException
 	 * @throws MalformedArrayException
-	 * @throws Request410Exception
-	 * @throws RequestException
-	 * @throws SocialAppConfigException
-	 * @throws UnknownItemException
 	 * @throws RedundancyLimitException
-	 * @throws InvalidOriginException
+	 * @throws RequestContentException
+	 * @throws RequestNetworkException
+	 * @throws RequestResultSizeException
+	 * @throws RequestServerException
+	 * @throws SocialAppConfigException
+	 * @throws ItemUnknownException
 	 */
 	private function retrieveKey($keyId): string {
 		$actor = $this->cacheActorService->getFromId($keyId);


### PR DESCRIPTION
The idea is to split all possible errors when requesting a remote instance in 4 groups to improve/manage the queue:

- Network issues - Request stays in the queue and a background process will retry later.
- Server issues - Request stays in the queue and a background process will retry later
- Content issues - Request is deleted.
- ActivityPub issues - Request is deleted.

Also, the caching of documents is now using the CurlService::request() to download content
