### PR TITLE
Add the ability to follow from external website

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -55,6 +55,7 @@ return [
 		['name' => 'ActivityPub#following', 'url' => '/@{username}/following', 'verb' => 'GET'],
 
 		['name' => 'OStatus#subscribe', 'url' => '/ostatus/follow/{uri}', 'verb' => 'GET'],
+		['name' => 'OStatus#getLink', 'url' => '/api/v1/ostatus/link/{local}/{account}', 'verb' => 'GET'],
 
 		['name' => 'SocialPub#displayPost', 'url' => '/@{username}/{postId}', 'verb' => 'GET'],
 

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -54,6 +54,8 @@ return [
 		['name' => 'ActivityPub#followers', 'url' => '/@{username}/followers', 'verb' => 'GET'],
 		['name' => 'ActivityPub#following', 'url' => '/@{username}/following', 'verb' => 'GET'],
 
+		['name' => 'OStatus#subscribe', 'url' => '/ostatus/follow/{uri}', 'verb' => 'GET'],
+
 		['name' => 'SocialPub#displayPost', 'url' => '/@{username}/{postId}', 'verb' => 'GET'],
 
 		['name' => 'Local#streamHome', 'url' => '/api/v1/stream/home', 'verb' => 'GET'],

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -55,6 +55,7 @@ return [
 		['name' => 'ActivityPub#following', 'url' => '/@{username}/following', 'verb' => 'GET'],
 
 		['name' => 'OStatus#subscribe', 'url' => '/ostatus/follow/{uri}', 'verb' => 'GET'],
+		['name' => 'OStatus#followRemote', 'url' => '/api/v1/ostatus/followRemote/{local}', 'verb' => 'GET'],
 		['name' => 'OStatus#getLink', 'url' => '/api/v1/ostatus/link/{local}/{account}', 'verb' => 'GET'],
 
 		['name' => 'SocialPub#displayPost', 'url' => '/@{username}/{postId}', 'verb' => 'GET'],

--- a/lib/Controller/OStatusController.php
+++ b/lib/Controller/OStatusController.php
@@ -63,7 +63,7 @@ class OStatusController extends Controller {
 
 	/**
 	 * @NoCSRFRequired
-	 * @PublicPage
+	 * @NoAdminRequired
 	 *
 	 * @param string $uri
 	 *

--- a/lib/Controller/OStatusController.php
+++ b/lib/Controller/OStatusController.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+
+/**
+ * Nextcloud - Social Support
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Maxence Lange <maxence@artificial-owl.com>
+ * @copyright 2018, Maxence Lange <maxence@artificial-owl.com>
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Social\Controller;
+
+
+use daita\MySmallPhpTools\Traits\Nextcloud\TNCDataResponse;
+use OCA\Social\AppInfo\Application;
+use OCA\Social\Service\MiscService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Response;
+use OCP\IRequest;
+
+
+class OStatusController extends Controller {
+
+
+	use TNCDataResponse;
+
+
+	/** @var MiscService */
+	private $miscService;
+
+
+	/**
+	 * OStatusController constructor.
+	 *
+	 * @param IRequest $request
+	 * @param MiscService $miscService
+	 */
+	public function __construct(IRequest $request, MiscService $miscService) {
+		parent::__construct(Application::APP_NAME, $request);
+
+		$this->miscService = $miscService;
+	}
+
+
+	/**
+	 * @NoCSRFRequired
+	 * @PublicPage
+	 *
+	 * @param string $uri
+	 *
+	 * @return Response
+	 */
+	public function subscribe(string $uri): Response {
+		return $this->success([$uri]);
+	}
+
+}
+

--- a/lib/Service/AccountService.php
+++ b/lib/Service/AccountService.php
@@ -161,6 +161,7 @@ class AccountService {
 	 * @throws NoUserException
 	 * @throws SocialAppConfigException
 	 * @throws UrlCloudException
+	 * @throws ItemUnknownException
 	 */
 	public function getActorFromUserId(string $userId, bool $create = false): Person {
 		$this->miscService->confirmUserId($userId);

--- a/lib/Service/CurlService.php
+++ b/lib/Service/CurlService.php
@@ -90,21 +90,15 @@ class CurlService {
 	/**
 	 * @param string $account
 	 *
-	 * @return Person
-	 * @throws InvalidOriginException
+	 * @return array
 	 * @throws InvalidResourceException
-	 * @throws MalformedArrayException
-	 * @throws RedundancyLimitException
 	 * @throws RequestContentException
-	 * @throws RetrieveAccountFormatException
 	 * @throws RequestNetworkException
 	 * @throws RequestResultSizeException
 	 * @throws RequestServerException
-	 * @throws SocialAppConfigException
-	 * @throws ItemUnknownException
 	 * @throws RequestResultNotJsonException
 	 */
-	public function retrieveAccount(string $account): Person {
+	public function webfingerAccount(string $account): array {
 		$account = $this->withoutBeginAt($account);
 
 		// we consider an account is like an email
@@ -121,6 +115,29 @@ class CurlService {
 		$request->addData('resource', 'acct:' . $account);
 		$request->setAddress($host);
 		$result = $this->request($request);
+
+		return $result;
+	}
+
+
+	/**
+	 * @param string $account
+	 *
+	 * @return Person
+	 * @throws InvalidOriginException
+	 * @throws InvalidResourceException
+	 * @throws MalformedArrayException
+	 * @throws RedundancyLimitException
+	 * @throws RequestContentException
+	 * @throws RetrieveAccountFormatException
+	 * @throws RequestNetworkException
+	 * @throws RequestResultSizeException
+	 * @throws RequestServerException
+	 * @throws SocialAppConfigException
+	 * @throws ItemUnknownException
+	 */
+	public function retrieveAccount(string $account): Person {
+		$result = $this->webfingerAccount($account);
 
 		try {
 			$link = $this->extractArray('rel', 'self', $this->getArray('links', $result));

--- a/lib/webfinger.php
+++ b/lib/webfinger.php
@@ -83,6 +83,11 @@ $finger = [
 			'rel' => 'self',
 			'type' => 'application/activity+json',
 			'href' => $href
+		],
+		[
+			'rel'      => 'http://ostatus.org/schema/1.0/subscribe',
+			'template' => urldecode(
+				$href = $urlGenerator->linkToRouteAbsolute('social.OStatus.subscribe', ['uri' => '{uri}']))
 		]
 	]
 ];

--- a/src/components/ProfileInfo.vue
+++ b/src/components/ProfileInfo.vue
@@ -35,6 +35,9 @@
 				</a>
 			</p>
 			<follow-button :account="accountInfo.account" />
+			<button v-if="serverData.public" class="primary" @click="followRemote">
+				{{ t('social', 'Follow') }}
+			</button>
 		</div>
 		<!-- TODO: we have no details, timeline and follower list for non-local accounts for now -->
 		<ul v-if="accountInfo.details && accountInfo.local" class="user-profile--sections">
@@ -145,7 +148,9 @@ export default {
 		}
 	},
 	methods: {
-
+		followRemote() {
+			window.open(OC.generateUrl('/apps/social/api/v1/ostatus/followRemote/' + encodeURI(this.uid)), 'followRemote', 'width=433,height=600toolbar=no,menubar=no,scrollbars=yes,resizable=yes')
+		}
 	}
 }
 

--- a/src/ostatus.js
+++ b/src/ostatus.js
@@ -1,0 +1,41 @@
+/*
+ * @copyright Copyright (c) 2019 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import Vue from 'vue'
+import store from './store'
+import OStatus from './views/OStatus'
+
+// eslint-disable-next-line
+__webpack_nonce__ = btoa(OC.requestToken)
+// eslint-disable-next-line
+__webpack_public_path__ = OC.linkTo('social', 'js/')
+
+Vue.prototype.t = t
+Vue.prototype.n = n
+Vue.prototype.OC = OC
+Vue.prototype.OCA = OCA
+
+/* eslint-disable-next-line no-new */
+new Vue({
+	render: h => h(OStatus),
+	store: store
+}).$mount('#vue-content')

--- a/src/views/OStatus.vue
+++ b/src/views/OStatus.vue
@@ -1,0 +1,78 @@
+<template>
+	<div>
+		<h2>{{ t('social', 'Follow on Nextcloud Social') }}</h2>
+		<div v-if="accountInfo">
+			<p>{{ t('social', 'Hello') }} <avatar :user="currentUser.uid" :size="16" />{{ currentUser.displayName }}</p>
+			<p>{{ t('social', 'Please confirm that you want to follow this account:') }}</p>
+
+			<avatar :url="avatarUrl" :disable-tooltip="true" :size="128" />
+			<h2>{{ displayName }}</h2>
+			<form @submit.prevent="follow">
+				<input type="text" :value="serverData.account">
+				<input type="submit" class="primary" value="Follow">
+			</form>
+		</div>
+		<div :class="{ 'icon-loading-dark': !accountInfo }" />
+	</div>
+</template>
+
+<style scoped>
+	h2, p {
+		color: var(--color-primary-text);
+	}
+	.avatardiv {
+		vertical-align: -4px;
+		margin-right: 3px;
+	}
+</style>
+
+<script>
+import { Avatar } from 'nextcloud-vue'
+import currentuserMixin from './../mixins/currentUserMixin'
+
+export default {
+	name: 'App',
+	components: {
+		Avatar
+	},
+	mixins: [currentuserMixin],
+	computed: {
+		account() {
+			return this.serverData.account
+		},
+		avatarUrl() {
+			return OC.generateUrl('/apps/social/api/v1/global/actor/avatar?id=' + this.accountInfo.id)
+		},
+		accountInfo: function() {
+			return this.$store.getters.getAccount(this.serverData.account)
+		},
+		currentUser() {
+			return window.oc_current_user
+		},
+		displayName() {
+			if (typeof this.accountInfo.name !== 'undefined' && this.accountInfo.name !== '') {
+				return this.accountInfo.name
+			}
+			return this.account
+		}
+	},
+	beforeMount: function() {
+		// importing server data into the store
+		const serverDataElmt = document.getElementById('serverData')
+		if (serverDataElmt !== null) {
+			const serverData = JSON.parse(document.getElementById('serverData').dataset.server)
+			window.oc_current_user = JSON.parse(JSON.stringify(serverData.currentUser))
+			this.$store.commit('setServerData', serverData)
+			this.$store.dispatch('fetchAccountInfo', this.serverData.account)
+
+		}
+	},
+	methods: {
+		follow() {
+			this.$store.dispatch('followAccount', { currentAccount: this.cloudId, accountToFollow: this.account }).then(() => {
+				window.location = this.serverData.url
+			})
+		}
+	}
+}
+</script>

--- a/src/views/OStatus.vue
+++ b/src/views/OStatus.vue
@@ -1,33 +1,67 @@
 <template>
-	<div>
-		<h2>{{ t('social', 'Follow on Nextcloud Social') }}</h2>
-		<div v-if="accountInfo">
+	<div v-if="accountInfo">
+		<div v-if="!serverData.local">
+			<h2>{{ t('social', 'Follow on Nextcloud Social') }}</h2>
 			<p>{{ t('social', 'Hello') }} <avatar :user="currentUser.uid" :size="16" />{{ currentUser.displayName }}</p>
-			<p>{{ t('social', 'Please confirm that you want to follow this account:') }}</p>
+			<p v-if="!isFollowing">
+				{{ t('social', 'Please confirm that you want to follow this account:') }}
+			</p>
 
 			<avatar :url="avatarUrl" :disable-tooltip="true" :size="128" />
 			<h2>{{ displayName }}</h2>
-			<form @submit.prevent="follow">
-				<input type="text" :value="serverData.account">
+			<form v-if="!isFollowing" @submit.prevent="follow">
 				<input type="submit" class="primary" value="Follow">
 			</form>
+			<p v-else>
+				<span class="icon icon-checkmark-white" />
+				{{ t('social', 'You are following this account') }}
+			</p>
+
+			<div v-if="isFollowing">
+				<button @click="close">
+					{{ t('social', 'Close') }}
+				</button>
+			</div>
 		</div>
-		<div :class="{ 'icon-loading-dark': !accountInfo }" />
+		<div v-if="serverData.local">
+			<p>{{ t('social', 'You are going to follow:') }}</p>
+			<avatar :user="serverData.local" :disable-tooltip="true" :size="128" />
+			<h2>{{ displayName }}</h2>
+			<form @submit.prevent="followRemote">
+				<input v-model="remote" type="text" :placeholder="t('social', 'name@domain of your federation account')">
+				<input type="submit" class="primary" :value="t('social', 'Continue')">
+			</form>
+			<p>{{ t('social', 'This step is needed as the user is probably not registered on the same server as you are. We will redirect you to your homeserver to follow this account.') }}</p>
+		</div>
 	</div>
+	<div v-else :class="{ 'icon-loading-dark': !accountInfo }" />
 </template>
 
 <style scoped>
 	h2, p {
 		color: var(--color-primary-text);
 	}
+	p .icon {
+		display: inline-block;
+	}
 	.avatardiv {
 		vertical-align: -4px;
 		margin-right: 3px;
+		filter: drop-shadow(0 0 0.5rem #333);
+		margin-top: 10px;
+		margin-bottom: 20px;
+	}
+</style>
+
+<style>
+	.wrapper {
+		margin-top: 20px;
 	}
 </style>
 
 <script>
 import { Avatar } from 'nextcloud-vue'
+import axios from 'nextcloud-axios'
 import currentuserMixin from './../mixins/currentUserMixin'
 
 export default {
@@ -36,7 +70,15 @@ export default {
 		Avatar
 	},
 	mixins: [currentuserMixin],
+	data() {
+		return {
+			remote: ''
+		}
+	},
 	computed: {
+		isFollowing() {
+			return this.$store.getters.isFollowingUser(this.account)
+		},
 		account() {
 			return this.serverData.account
 		},
@@ -61,17 +103,32 @@ export default {
 		const serverDataElmt = document.getElementById('serverData')
 		if (serverDataElmt !== null) {
 			const serverData = JSON.parse(document.getElementById('serverData').dataset.server)
-			window.oc_current_user = JSON.parse(JSON.stringify(serverData.currentUser))
+			if (serverData.currentUser) {
+				window.oc_current_user = JSON.parse(JSON.stringify(serverData.currentUser))
+			}
 			this.$store.commit('setServerData', serverData)
-			this.$store.dispatch('fetchAccountInfo', this.serverData.account)
+			if (this.serverData.account && !this.serverData.local) {
+				this.$store.dispatch('fetchAccountInfo', this.serverData.account)
+			}
+			if (this.serverData.local) {
+				this.$store.dispatch('fetchPublicAccountInfo', this.serverData.local)
+			}
 
 		}
 	},
 	methods: {
 		follow() {
 			this.$store.dispatch('followAccount', { currentAccount: this.cloudId, accountToFollow: this.account }).then(() => {
-				window.location = this.serverData.url
+
 			})
+		},
+		followRemote() {
+			axios.get(OC.generateUrl(`/apps/social/api/v1/ostatus/link/${this.serverData.local}/` + encodeURI(this.remote))).then((a) => {
+				window.location = a.data.result.url
+			})
+		},
+		close() {
+			window.close()
 		}
 	}
 }

--- a/templates/ostatus.php
+++ b/templates/ostatus.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @copyright Copyright (c) 2019 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+script('social', 'ostatus');
+style('social', 'style');
+?>
+<span id="serverData" data-server="<?php p(json_encode($_['serverData']));?>"></span>
+<div id="vue-content"></div>

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -3,11 +3,14 @@ const VueLoaderPlugin = require('vue-loader/lib/plugin');
 
 
 module.exports = {
-	entry: path.join(__dirname, 'src', 'main.js'),
+	entry: {
+		social: path.join(__dirname, 'src', 'main.js'),
+		ostatus: path.join(__dirname, 'src', 'ostatus.js'),
+	},
 	output: {
 		path: path.resolve(__dirname, './js'),
 		publicPath: '/js/',
-		filename: 'social.js',
+		filename: '[name].js',
 		chunkFilename: '[name].[chunkhash].js'
 	},
 	module: {


### PR DESCRIPTION
related to #268

Implementation of OStatus (it seems to work like this):

- the remote website open a page (in popup) from the app, with the remote account in params.
- in the opened popup, we display the result of a search on the remote account set in params. We display also a 'Follow' button.
- if user is not authed, login/password.

ToDo:
- [x] Implement popup for following external accounts
- [x] Open popover to follow from public pages

## Screenshots

## Follow from a public mastodon page
![image](https://user-images.githubusercontent.com/3404133/52336642-b916e800-2a05-11e9-911b-304b4d8729d0.png)

![image](https://user-images.githubusercontent.com/3404133/52336614-a3a1be00-2a05-11e9-8b3d-e453c45836e7.png)

### Follow with a remote account from public profile pages:

![image](https://user-images.githubusercontent.com/3404133/52336544-7bb25a80-2a05-11e9-86dc-8338dd3450dd.png)
