### PR TITLE
throw RequestResultNotJsonException on unusual result

### DIFF
--- a/lib/Controller/SocialPubController.php
+++ b/lib/Controller/SocialPubController.php
@@ -94,6 +94,12 @@ class SocialPubController extends Controller {
 		$this->navigationController = $navigationController;
 	}
 
+	/**
+	 * @param $username
+	 *
+	 * @return Response
+	 * @throws UrlCloudException
+	 */
 	private function renderPage($username): Response {
 		if ($this->userId) {
 			return $this->navigationController->navigate('');

--- a/lib/Db/NotesRequestBuilder.php
+++ b/lib/Db/NotesRequestBuilder.php
@@ -31,11 +31,10 @@ namespace OCA\Social\Db;
 
 
 use daita\MySmallPhpTools\Traits\TArrayTools;
-use DateTime;
 use Doctrine\DBAL\Query\QueryBuilder;
 use OCA\Social\Exceptions\InvalidResourceException;
-use OCA\Social\Model\ActivityPub\Object\Note;
 use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Note;
 use OCA\Social\Model\InstancePath;
 use OCP\DB\QueryBuilder\ICompositeExpression;
 use OCP\DB\QueryBuilder\IQueryBuilder;

--- a/lib/Exceptions/RequestResultNotJsonException.php
+++ b/lib/Exceptions/RequestResultNotJsonException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace OCA\Social\Exceptions;
+
+class RequestResultNotJsonException extends \Exception {
+
+}
+

--- a/lib/Interfaces/Activity/DeleteInterface.php
+++ b/lib/Interfaces/Activity/DeleteInterface.php
@@ -77,8 +77,8 @@ class DeleteInterface implements IActivityPubInterface {
 						$interface->delete($object);
 
 						return;
-					} catch (UnknownItemException $e) {
 					} catch (ItemNotFoundException $e) {
+					} catch (ItemUnknownException $e) {
 					}
 				}
 			}

--- a/lib/Interfaces/Activity/FollowInterface.php
+++ b/lib/Interfaces/Activity/FollowInterface.php
@@ -42,6 +42,7 @@ use OCA\Social\Exceptions\ItemNotFoundException;
 use OCA\Social\Exceptions\RedundancyLimitException;
 use OCA\Social\Exceptions\RequestContentException;
 use OCA\Social\Exceptions\RequestNetworkException;
+use OCA\Social\Exceptions\RequestResultNotJsonException;
 use OCA\Social\Exceptions\RequestResultSizeException;
 use OCA\Social\Exceptions\RequestServerException;
 use OCA\Social\Exceptions\SocialAppConfigException;
@@ -147,6 +148,7 @@ class FollowInterface implements IActivityPubInterface {
 	 * @throws RequestNetworkException
 	 * @throws RequestResultSizeException
 	 * @throws RequestServerException
+	 * @throws RequestResultNotJsonException
 	 */
 	public function processIncomingRequest(ACore $follow) {
 		/** @var Follow $follow */

--- a/lib/Interfaces/Object/NoteInterface.php
+++ b/lib/Interfaces/Object/NoteInterface.php
@@ -38,7 +38,6 @@ use OCA\Social\Exceptions\NoteNotFoundException;
 use OCA\Social\Interfaces\IActivityPubInterface;
 use OCA\Social\Model\ActivityPub\ACore;
 use OCA\Social\Model\ActivityPub\Activity\Create;
-use OCA\Social\Model\ActivityPub\Activity\Update;
 use OCA\Social\Model\ActivityPub\Object\Note;
 use OCA\Social\Service\ConfigService;
 use OCA\Social\Service\CurlService;

--- a/lib/Service/AccountService.php
+++ b/lib/Service/AccountService.php
@@ -38,6 +38,7 @@ use OCA\Social\Db\FollowsRequest;
 use OCA\Social\Db\NotesRequest;
 use OCA\Social\Exceptions\AccountAlreadyExistsException;
 use OCA\Social\Exceptions\ActorDoesNotExistException;
+use OCA\Social\Exceptions\ItemUnknownException;
 use OCA\Social\Exceptions\SocialAppConfigException;
 use OCA\Social\Exceptions\UrlCloudException;
 use OCA\Social\Model\ActivityPub\Actor\Person;
@@ -245,8 +246,11 @@ class AccountService {
 				return;
 			}
 
-			$iconId = $this->documentService->cacheLocalAvatarByUsername($actor);
-			$actor->setIconId($iconId);
+			try {
+				$iconId = $this->documentService->cacheLocalAvatarByUsername($actor);
+				$actor->setIconId($iconId);
+			} catch (ItemUnknownException $e) {
+			}
 
 			$count = [
 				'followers' => $this->followsRequest->countFollowers($actor->getId()),

--- a/lib/Service/ActivityService.php
+++ b/lib/Service/ActivityService.php
@@ -43,6 +43,7 @@ use OCA\Social\Exceptions\NoHighPriorityRequestException;
 use OCA\Social\Exceptions\QueueStatusException;
 use OCA\Social\Exceptions\RequestContentException;
 use OCA\Social\Exceptions\RequestNetworkException;
+use OCA\Social\Exceptions\RequestResultNotJsonException;
 use OCA\Social\Exceptions\RequestResultSizeException;
 use OCA\Social\Exceptions\RequestServerException;
 use OCA\Social\Exceptions\SocialAppConfigException;
@@ -265,6 +266,8 @@ class ActivityService {
 		try {
 			$this->signatureService->signRequest($request, $queue);
 			$this->curlService->request($request);
+			$this->queueService->endRequest($queue, true);
+		} catch (RequestResultNotJsonException $e) {
 			$this->queueService->endRequest($queue, true);
 		} catch (ActorDoesNotExistException $e) {
 			$this->miscService->log(

--- a/lib/Service/CacheActorService.php
+++ b/lib/Service/CacheActorService.php
@@ -40,6 +40,7 @@ use OCA\Social\Exceptions\InvalidOriginException;
 use OCA\Social\Exceptions\InvalidResourceException;
 use OCA\Social\Exceptions\RedundancyLimitException;
 use OCA\Social\Exceptions\RequestContentException;
+use OCA\Social\Exceptions\RequestResultNotJsonException;
 use OCA\Social\Exceptions\RetrieveAccountFormatException;
 use OCA\Social\Exceptions\RequestNetworkException;
 use OCA\Social\Exceptions\RequestResultSizeException;
@@ -120,6 +121,7 @@ class CacheActorService {
 	 * @throws RequestServerException
 	 * @throws SocialAppConfigException
 	 * @throws ItemUnknownException
+	 * @throws RequestResultNotJsonException
 	 */
 	public function getFromId(string $id, bool $refresh = false): Person {
 
@@ -188,6 +190,7 @@ class CacheActorService {
 	 * @throws RequestServerException
 	 * @throws SocialAppConfigException
 	 * @throws ItemUnknownException
+	 * @throws RequestResultNotJsonException
 	 */
 	public function getFromAccount(string $account, bool $retrieve = true): Person {
 

--- a/lib/Service/CacheDocumentService.php
+++ b/lib/Service/CacheDocumentService.php
@@ -39,6 +39,7 @@ use OCA\Social\Exceptions\CacheContentMimeTypeException;
 use OCA\Social\Exceptions\CacheDocumentDoesNotExistException;
 use OCA\Social\Exceptions\RequestContentException;
 use OCA\Social\Exceptions\RequestNetworkException;
+use OCA\Social\Exceptions\RequestResultNotJsonException;
 use OCA\Social\Exceptions\RequestResultSizeException;
 use OCA\Social\Exceptions\RequestServerException;
 use OCP\Files\IAppData;
@@ -98,6 +99,7 @@ class CacheDocumentService {
 	 * @throws RequestNetworkException
 	 * @throws RequestServerException
 	 * @throws RequestResultSizeException
+	 * @throws RequestResultNotJsonException
 	 */
 	public function saveRemoteFileToCache(string $url, &$mime = '') {
 
@@ -191,6 +193,7 @@ class CacheDocumentService {
 	 * @throws RequestNetworkException
 	 * @throws RequestServerException
 	 * @throws RequestResultSizeException
+	 * @throws RequestResultNotJsonException
 	 */
 	public function retrieveContent(string $url) {
 		$url = parse_url($url);

--- a/lib/Service/CurlService.php
+++ b/lib/Service/CurlService.php
@@ -41,6 +41,7 @@ use OCA\Social\Exceptions\InvalidOriginException;
 use OCA\Social\Exceptions\InvalidResourceException;
 use OCA\Social\Exceptions\RedundancyLimitException;
 use OCA\Social\Exceptions\RequestContentException;
+use OCA\Social\Exceptions\RequestResultNotJsonException;
 use OCA\Social\Exceptions\RetrieveAccountFormatException;
 use OCA\Social\Exceptions\RequestNetworkException;
 use OCA\Social\Exceptions\RequestResultSizeException;
@@ -101,6 +102,7 @@ class CurlService {
 	 * @throws RequestServerException
 	 * @throws SocialAppConfigException
 	 * @throws ItemUnknownException
+	 * @throws RequestResultNotJsonException
 	 */
 	public function retrieveAccount(string $account): Person {
 		$account = $this->withoutBeginAt($account);
@@ -152,6 +154,7 @@ class CurlService {
 	 * @throws RequestNetworkException
 	 * @throws RequestServerException
 	 * @throws RequestResultSizeException
+	 * @throws RequestResultNotJsonException
 	 */
 	public function retrieveObject($id): array {
 
@@ -177,6 +180,7 @@ class CurlService {
 	 * @throws RequestNetworkException
 	 * @throws RequestResultSizeException
 	 * @throws RequestServerException
+	 * @throws RequestResultNotJsonException
 	 */
 	public function request(Request $request) {
 
@@ -204,7 +208,12 @@ class CurlService {
 			'[>>] request: ' . json_encode($request) . ' - result: ' . $result, 1
 		);
 
-		return json_decode((string)$result, true);
+		$result = json_decode((string)$result, true);
+		if (is_array($result)) {
+			return $result;
+		}
+
+		throw new RequestResultNotJsonException();
 	}
 
 

--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -42,6 +42,7 @@ use OCA\Social\Exceptions\CacheDocumentDoesNotExistException;
 use OCA\Social\Exceptions\ItemUnknownException;
 use OCA\Social\Exceptions\RequestContentException;
 use OCA\Social\Exceptions\RequestNetworkException;
+use OCA\Social\Exceptions\RequestResultNotJsonException;
 use OCA\Social\Exceptions\RequestResultSizeException;
 use OCA\Social\Exceptions\RequestServerException;
 use OCA\Social\Exceptions\SocialAppConfigException;
@@ -114,6 +115,7 @@ class DocumentService {
 	 * @return Document
 	 * @throws CacheDocumentDoesNotExistException
 	 * @throws MalformedArrayException
+	 * @throws RequestResultNotJsonException
 	 */
 	public function cacheRemoteDocument(string $id, bool $public = false) {
 		$document = $this->cacheDocumentsRequest->getById($id, $public);

--- a/lib/Service/FollowService.php
+++ b/lib/Service/FollowService.php
@@ -41,6 +41,7 @@ use OCA\Social\Exceptions\InvalidOriginException;
 use OCA\Social\Exceptions\InvalidResourceException;
 use OCA\Social\Exceptions\RedundancyLimitException;
 use OCA\Social\Exceptions\RequestContentException;
+use OCA\Social\Exceptions\RequestResultNotJsonException;
 use OCA\Social\Exceptions\RetrieveAccountFormatException;
 use OCA\Social\Exceptions\RequestNetworkException;
 use OCA\Social\Exceptions\RequestResultSizeException;
@@ -133,6 +134,7 @@ class FollowService {
 	 * @throws RequestNetworkException
 	 * @throws RequestResultSizeException
 	 * @throws RequestServerException
+	 * @throws RequestResultNotJsonException
 	 */
 	public function followAccount(Person $actor, string $account) {
 		$remoteActor = $this->cacheActorService->getFromAccount($account);
@@ -181,6 +183,7 @@ class FollowService {
 	 * @throws SocialAppConfigException
 	 * @throws ItemUnknownException
 	 * @throws UrlCloudException
+	 * @throws RequestResultNotJsonException
 	 */
 	public function unfollowAccount(Person $actor, string $account) {
 		$remoteActor = $this->cacheActorService->getFromAccount($account);

--- a/lib/Service/NoteService.php
+++ b/lib/Service/NoteService.php
@@ -43,6 +43,7 @@ use OCA\Social\Exceptions\NoteNotFoundException;
 use OCA\Social\Exceptions\RedundancyLimitException;
 use OCA\Social\Exceptions\RequestContentException;
 use OCA\Social\Exceptions\RequestNetworkException;
+use OCA\Social\Exceptions\RequestResultNotJsonException;
 use OCA\Social\Exceptions\RequestResultSizeException;
 use OCA\Social\Exceptions\RequestServerException;
 use OCA\Social\Exceptions\SocialAppConfigException;
@@ -260,6 +261,7 @@ class NoteService {
 	 * @throws RequestServerException
 	 * @throws SocialAppConfigException
 	 * @throws ItemUnknownException
+	 * @throws RequestResultNotJsonException
 	 */
 	public function replyTo(Note $note, string $replyTo) {
 		if ($replyTo === '') {
@@ -401,6 +403,7 @@ class NoteService {
 	 * @throws RequestNetworkException
 	 * @throws RequestResultSizeException
 	 * @throws RequestServerException
+	 * @throws RequestResultNotJsonException
 	 */
 	public function getAuthorFromPostId($noteId) {
 		$note = $this->notesRequest->getNoteById($noteId);

--- a/lib/Service/SignatureService.php
+++ b/lib/Service/SignatureService.php
@@ -43,6 +43,7 @@ use OCA\Social\Exceptions\LinkedDataSignatureMissingException;
 use OCA\Social\Exceptions\RedundancyLimitException;
 use OCA\Social\Exceptions\RequestContentException;
 use OCA\Social\Exceptions\RequestNetworkException;
+use OCA\Social\Exceptions\RequestResultNotJsonException;
 use OCA\Social\Exceptions\RequestResultSizeException;
 use OCA\Social\Exceptions\RequestServerException;
 use OCA\Social\Exceptions\SignatureException;
@@ -177,6 +178,7 @@ class SignatureService {
 	 * @throws SignatureIsGoneException
 	 * @throws SocialAppConfigException
 	 * @throws ItemUnknownException
+	 * @throws RequestResultNotJsonException
 	 */
 	public function checkRequest(IRequest $request, int &$time = 0): string {
 		$dTime = new DateTime($request->getHeader('date'));
@@ -210,6 +212,7 @@ class SignatureService {
 	 * @throws RequestServerException
 	 * @throws SocialAppConfigException
 	 * @throws ItemUnknownException
+	 * @throws RequestResultNotJsonException
 	 */
 	public function checkObject(ACore $object): bool {
 		try {
@@ -276,6 +279,7 @@ class SignatureService {
 	 * @throws ItemUnknownException
 	 * @throws RequestContentException
 	 * @throws RequestResultSizeException
+	 * @throws RequestResultNotJsonException
 	 */
 	private function checkRequestSignature(IRequest $request): string {
 		$signatureHeader = $request->getHeader('Signature');
@@ -365,6 +369,7 @@ class SignatureService {
 	 * @return string
 	 * @throws InvalidOriginException
 	 * @throws InvalidResourceException
+	 * @throws ItemUnknownException
 	 * @throws MalformedArrayException
 	 * @throws RedundancyLimitException
 	 * @throws RequestContentException
@@ -372,7 +377,7 @@ class SignatureService {
 	 * @throws RequestResultSizeException
 	 * @throws RequestServerException
 	 * @throws SocialAppConfigException
-	 * @throws ItemUnknownException
+	 * @throws RequestResultNotJsonException
 	 */
 	private function retrieveKey(string $keyId, bool $refresh = false): string {
 		$actor = $this->cacheActorService->getFromId($keyId, $refresh);


### PR DESCRIPTION
Avoid some strange behaviors if the remote instance is under maintenance mode.