### PR TITLE
Use chunkhash to properly trigger reload of webpack chunks on upgrade

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -7,7 +7,8 @@ module.exports = {
 	output: {
 		path: path.resolve(__dirname, './js'),
 		publicPath: '/js/',
-		filename: 'social.js'
+		filename: 'social.js',
+		chunkFilename: '[name].[chunkhash].js'
 	},
 	module: {
 		rules: [


### PR DESCRIPTION
Fixes #373 

Instead of profile.js as the name for chunks we will now use profile.[chunkhash].js to properly force the browser to reload those files instead of using the ones from the cache.


