### PR TITLE
Delete Note from db if author is no more in cache

### DIFF
--- a/lib/Db/NotesRequest.php
+++ b/lib/Db/NotesRequest.php
@@ -364,16 +364,5 @@ class NotesRequest extends NotesRequestBuilder {
 		return $notes;
 	}
 
-
-	/**
-	 * @param string $id
-	 */
-	public function deleteNoteById(string $id) {
-		$qb = $this->getNotesDeleteSql();
-		$this->limitToIdString($qb, $id);
-
-		$qb->execute();
-	}
-
 }
 

--- a/lib/Db/NotesRequestBuilder.php
+++ b/lib/Db/NotesRequestBuilder.php
@@ -354,9 +354,21 @@ class NotesRequestBuilder extends CoreRequestBuilder {
 			$note->setCompleteDetails(true);
 			$note->setActor($actor);
 		} catch (InvalidResourceException $e) {
+			$this->deleteNoteById($note->getId());
 		}
 
 		return $note;
+	}
+
+
+	/**
+	 * @param string $id
+	 */
+	public function deleteNoteById(string $id) {
+		$qb = $this->getNotesDeleteSql();
+		$this->limitToIdString($qb, $id);
+
+		$qb->execute();
 	}
 
 }


### PR DESCRIPTION
This is an hotfix for the missing actor_info on the front-end.

We should also remove the Notes when the author is deleted from a remote instance.