### PR TITLE
creating a new field id_prim, set as primary and fill it

### DIFF
--- a/lib/Db/ActorsRequest.php
+++ b/lib/Db/ActorsRequest.php
@@ -85,6 +85,8 @@ class ActorsRequest extends ActorsRequestBuilder {
 			   $qb->createNamedParameter(new DateTime('now'), IQueryBuilder::PARAM_DATE)
 		   );
 
+		$this->generatePrimaryKey($qb, $id);
+
 		$qb->execute();
 
 		return $id;

--- a/lib/Db/CacheActorsRequest.php
+++ b/lib/Db/CacheActorsRequest.php
@@ -106,6 +106,8 @@ class CacheActorsRequest extends CacheActorsRequestBuilder {
 
 		$qb->setValue('icon_id', $qb->createNamedParameter($iconId));
 
+		$this->generatePrimaryKey($qb, $actor->getId());
+
 		$qb->execute();
 	}
 

--- a/lib/Db/CacheDocumentsRequest.php
+++ b/lib/Db/CacheDocumentsRequest.php
@@ -61,6 +61,9 @@ class CacheDocumentsRequest extends CacheDocumentsRequestBuilder {
 			   'creation',
 			   $qb->createNamedParameter(new DateTime('now'), IQueryBuilder::PARAM_DATE)
 		   );
+
+		$this->generatePrimaryKey($qb, $document->getId());
+
 		$qb->execute();
 	}
 

--- a/lib/Db/CoreRequestBuilder.php
+++ b/lib/Db/CoreRequestBuilder.php
@@ -113,7 +113,6 @@ class CoreRequestBuilder {
 	 */
 	public function generatePrimaryKey(IQueryBuilder $qb, string $id) {
 		$qb->setValue('id_prim', $qb->createNamedParameter(hash('sha512', $id)));
-		$this->miscService->log('__' . hash('sha512', 'toto'));
 	}
 
 

--- a/lib/Db/CoreRequestBuilder.php
+++ b/lib/Db/CoreRequestBuilder.php
@@ -108,6 +108,16 @@ class CoreRequestBuilder {
 
 
 	/**
+	 * @param IQueryBuilder $qb
+	 * @param string $id
+	 */
+	public function generatePrimaryKey(IQueryBuilder $qb, string $id) {
+		$qb->setValue('id_prim', $qb->createNamedParameter(hash('sha512', $id)));
+		$this->miscService->log('__' . hash('sha512', 'toto'));
+	}
+
+
+	/**
 	 * Limit the request to the Id
 	 *
 	 * @param IQueryBuilder $qb

--- a/lib/Db/FollowsRequest.php
+++ b/lib/Db/FollowsRequest.php
@@ -66,6 +66,8 @@ class FollowsRequest extends FollowsRequestBuilder {
 			   $qb->createNamedParameter(new DateTime('now'), IQueryBuilder::PARAM_DATE)
 		   );
 
+		$this->generatePrimaryKey($qb, $follow->getId());
+
 		$qb->execute();
 	}
 

--- a/lib/Db/NotesRequest.php
+++ b/lib/Db/NotesRequest.php
@@ -455,6 +455,8 @@ class NotesRequest extends NotesRequestBuilder {
 			   $qb->createNamedParameter(new DateTime('now'), IQueryBuilder::PARAM_DATE)
 		   );
 
+		$this->generatePrimaryKey($qb, $note->getId());
+
 		return $qb;
 	}
 

--- a/lib/Migration/Version0002Date20190305091901.php
+++ b/lib/Migration/Version0002Date20190305091901.php
@@ -130,8 +130,6 @@ class Version0002Date20190305091901 extends SimpleMigrationStep {
 					   ->eq($field, $update->createNamedParameter($id))
 				);
 				$update->execute();
-
-				$update->execute();
 			}
 			$cursor->closeCursor();
 

--- a/lib/Migration/Version0002Date20190305091901.php
+++ b/lib/Migration/Version0002Date20190305091901.php
@@ -1,0 +1,131 @@
+<?php
+declare(strict_types=1);
+
+
+/**
+ * Nextcloud - Social Support
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Maxence Lange <maxence@artificial-owl.com>
+ * @copyright 2018, Maxence Lange <maxence@artificial-owl.com>
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCA\Social\Migration;
+
+
+use Closure;
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Schema\SchemaException;
+use Doctrine\DBAL\Types\Type;
+use OCA\Social\Db\CoreRequestBuilder;
+use OCP\DB\ISchemaWrapper;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+
+/**
+ * Class Version0002Date20190305091901
+ *
+ * @package OCA\Social\Migration
+ */
+class Version0002Date20190305091901 extends SimpleMigrationStep {
+
+
+	/** @var IDBConnection */
+	private $connection;
+
+
+	/** @var array */
+	public static $setAsKeys = [
+		[CoreRequestBuilder::TABLE_CACHE_ACTORS, 'id'],
+		[CoreRequestBuilder::TABLE_CACHE_DOCUMENTS, 'id'],
+		[CoreRequestBuilder::TABLE_SERVER_ACTORS, 'id'],
+		[CoreRequestBuilder::TABLE_SERVER_FOLLOWS, 'id'],
+		[CoreRequestBuilder::TABLE_SERVER_NOTES, 'id']
+	];
+
+
+	/**
+	 * @param IDBConnection $connection
+	 */
+	public function __construct(IDBConnection $connection) {
+		$this->connection = $connection;
+	}
+
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 *
+	 * @return ISchemaWrapper
+	 * @throws SchemaException
+	 * @throws DBALException
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options
+	): ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		foreach (self::$setAsKeys as $edit) {
+			list($tableName, $field) = $edit;
+
+			$table = $schema->getTable($tableName);
+
+			$prim = $this->getPrimField($field);
+			$table->addColumn($prim, Type::STRING, ['notnull' => false, 'length' => 255]);
+			$table->setPrimaryKey([$prim]);
+		}
+
+		return $schema;
+	}
+
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 */
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
+
+		foreach (self::$setAsKeys as $edit) {
+			list($tableName, $field) = $edit;
+
+			$prim = $this->getPrimField($field);
+			$qb = $this->connection->getQueryBuilder();
+			$qb->update($tableName)
+			   ->set($prim, $qb->createFunction('SHA2(' . $field . ', 512)'))
+			   ->execute();
+		}
+	}
+
+
+	/**
+	 * @param string $field
+	 *
+	 * @return string
+	 */
+	private function getPrimField(string $field): string {
+		return $field . '_prim';
+	}
+}
+


### PR DESCRIPTION
Issue is that length of field to be set as primary are limited and _might_ be an issue on the fediverse. Solution from @blizzz  is to hash the string id to an hash, and stored the hash in the primary key.

It might slow done some requests, but we could also improve those request by using the generated primary key 'id_prim' instead of 'id'