### PR TITLE
force large field to 1000

### DIFF
--- a/lib/Migration/Version0002Date20190226000001.php
+++ b/lib/Migration/Version0002Date20190226000001.php
@@ -79,6 +79,9 @@ class Version0002Date20190226000001 extends SimpleMigrationStep {
 		[CoreRequestBuilder::TABLE_SERVER_FOLLOWS, 'object_id'],
 		[CoreRequestBuilder::TABLE_SERVER_FOLLOWS, 'follow_id'],
 
+		[CoreRequestBuilder::TABLE_SERVER_NOTES, 'to_array'],
+		[CoreRequestBuilder::TABLE_SERVER_NOTES, 'cc'],
+		[CoreRequestBuilder::TABLE_SERVER_NOTES, 'bcc'],
 		[CoreRequestBuilder::TABLE_SERVER_NOTES, 'id'],
 		[CoreRequestBuilder::TABLE_SERVER_NOTES, 'to'],
 		[CoreRequestBuilder::TABLE_SERVER_NOTES, 'attributed_to'],
@@ -137,11 +140,21 @@ class Version0002Date20190226000001 extends SimpleMigrationStep {
 	 * @param IOutput $output
 	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
 	 * @param array $options
+	 *
+	 * @throws SchemaException
 	 */
 	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
 
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
 		foreach (array_merge(self::$editToText, self::$editToChar1000) as $edit) {
 			list($tableName, $field) = $edit;
+
+			$table = $schema->getTable($tableName);
+			if (!$table->hasColumn($field)) {
+				continue;
+			}
 
 			$qb = $this->connection->getQueryBuilder();
 			$qb->update($tableName)


### PR DESCRIPTION
This would force some too large field to VARCHAR(1000) without loosing too many data.


Might need to run this SQL command first: `DELETE FROM oc_migrations WHERE app='social' AND version LIKE '0002Date2019022600000%';` if a migration have been run within the last few days from the master branch