### PR TITLE
Bugfix/boost

### DIFF
--- a/lib/Db/NotesRequest.php
+++ b/lib/Db/NotesRequest.php
@@ -155,7 +155,7 @@ class NotesRequest extends NotesRequestBuilder {
 
 		$qb = $this->getNotesSelectSql();
 		$this->limitToIdString($qb, $id);
-//		$this->limitToType($qb, Note::TYPE);
+		$this->leftJoinCacheActors($qb, 'attributed_to');
 
 		if ($asViewer) {
 			$this->limitToViewer($qb);

--- a/src/components/TimelineEntry.vue
+++ b/src/components/TimelineEntry.vue
@@ -98,6 +98,9 @@ export default {
 		},
 		formatedMessage() {
 			let message = this.item.content
+			if (typeof message === 'undefined') {
+				return ''
+			}
 			message = message.replace(/(?:\r\n|\r|\n)/g, '<br />')
 			message = message.linkify({
 				formatHref: {

--- a/src/store/timeline.js
+++ b/src/store/timeline.js
@@ -53,6 +53,12 @@ const mutations = {
 	},
 	setAccount(state, account) {
 		state.account = account
+	},
+	boostPost(state, post) {
+		Vue.set(state.timeline[post.id].action.values, 'boosted', true)
+	},
+	unboostPost(state, post) {
+		Vue.set(state.timeline[post.id].action.values, 'boosted', false)
 	}
 }
 const getters = {
@@ -100,7 +106,7 @@ const actions = {
 	postBoost(context, post) {
 		return new Promise((resolve, reject) => {
 			axios.post(OC.generateUrl(`apps/social/api/v1/post/boost?postId=${post.id}`)).then((response) => {
-				post.action.values.boosted = true
+				context.commit('boostPost', post)
 				// eslint-disable-next-line no-console
 				console.log('Post boosted with token ' + response.data.result.token)
 				resolve(response)
@@ -113,7 +119,7 @@ const actions = {
 	},
 	postUnBoost(context, post) {
 		return axios.delete(OC.generateUrl(`apps/social/api/v1/post/boost?postId=${post.id}`)).then((response) => {
-			post.action.values.boosted = false
+			context.commit('unboostPost', post)
 			// eslint-disable-next-line no-console
 			console.log('Boost deleted with token ' + response.data.result.token)
 		}).catch((error) => {


### PR DESCRIPTION
@daita This should fix the console errors

Note that https://github.com/nextcloud/social/commit/cc402ada48831e0ae4e4a24eabebcbf39ae7360b will make sure that timeline entries with an empty content attribute (boosts) are always shown, but they have no content.

![image](https://user-images.githubusercontent.com/3404133/57178309-6a46e600-6e6e-11e9-8be9-860a649797a4.png)

Should those be hidden by default or is it a bug that the content is missing?