### PR TITLE
🐛 FIX: line breaks not handled correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"nextcloud-auth": "0.0.3",
 		"tributejs": "^3.7.3",
 		"twemoji": "^12.0.1",
+		"he": "^1.2.0",
 		"uuid": "^3.3.3",
 		"v-tooltip": "^3.0.0-alpha.11",
 		"vue": "^2.6.10",

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -732,9 +732,11 @@ export default {
 				var em = document.createTextNode(emoji.getAttribute('alt'))
 				emoji.replaceWith(em)
 			})
+
 			let contentHtml = element.innerHTML
+
+			// Extract mentions from content and create an array ot of them
 			let to = []
-			let hashtags = []
 			const mentionRegex = /<span class="mention"[^>]+><a[^>]+><img[^>]+>@([\w-_.]+@[\w-.]+)/g
 			let match = null
 			do {
@@ -744,7 +746,9 @@ export default {
 				}
 			} while (match)
 
+			// Extract hashtags from content and create an array ot of them
 			const hashtagRegex = />#([^<]+)</g
+			let hashtags = []
 			match = null
 			do {
 				match = hashtagRegex.exec(contentHtml)
@@ -753,16 +757,21 @@ export default {
 				}
 			} while (match)
 
+			// Remove all html tags but <br>
+			let content = element.innerHTML.replace(/<(?!br\s*\/?)[^>]+>/gi, '').replace(/<br\s*\/?>/gi, '\n').trim()
+
 			let data = {
-				content: element.innerText.trim(),
+				content: content,
 				to: to,
 				hashtags: hashtags,
 				type: this.type,
 				attachments: this.postAttachments
 			}
+
 			if (this.replyTo) {
 				data.replyTo = this.replyTo.id
 			}
+
 			return data
 		},
 		keyup(event) {

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -392,6 +392,7 @@ import Avatar from 'nextcloud-vue/dist/Components/Avatar'
 import PopoverMenu from 'nextcloud-vue/dist/Components/PopoverMenu'
 import EmojiPicker from 'vue-emoji-picker'
 import VueTribute from 'vue-tribute'
+import he from 'he'
 import CurrentUserMixin from './../mixins/currentUserMixin'
 import FocusOnCreate from '../directives/focusOnCreate'
 import axios from 'nextcloud-axios'
@@ -757,8 +758,9 @@ export default {
 				}
 			} while (match)
 
-			// Remove all html tags but <br>
-			let content = element.innerHTML.replace(/<(?!br\s*\/?)[^>]+>/gi, '').replace(/<br\s*\/?>/gi, '\n').trim()
+			// Remove all html tags but </div> (wich we turn in newlines) and decode the remaining html entities 
+			let content = contentHtml.replace(/<(?!\/div)[^>]+>/gi, '').replace(/<\/div>/gi, '\n').trim()
+			content = he.decode(content)
 
 			let data = {
 				content: content,

--- a/src/components/TimelinePost.vue
+++ b/src/components/TimelinePost.vue
@@ -109,7 +109,6 @@ export default {
 			if (typeof message === 'undefined') {
 				return ''
 			}
-			message = message.replace(/(?:\r\n|\r|\n)/g, '<br />')
 			message = message.linkify({
 				formatHref: {
 					mention: function(href) {
@@ -120,6 +119,7 @@ export default {
 			if (this.item.hashtags !== undefined) {
 				message = this.mangleHashtags(message)
 			}
+			message = message.replace(/(?:\r\n|\r|\n)/g, '<br>')
 			message = this.$twemoji.parse(message)
 			return message
 		},


### PR DESCRIPTION
* Resolves: #560 
* Target version: master 

### Summary
this should remove all html attributes except line breaks, but replaces them with `\n` before sending it to the backend and it also properly makes `<br>`s out of `\n`s again when displaying a post
