### PR TITLE
Fixes the overlap of the tooltip and the popover menu in TimeLinePost

### DIFF
--- a/src/components/TimelinePost.vue
+++ b/src/components/TimelinePost.vue
@@ -29,7 +29,7 @@
 				<a v-if="item.actor_info.account !== cloudId" v-tooltip.bottom="t('social', 'Boost')"
 					:class="(isBoosted) ? 'icon-boosted' : 'icon-boost'"
 					@click.prevent="boost" />
-				<div v-if="popoverMenu.length > 0" v-tooltip.bottom="t('social', 'More actions')" class="post-actions-more">
+				<div v-if="popoverMenu.length > 0" v-tooltip.bottom="menuOpened ? '' : t('social', 'More actions')" class="post-actions-more">
 					<a class="icon-more" @click.prevent="togglePopoverMenu" />
 					<div :class="{open: menuOpened}" class="popovermenu menu-center">
 						<popover-menu :menu="popoverMenu" />


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/social/issues/434
* Target version: master 

### Summary

This is a simple fix to https://github.com/nextcloud/social/issues/434 by setting the tooltip's content to an empty string when the popover menu is opened.

### Tests done

Tested on FF/MacOS and FF/iOS.

This works good on FF/MacOS. But, tooltips don't work very well on FF/iOS (ie: one must click on the icon to see the tooltip and then click a second time to effectively perform the action).  Wrt this three-dot-menu, the behaviour is the following:

1. Click a first time on the icon => the tooltip "more actions" shows up
2. Click a second time on the icon => the popover menu shows up
3. Click a third time on the icon => A quite large empty tooltip shows up above the popover menu, hiding it.

That being said, I doubt using an action menu would improve this behaviour.



