### PR TITLE
Fixes a typo in LikeService's delete function

### DIFF
--- a/lib/Service/LikeService.php
+++ b/lib/Service/LikeService.php
@@ -198,7 +198,7 @@ class LikeService {
 		} catch (ItemNotFoundException $e) {
 		}
 
-		$this->streamActionService->setActionBool($actor->getId(), $postId, 'boosted', false);
+		$this->streamActionService->setActionBool($actor->getId(), $postId, 'liked', false);
 
 		return $undo;
 	}


### PR DESCRIPTION
* Resolves: #639 
* Target version: master 

### Summary

Fixes a typo in LikeService's delete function that prevents the unlike function from working properly
