### PR TITLE
Uses hashtag-regex to rewrite hashtag's href rather than linkifyjs.

### DIFF
--- a/lib/Model/ActivityPub/Object/Note.php
+++ b/lib/Model/ActivityPub/Object/Note.php
@@ -129,6 +129,7 @@ class Note extends Stream implements JsonSerializable {
 		parent::import($data);
 
 		$this->importAttachments($this->getArray('attachment', $data, []));
+		$this->fillHashtags();
 	}
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6800,6 +6800,11 @@
 				"minimalistic-assert": "^1.0.1"
 			}
 		},
+		"hashtag-regex": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/hashtag-regex/-/hashtag-regex-2.0.0.tgz",
+			"integrity": "sha512-6qWo1g10ggwyorTjMEswX/z8DkODD1XnfjBjndIAj7rnUOgVlwYQz4UPQU9yBz2jBGd3Im1D1wlzzI/o6Q1Ptw=="
+		},
 		"he": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 	},
 	"dependencies": {
 		"vue-masonry-css": "^1.0.3",
+		"hashtag-regex": "^2.0.0",
 		"linkifyjs": "^2.1.8",
 		"nextcloud-axios": "^0.2.0",
 		"nextcloud-vue": "^0.11.4",

--- a/src/components/TimelinePost.vue
+++ b/src/components/TimelinePost.vue
@@ -145,7 +145,7 @@ export default {
 				var a = '<a href="' + OC.generateUrl('/apps/social/timeline/tags/' + matched.substring(1)) + '">' + matched + '</a>'
 				return a
 			})
-			return msg;
+			return msg
 		},
 		userDisplayName(actorInfo) {
 			return actorInfo.name !== '' ? actorInfo.name : actorInfo.preferredUsername

--- a/src/components/TimelinePost.vue
+++ b/src/components/TimelinePost.vue
@@ -102,7 +102,7 @@ export default {
 			return Date.parse(this.item.published)
 		},
 		formatedMessage() {
-			let message = this.item.content
+			var message = this.item.content
 			if (typeof message === 'undefined') {
 				return ''
 			}
@@ -114,12 +114,7 @@ export default {
 					}
 				}
 			})
-			// Replace hashtag's href parameter with local ones
-			const regex = hashtagRegex()
-			message = message.replace(regex, function(matched) {
-				var a = '<a href="' + OC.generateUrl('/apps/social/timeline/tags/' + matched.substring(1)) + '">' + matched + '</a>'
-				return a
-			})
+			message = this.mangleHashtags(message)
 			message = this.$twemoji.parse(message)
 			return message
 		},
@@ -143,6 +138,15 @@ export default {
 		}
 	},
 	methods: {
+		mangleHashtags(msg) {
+			// Replace hashtag's href parameter with local ones
+			const regex = hashtagRegex()
+			msg = msg.replace(regex, function(matched) {
+				var a = '<a href="' + OC.generateUrl('/apps/social/timeline/tags/' + matched.substring(1)) + '">' + matched + '</a>'
+				return a
+			})
+			return msg;
+		},
 		userDisplayName(actorInfo) {
 			return actorInfo.name !== '' ? actorInfo.name : actorInfo.preferredUsername
 		},

--- a/src/components/TimelinePost.vue
+++ b/src/components/TimelinePost.vue
@@ -52,15 +52,15 @@
 <script>
 import Avatar from 'nextcloud-vue/dist/Components/Avatar'
 import * as linkify from 'linkifyjs'
-import pluginTag from 'linkifyjs/plugins/hashtag'
 import pluginMention from 'linkifyjs/plugins/mention'
 import 'linkifyjs/string'
 import popoverMenu from './../mixins/popoverMenu'
 import currentUser from './../mixins/currentUserMixin'
 import PostAttachment from './PostAttachment'
 
-pluginTag(linkify)
 pluginMention(linkify)
+
+const hashtagRegex = require('hashtag-regex')
 
 export default {
 	name: 'TimelinePost',
@@ -109,13 +109,16 @@ export default {
 			message = message.replace(/(?:\r\n|\r|\n)/g, '<br />')
 			message = message.linkify({
 				formatHref: {
-					hashtag: function(href) {
-						return OC.generateUrl('/apps/social/timeline/tags/' + href.substring(1))
-					},
 					mention: function(href) {
 						return OC.generateUrl('/apps/social/@' + href.substring(1))
 					}
 				}
+			})
+			// Replace hashtag's href parameter with local ones
+			const regex = hashtagRegex()
+			message = message.replace(regex, function(matched) {
+				var a = '<a href="' + OC.generateUrl('/apps/social/timeline/tags/' + matched.substring(1)) + '">' + matched + '</a>'
+				return a
 			})
 			message = this.$twemoji.parse(message)
 			return message

--- a/src/store/timeline.js
+++ b/src/store/timeline.js
@@ -144,10 +144,10 @@ const actions = {
 	postUnlike(context, { post, parentAnnounce }) {
 		return axios.delete(OC.generateUrl(`apps/social/api/v1/post/like?postId=${post.id}`)).then((response) => {
 			context.commit('unlikePost', { post, parentAnnounce })
-                        // Remove post from list if we are in the 'liked' timeline
-                       	if (state.type === 'liked') {
-                        	context.commit('removePost', post)
-                        }
+			// Remove post from list if we are in the 'liked' timeline
+			if (state.type === 'liked') {
+				context.commit('removePost', post)
+			}
 		}).catch((error) => {
 			OC.Notification.showTemporary('Failed to unlike post')
 			console.error('Failed to unlike post', error)


### PR DESCRIPTION
Reason: linkifyjs doesn't support non-latin characters. So "#Framasphère"
        is identified as "#Framasph" for example.

Signed-off-by: Cyrille Bollu <cyrpub@bollu.be>

* Resolves: #656 
* Target version: master 

### Summary

See #656
