### PR TITLE
Identify hashtags from what's found in a toot's DB entry

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -24,6 +24,7 @@
 	<author mail="jus@bitgrid.net">Julius Härtl</author>
 	<author mail="jonas@violoncello.ch" homepage="https://violoncello.ch">Jonas Sulzer</author>
 	<author mail="hey@jancborchardt.net" homepage="https://jancborchardt.net">Jan-Christoph Borchardt</author>
+	<author mail="cyrpub@bollu.be">Cyrille Bollu</author>
 	<namespace>Social</namespace>
 	<category>social</category>
 	<website>https://github.com/nextcloud/social</website>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -96,6 +96,7 @@ return [
 		['name' => 'Local#globalActorInfo', 'url' => '/api/v1/global/actor/info', 'verb' => 'GET'],
 		['name' => 'Local#globalActorAvatar', 'url' => '/api/v1/global/actor/avatar', 'verb' => 'GET'],
 		['name' => 'Local#globalAccountsSearch', 'url' => '/api/v1/global/accounts/search', 'verb' => 'GET'],
+		['name' => 'Local#globalTagsSearch', 'url' => '/api/v1/global/tags/search', 'verb' => 'GET'],
 
 //		['name' => 'Local#documentsCache', 'url' => '/api/v1/documents/cache', 'verb' => 'POST'],
 

--- a/lib/Controller/LocalController.php
+++ b/lib/Controller/LocalController.php
@@ -810,7 +810,7 @@ class LocalController extends Controller {
 		}
 
 		try {
-			$tags = $this->hashtagService->searchHashtags($search);
+			$tags = $this->hashtagService->searchHashtags($search, false);
 
 			return $this->success(['tags' => $tags, 'exact' => $match]);
 		} catch (Exception $e) {

--- a/lib/Controller/LocalController.php
+++ b/lib/Controller/LocalController.php
@@ -769,14 +769,15 @@ class LocalController extends Controller {
 		/* Look for an exactly matching account */
 		$match = null;
 		try {
-			$match = $this->hashtagService->getHashtag($search);
+			$match = $this->cacheActorService->getFromAccount($search, false);
+			$match->setCompleteDetails(true);
 		} catch (Exception $e) {
 		}
 
 		try {
-			$tags = $this->hashtagService->searchHashtags($search);
+			$accounts = $this->cacheActorService->searchCachedAccounts($search);
 
-			return $this->success(['tags' => $tags, 'exact' => $match]);
+			return $this->success(['accounts' => $accounts, 'exact' => $match]);
 		} catch (Exception $e) {
 			return $this->fail($e);
 		}
@@ -799,20 +800,19 @@ class LocalController extends Controller {
 		}
 
 		if ($search === '') {
-			return $this->success(['accounts' => [], 'exact' => []]);
+			return $this->success(['tags' => [], 'exact' => []]);
 		}
 
 		$match = null;
 		try {
-			$match = $this->cacheActorService->getFromAccount($search, false);
-			$match->setCompleteDetails(true);
+			$match = $this->hashtagService->getHashtag($search);
 		} catch (Exception $e) {
 		}
 
 		try {
-			$accounts = $this->cacheActorService->searchCachedAccounts($search);
+			$tags = $this->hashtagService->searchHashtags($search);
 
-			return $this->success(['accounts' => $accounts, 'exact' => $match]);
+			return $this->success(['tags' => $tags, 'exact' => $match]);
 		} catch (Exception $e) {
 			return $this->fail($e);
 		}

--- a/lib/Db/CoreRequestBuilder.php
+++ b/lib/Db/CoreRequestBuilder.php
@@ -37,7 +37,6 @@ use Doctrine\DBAL\Query\QueryBuilder;
 use Exception;
 use OC\DB\SchemaWrapper;
 use OCA\Social\AP;
-use OCA\Social\AppInfo\Application;
 use OCA\Social\Exceptions\DateTimeException;
 use OCA\Social\Exceptions\InvalidResourceException;
 use OCA\Social\Model\ActivityPub\Actor\Person;
@@ -307,10 +306,13 @@ class CoreRequestBuilder {
 	 *
 	 * @param IQueryBuilder $qb
 	 * @param string $hashtag
+	 * @param bool $all
 	 */
-	protected function searchInHashtag(IQueryBuilder &$qb, string $hashtag) {
+	protected function searchInHashtag(IQueryBuilder &$qb, string $hashtag, bool $all = false) {
 		$dbConn = $this->dbConnection;
-		$this->searchInDBField($qb, 'hashtag', '%' . $dbConn->escapeLikeParameter($hashtag) . '%');
+		$this->searchInDBField(
+			$qb, 'hashtag', (($all) ? '%' : '') . $dbConn->escapeLikeParameter($hashtag) . '%'
+		);
 	}
 
 

--- a/lib/Db/HashtagsRequest.php
+++ b/lib/Db/HashtagsRequest.php
@@ -118,12 +118,13 @@ class HashtagsRequest extends HashtagsRequestBuilder {
 
 	/**
 	 * @param string $hashtag
+	 * @param bool $all
 	 *
 	 * @return array
 	 */
-	public function searchHashtags(string $hashtag): array {
+	public function searchHashtags(string $hashtag, bool $all): array {
 		$qb = $this->getHashtagsSelectSql();
-		$this->searchInHashtag($qb, $hashtag);
+		$this->searchInHashtag($qb, $hashtag, $all);
 		$this->limitResults($qb, 25);
 
 		$hashtags = [];

--- a/lib/Db/StreamRequestBuilder.php
+++ b/lib/Db/StreamRequestBuilder.php
@@ -97,7 +97,7 @@ class StreamRequestBuilder extends CoreRequestBuilder {
 			   's.type', 's.to', 's.to_array', 's.cc', 's.bcc', 's.content',
 			   's.summary', 's.attachments', 's.published', 's.published_time', 's.cache',
 			   's.object_id', 's.attributed_to', 's.in_reply_to', 's.source', 's.local',
-			   's.instances', 's.creation', 's.hidden_on_timeline', 's.details'
+			   's.instances', 's.creation', 's.hidden_on_timeline', 's.details', 's.hashtags'
 		   )
 		   ->from(self::TABLE_STREAMS, 's');
 

--- a/lib/Service/HashtagService.php
+++ b/lib/Service/HashtagService.php
@@ -36,6 +36,8 @@ use OCA\Social\Db\HashtagsRequest;
 use OCA\Social\Db\StreamRequest;
 use OCA\Social\Exceptions\DateTimeException;
 use OCA\Social\Exceptions\HashtagDoesNotExistException;
+use OCA\Social\Exceptions\ItemUnknownException;
+use OCA\Social\Exceptions\SocialAppConfigException;
 use OCA\Social\Model\ActivityPub\Object\Note;
 use OCA\Social\Model\ActivityPub\Stream;
 
@@ -100,6 +102,8 @@ class HashtagService {
 	/**
 	 * @return int
 	 * @throws DateTimeException
+	 * @throws ItemUnknownException
+	 * @throws SocialAppConfigException
 	 */
 	public function manageHashtags(): int {
 		$current = $this->hashtagsRequest->getAll();
@@ -146,11 +150,12 @@ class HashtagService {
 
 	/**
 	 * @param string $hashtag
+	 * @param bool $all
 	 *
 	 * @return array
 	 */
-	public function searchHashtags(string $hashtag): array {
-		return $this->hashtagsRequest->searchHashtags($hashtag);
+	public function searchHashtags(string $hashtag, bool $all = false): array {
+		return $this->hashtagsRequest->searchHashtags($hashtag, $all);
 	}
 
 
@@ -159,6 +164,8 @@ class HashtagService {
 	 *
 	 * @return Stream[]
 	 * @throws DateTimeException
+	 * @throws ItemUnknownException
+	 * @throws SocialAppConfigException
 	 */
 	private function getTrendSince(int $timestamp): array {
 		$result = [];

--- a/lib/Service/SearchService.php
+++ b/lib/Service/SearchService.php
@@ -139,7 +139,7 @@ class SearchService {
 		}
 
 		try {
-			$hashtags = $this->hashtagService->searchHashtags($search);
+			$hashtags = $this->hashtagService->searchHashtags($search, true);
 			$result['result'] = $hashtags;
 		} catch (Exception $e) {
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "^7.0.0"
+				"@babel/highlight": "7.5.0"
 			}
 		},
 		"@babel/core": {
@@ -19,20 +19,20 @@
 			"integrity": "sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.5.5",
-				"@babel/generator": "^7.5.5",
-				"@babel/helpers": "^7.5.5",
-				"@babel/parser": "^7.5.5",
-				"@babel/template": "^7.4.4",
-				"@babel/traverse": "^7.5.5",
-				"@babel/types": "^7.5.5",
-				"convert-source-map": "^1.1.0",
-				"debug": "^4.1.0",
-				"json5": "^2.1.0",
-				"lodash": "^4.17.13",
-				"resolve": "^1.3.2",
-				"semver": "^5.4.1",
-				"source-map": "^0.5.0"
+				"@babel/code-frame": "7.5.5",
+				"@babel/generator": "7.5.5",
+				"@babel/helpers": "7.5.5",
+				"@babel/parser": "7.5.5",
+				"@babel/template": "7.4.4",
+				"@babel/traverse": "7.5.5",
+				"@babel/types": "7.5.5",
+				"convert-source-map": "1.6.0",
+				"debug": "4.1.1",
+				"json5": "2.1.0",
+				"lodash": "4.17.14",
+				"resolve": "1.11.1",
+				"semver": "5.7.0",
+				"source-map": "0.5.7"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
@@ -41,7 +41,7 @@
 					"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
 					"dev": true,
 					"requires": {
-						"@babel/highlight": "^7.0.0"
+						"@babel/highlight": "7.5.0"
 					}
 				},
 				"@babel/generator": {
@@ -50,11 +50,11 @@
 					"integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.5.5",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.17.13",
-						"source-map": "^0.5.0",
-						"trim-right": "^1.0.1"
+						"@babel/types": "7.5.5",
+						"jsesc": "2.5.2",
+						"lodash": "4.17.14",
+						"source-map": "0.5.7",
+						"trim-right": "1.0.1"
 					}
 				},
 				"@babel/parser": {
@@ -69,15 +69,15 @@
 					"integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "^7.5.5",
-						"@babel/generator": "^7.5.5",
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/helper-split-export-declaration": "^7.4.4",
-						"@babel/parser": "^7.5.5",
-						"@babel/types": "^7.5.5",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.13"
+						"@babel/code-frame": "7.5.5",
+						"@babel/generator": "7.5.5",
+						"@babel/helper-function-name": "7.1.0",
+						"@babel/helper-split-export-declaration": "7.4.4",
+						"@babel/parser": "7.5.5",
+						"@babel/types": "7.5.5",
+						"debug": "4.1.1",
+						"globals": "11.12.0",
+						"lodash": "4.17.14"
 					}
 				},
 				"@babel/types": {
@@ -86,9 +86,9 @@
 					"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
 					"dev": true,
 					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.13",
-						"to-fast-properties": "^2.0.0"
+						"esutils": "2.0.2",
+						"lodash": "4.17.14",
+						"to-fast-properties": "2.0.0"
 					}
 				},
 				"debug": {
@@ -97,7 +97,7 @@
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"ms": {
@@ -120,11 +120,11 @@
 			"integrity": "sha512-1TTVrt7J9rcG5PMjvO7VEG3FrEoEJNHxumRq66GemPmzboLWtIjjcJgk8rokuAS7IiRSpgVSu5Vb9lc99iJkOA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.5.0",
-				"jsesc": "^2.5.1",
-				"lodash": "^4.17.11",
-				"source-map": "^0.5.0",
-				"trim-right": "^1.0.1"
+				"@babel/types": "7.5.0",
+				"jsesc": "2.5.2",
+				"lodash": "4.17.14",
+				"source-map": "0.5.7",
+				"trim-right": "1.0.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -141,7 +141,7 @@
 			"integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.0.0"
+				"@babel/types": "7.5.0"
 			}
 		},
 		"@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -150,8 +150,8 @@
 			"integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-explode-assignable-expression": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/helper-explode-assignable-expression": "7.1.0",
+				"@babel/types": "7.5.0"
 			}
 		},
 		"@babel/helper-call-delegate": {
@@ -160,9 +160,9 @@
 			"integrity": "sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "^7.4.4",
-				"@babel/traverse": "^7.4.4",
-				"@babel/types": "^7.4.4"
+				"@babel/helper-hoist-variables": "7.4.4",
+				"@babel/traverse": "7.5.0",
+				"@babel/types": "7.5.0"
 			}
 		},
 		"@babel/helper-define-map": {
@@ -171,9 +171,9 @@
 			"integrity": "sha512-fTfxx7i0B5NJqvUOBBGREnrqbTxRh7zinBANpZXAVDlsZxYdclDp467G1sQ8VZYMnAURY3RpBUAgOYT9GfzHBg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/types": "^7.5.5",
-				"lodash": "^4.17.13"
+				"@babel/helper-function-name": "7.1.0",
+				"@babel/types": "7.5.5",
+				"lodash": "4.17.14"
 			},
 			"dependencies": {
 				"@babel/types": {
@@ -182,9 +182,9 @@
 					"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
 					"dev": true,
 					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.13",
-						"to-fast-properties": "^2.0.0"
+						"esutils": "2.0.2",
+						"lodash": "4.17.14",
+						"to-fast-properties": "2.0.0"
 					}
 				}
 			}
@@ -195,8 +195,8 @@
 			"integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
 			"dev": true,
 			"requires": {
-				"@babel/traverse": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/traverse": "7.5.0",
+				"@babel/types": "7.5.0"
 			}
 		},
 		"@babel/helper-function-name": {
@@ -205,9 +205,9 @@
 			"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.0.0",
-				"@babel/template": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/helper-get-function-arity": "7.0.0",
+				"@babel/template": "7.4.4",
+				"@babel/types": "7.5.0"
 			}
 		},
 		"@babel/helper-get-function-arity": {
@@ -216,7 +216,7 @@
 			"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.0.0"
+				"@babel/types": "7.5.0"
 			}
 		},
 		"@babel/helper-hoist-variables": {
@@ -225,7 +225,7 @@
 			"integrity": "sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.4.4"
+				"@babel/types": "7.5.0"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
@@ -234,7 +234,7 @@
 			"integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.5.5"
+				"@babel/types": "7.5.5"
 			},
 			"dependencies": {
 				"@babel/types": {
@@ -243,9 +243,9 @@
 					"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
 					"dev": true,
 					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.13",
-						"to-fast-properties": "^2.0.0"
+						"esutils": "2.0.2",
+						"lodash": "4.17.14",
+						"to-fast-properties": "2.0.0"
 					}
 				}
 			}
@@ -256,7 +256,7 @@
 			"integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.0.0"
+				"@babel/types": "7.5.0"
 			}
 		},
 		"@babel/helper-module-transforms": {
@@ -265,12 +265,12 @@
 			"integrity": "sha512-jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.0.0",
-				"@babel/helper-simple-access": "^7.1.0",
-				"@babel/helper-split-export-declaration": "^7.4.4",
-				"@babel/template": "^7.4.4",
-				"@babel/types": "^7.5.5",
-				"lodash": "^4.17.13"
+				"@babel/helper-module-imports": "7.0.0",
+				"@babel/helper-simple-access": "7.1.0",
+				"@babel/helper-split-export-declaration": "7.4.4",
+				"@babel/template": "7.4.4",
+				"@babel/types": "7.5.5",
+				"lodash": "4.17.14"
 			},
 			"dependencies": {
 				"@babel/types": {
@@ -279,9 +279,9 @@
 					"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
 					"dev": true,
 					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.13",
-						"to-fast-properties": "^2.0.0"
+						"esutils": "2.0.2",
+						"lodash": "4.17.14",
+						"to-fast-properties": "2.0.0"
 					}
 				}
 			}
@@ -292,7 +292,7 @@
 			"integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.0.0"
+				"@babel/types": "7.5.0"
 			}
 		},
 		"@babel/helper-plugin-utils": {
@@ -307,7 +307,7 @@
 			"integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.13"
+				"lodash": "4.17.14"
 			}
 		},
 		"@babel/helper-remap-async-to-generator": {
@@ -316,11 +316,11 @@
 			"integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.0.0",
-				"@babel/helper-wrap-function": "^7.1.0",
-				"@babel/template": "^7.1.0",
-				"@babel/traverse": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/helper-annotate-as-pure": "7.0.0",
+				"@babel/helper-wrap-function": "7.2.0",
+				"@babel/template": "7.4.4",
+				"@babel/traverse": "7.5.0",
+				"@babel/types": "7.5.0"
 			}
 		},
 		"@babel/helper-replace-supers": {
@@ -329,10 +329,10 @@
 			"integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.5.5",
-				"@babel/helper-optimise-call-expression": "^7.0.0",
-				"@babel/traverse": "^7.5.5",
-				"@babel/types": "^7.5.5"
+				"@babel/helper-member-expression-to-functions": "7.5.5",
+				"@babel/helper-optimise-call-expression": "7.0.0",
+				"@babel/traverse": "7.5.5",
+				"@babel/types": "7.5.5"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
@@ -341,7 +341,7 @@
 					"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
 					"dev": true,
 					"requires": {
-						"@babel/highlight": "^7.0.0"
+						"@babel/highlight": "7.5.0"
 					}
 				},
 				"@babel/generator": {
@@ -350,11 +350,11 @@
 					"integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.5.5",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.17.13",
-						"source-map": "^0.5.0",
-						"trim-right": "^1.0.1"
+						"@babel/types": "7.5.5",
+						"jsesc": "2.5.2",
+						"lodash": "4.17.14",
+						"source-map": "0.5.7",
+						"trim-right": "1.0.1"
 					}
 				},
 				"@babel/parser": {
@@ -369,15 +369,15 @@
 					"integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "^7.5.5",
-						"@babel/generator": "^7.5.5",
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/helper-split-export-declaration": "^7.4.4",
-						"@babel/parser": "^7.5.5",
-						"@babel/types": "^7.5.5",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.13"
+						"@babel/code-frame": "7.5.5",
+						"@babel/generator": "7.5.5",
+						"@babel/helper-function-name": "7.1.0",
+						"@babel/helper-split-export-declaration": "7.4.4",
+						"@babel/parser": "7.5.5",
+						"@babel/types": "7.5.5",
+						"debug": "4.1.1",
+						"globals": "11.12.0",
+						"lodash": "4.17.14"
 					}
 				},
 				"@babel/types": {
@@ -386,9 +386,9 @@
 					"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
 					"dev": true,
 					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.13",
-						"to-fast-properties": "^2.0.0"
+						"esutils": "2.0.2",
+						"lodash": "4.17.14",
+						"to-fast-properties": "2.0.0"
 					}
 				},
 				"debug": {
@@ -397,7 +397,7 @@
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"ms": {
@@ -420,8 +420,8 @@
 			"integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/template": "7.4.4",
+				"@babel/types": "7.5.0"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
@@ -430,7 +430,7 @@
 			"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.4.4"
+				"@babel/types": "7.5.0"
 			}
 		},
 		"@babel/helper-wrap-function": {
@@ -439,10 +439,10 @@
 			"integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/template": "^7.1.0",
-				"@babel/traverse": "^7.1.0",
-				"@babel/types": "^7.2.0"
+				"@babel/helper-function-name": "7.1.0",
+				"@babel/template": "7.4.4",
+				"@babel/traverse": "7.5.0",
+				"@babel/types": "7.5.0"
 			}
 		},
 		"@babel/helpers": {
@@ -451,9 +451,9 @@
 			"integrity": "sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.4.4",
-				"@babel/traverse": "^7.5.5",
-				"@babel/types": "^7.5.5"
+				"@babel/template": "7.4.4",
+				"@babel/traverse": "7.5.5",
+				"@babel/types": "7.5.5"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
@@ -462,7 +462,7 @@
 					"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
 					"dev": true,
 					"requires": {
-						"@babel/highlight": "^7.0.0"
+						"@babel/highlight": "7.5.0"
 					}
 				},
 				"@babel/generator": {
@@ -471,11 +471,11 @@
 					"integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.5.5",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.17.13",
-						"source-map": "^0.5.0",
-						"trim-right": "^1.0.1"
+						"@babel/types": "7.5.5",
+						"jsesc": "2.5.2",
+						"lodash": "4.17.14",
+						"source-map": "0.5.7",
+						"trim-right": "1.0.1"
 					}
 				},
 				"@babel/parser": {
@@ -490,15 +490,15 @@
 					"integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "^7.5.5",
-						"@babel/generator": "^7.5.5",
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/helper-split-export-declaration": "^7.4.4",
-						"@babel/parser": "^7.5.5",
-						"@babel/types": "^7.5.5",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.13"
+						"@babel/code-frame": "7.5.5",
+						"@babel/generator": "7.5.5",
+						"@babel/helper-function-name": "7.1.0",
+						"@babel/helper-split-export-declaration": "7.4.4",
+						"@babel/parser": "7.5.5",
+						"@babel/types": "7.5.5",
+						"debug": "4.1.1",
+						"globals": "11.12.0",
+						"lodash": "4.17.14"
 					}
 				},
 				"@babel/types": {
@@ -507,9 +507,9 @@
 					"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
 					"dev": true,
 					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.13",
-						"to-fast-properties": "^2.0.0"
+						"esutils": "2.0.2",
+						"lodash": "4.17.14",
+						"to-fast-properties": "2.0.0"
 					}
 				},
 				"debug": {
@@ -518,7 +518,7 @@
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"ms": {
@@ -541,9 +541,9 @@
 			"integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.0",
-				"esutils": "^2.0.2",
-				"js-tokens": "^4.0.0"
+				"chalk": "2.4.2",
+				"esutils": "2.0.2",
+				"js-tokens": "4.0.0"
 			}
 		},
 		"@babel/parser": {
@@ -557,9 +557,9 @@
 			"integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-remap-async-to-generator": "^7.1.0",
-				"@babel/plugin-syntax-async-generators": "^7.2.0"
+				"@babel/helper-plugin-utils": "7.0.0",
+				"@babel/helper-remap-async-to-generator": "7.1.0",
+				"@babel/plugin-syntax-async-generators": "7.2.0"
 			}
 		},
 		"@babel/plugin-proposal-dynamic-import": {
@@ -568,8 +568,8 @@
 			"integrity": "sha512-x/iMjggsKTFHYC6g11PL7Qy58IK8H5zqfm9e6hu4z1iH2IRyAp9u9dL80zA6R76yFovETFLKz2VJIC2iIPBuFw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-dynamic-import": "^7.2.0"
+				"@babel/helper-plugin-utils": "7.0.0",
+				"@babel/plugin-syntax-dynamic-import": "7.2.0"
 			}
 		},
 		"@babel/plugin-proposal-json-strings": {
@@ -578,8 +578,8 @@
 			"integrity": "sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-json-strings": "^7.2.0"
+				"@babel/helper-plugin-utils": "7.0.0",
+				"@babel/plugin-syntax-json-strings": "7.2.0"
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
@@ -588,8 +588,8 @@
 			"integrity": "sha512-F2DxJJSQ7f64FyTVl5cw/9MWn6naXGdk3Q3UhDbFEEHv+EilCPoeRD3Zh/Utx1CJz4uyKlQ4uH+bJPbEhMV7Zw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+				"@babel/helper-plugin-utils": "7.0.0",
+				"@babel/plugin-syntax-object-rest-spread": "7.2.0"
 			}
 		},
 		"@babel/plugin-proposal-optional-catch-binding": {
@@ -598,8 +598,8 @@
 			"integrity": "sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
+				"@babel/helper-plugin-utils": "7.0.0",
+				"@babel/plugin-syntax-optional-catch-binding": "7.2.0"
 			}
 		},
 		"@babel/plugin-proposal-unicode-property-regex": {
@@ -608,9 +608,9 @@
 			"integrity": "sha512-j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.4.4",
-				"regexpu-core": "^4.5.4"
+				"@babel/helper-plugin-utils": "7.0.0",
+				"@babel/helper-regex": "7.5.5",
+				"regexpu-core": "4.5.4"
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
@@ -619,7 +619,7 @@
 			"integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-dynamic-import": {
@@ -628,7 +628,7 @@
 			"integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-json-strings": {
@@ -637,7 +637,7 @@
 			"integrity": "sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-object-rest-spread": {
@@ -646,7 +646,7 @@
 			"integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-optional-catch-binding": {
@@ -655,7 +655,7 @@
 			"integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "7.0.0"
 			}
 		},
 		"@babel/plugin-transform-arrow-functions": {
@@ -664,7 +664,7 @@
 			"integrity": "sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "7.0.0"
 			}
 		},
 		"@babel/plugin-transform-async-to-generator": {
@@ -673,9 +673,9 @@
 			"integrity": "sha512-mqvkzwIGkq0bEF1zLRRiTdjfomZJDV33AH3oQzHVGkI2VzEmXLpKKOBvEVaFZBJdN0XTyH38s9j/Kiqr68dggg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.0.0",
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-remap-async-to-generator": "^7.1.0"
+				"@babel/helper-module-imports": "7.0.0",
+				"@babel/helper-plugin-utils": "7.0.0",
+				"@babel/helper-remap-async-to-generator": "7.1.0"
 			}
 		},
 		"@babel/plugin-transform-block-scoped-functions": {
@@ -684,7 +684,7 @@
 			"integrity": "sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "7.0.0"
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
@@ -693,8 +693,8 @@
 			"integrity": "sha512-82A3CLRRdYubkG85lKwhZB0WZoHxLGsJdux/cOVaJCJpvYFl1LVzAIFyRsa7CvXqW8rBM4Zf3Bfn8PHt5DP0Sg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"lodash": "^4.17.13"
+				"@babel/helper-plugin-utils": "7.0.0",
+				"lodash": "4.17.14"
 			}
 		},
 		"@babel/plugin-transform-classes": {
@@ -703,14 +703,14 @@
 			"integrity": "sha512-U2htCNK/6e9K7jGyJ++1p5XRU+LJjrwtoiVn9SzRlDT2KubcZ11OOwy3s24TjHxPgxNwonCYP7U2K51uVYCMDg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.0.0",
-				"@babel/helper-define-map": "^7.5.5",
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/helper-optimise-call-expression": "^7.0.0",
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.5.5",
-				"@babel/helper-split-export-declaration": "^7.4.4",
-				"globals": "^11.1.0"
+				"@babel/helper-annotate-as-pure": "7.0.0",
+				"@babel/helper-define-map": "7.5.5",
+				"@babel/helper-function-name": "7.1.0",
+				"@babel/helper-optimise-call-expression": "7.0.0",
+				"@babel/helper-plugin-utils": "7.0.0",
+				"@babel/helper-replace-supers": "7.5.5",
+				"@babel/helper-split-export-declaration": "7.4.4",
+				"globals": "11.12.0"
 			}
 		},
 		"@babel/plugin-transform-computed-properties": {
@@ -719,7 +719,7 @@
 			"integrity": "sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "7.0.0"
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
@@ -728,7 +728,7 @@
 			"integrity": "sha512-YbYgbd3TryYYLGyC7ZR+Tq8H/+bCmwoaxHfJHupom5ECstzbRLTch6gOQbhEY9Z4hiCNHEURgq06ykFv9JZ/QQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "7.0.0"
 			}
 		},
 		"@babel/plugin-transform-dotall-regex": {
@@ -737,9 +737,9 @@
 			"integrity": "sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.4.4",
-				"regexpu-core": "^4.5.4"
+				"@babel/helper-plugin-utils": "7.0.0",
+				"@babel/helper-regex": "7.5.5",
+				"regexpu-core": "4.5.4"
 			}
 		},
 		"@babel/plugin-transform-duplicate-keys": {
@@ -748,7 +748,7 @@
 			"integrity": "sha512-igcziksHizyQPlX9gfSjHkE2wmoCH3evvD2qR5w29/Dk0SMKE/eOI7f1HhBdNhR/zxJDqrgpoDTq5YSLH/XMsQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "7.0.0"
 			}
 		},
 		"@babel/plugin-transform-exponentiation-operator": {
@@ -757,8 +757,8 @@
 			"integrity": "sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-builder-binary-assignment-operator-visitor": "7.1.0",
+				"@babel/helper-plugin-utils": "7.0.0"
 			}
 		},
 		"@babel/plugin-transform-for-of": {
@@ -767,7 +767,7 @@
 			"integrity": "sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "7.0.0"
 			}
 		},
 		"@babel/plugin-transform-function-name": {
@@ -776,8 +776,8 @@
 			"integrity": "sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-function-name": "7.1.0",
+				"@babel/helper-plugin-utils": "7.0.0"
 			}
 		},
 		"@babel/plugin-transform-literals": {
@@ -786,7 +786,7 @@
 			"integrity": "sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "7.0.0"
 			}
 		},
 		"@babel/plugin-transform-member-expression-literals": {
@@ -795,7 +795,7 @@
 			"integrity": "sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "7.0.0"
 			}
 		},
 		"@babel/plugin-transform-modules-amd": {
@@ -804,9 +804,9 @@
 			"integrity": "sha512-n20UsQMKnWrltocZZm24cRURxQnWIvsABPJlw/fvoy9c6AgHZzoelAIzajDHAQrDpuKFFPPcFGd7ChsYuIUMpg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.1.0",
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"babel-plugin-dynamic-import-node": "^2.3.0"
+				"@babel/helper-module-transforms": "7.5.5",
+				"@babel/helper-plugin-utils": "7.0.0",
+				"babel-plugin-dynamic-import-node": "2.3.0"
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
@@ -815,10 +815,10 @@
 			"integrity": "sha512-xmHq0B+ytyrWJvQTc5OWAC4ii6Dhr0s22STOoydokG51JjWhyYo5mRPXoi+ZmtHQhZZwuXNN+GG5jy5UZZJxIQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.4.4",
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-simple-access": "^7.1.0",
-				"babel-plugin-dynamic-import-node": "^2.3.0"
+				"@babel/helper-module-transforms": "7.5.5",
+				"@babel/helper-plugin-utils": "7.0.0",
+				"@babel/helper-simple-access": "7.1.0",
+				"babel-plugin-dynamic-import-node": "2.3.0"
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
@@ -827,9 +827,9 @@
 			"integrity": "sha512-Q2m56tyoQWmuNGxEtUyeEkm6qJYFqs4c+XyXH5RAuYxObRNz9Zgj/1g2GMnjYp2EUyEy7YTrxliGCXzecl/vJg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-hoist-variables": "^7.4.4",
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"babel-plugin-dynamic-import-node": "^2.3.0"
+				"@babel/helper-hoist-variables": "7.4.4",
+				"@babel/helper-plugin-utils": "7.0.0",
+				"babel-plugin-dynamic-import-node": "2.3.0"
 			}
 		},
 		"@babel/plugin-transform-modules-umd": {
@@ -838,8 +838,8 @@
 			"integrity": "sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.1.0",
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-module-transforms": "7.5.5",
+				"@babel/helper-plugin-utils": "7.0.0"
 			}
 		},
 		"@babel/plugin-transform-named-capturing-groups-regex": {
@@ -848,7 +848,7 @@
 			"integrity": "sha512-z7+2IsWafTBbjNsOxU/Iv5CvTJlr5w4+HGu1HovKYTtgJ362f7kBcQglkfmlspKKZ3bgrbSGvLfNx++ZJgCWsg==",
 			"dev": true,
 			"requires": {
-				"regexp-tree": "^0.1.6"
+				"regexp-tree": "0.1.11"
 			}
 		},
 		"@babel/plugin-transform-new-target": {
@@ -857,7 +857,7 @@
 			"integrity": "sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "7.0.0"
 			}
 		},
 		"@babel/plugin-transform-object-super": {
@@ -866,8 +866,8 @@
 			"integrity": "sha512-un1zJQAhSosGFBduPgN/YFNvWVpRuHKU7IHBglLoLZsGmruJPOo6pbInneflUdmq7YvSVqhpPs5zdBvLnteltQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.5.5"
+				"@babel/helper-plugin-utils": "7.0.0",
+				"@babel/helper-replace-supers": "7.5.5"
 			}
 		},
 		"@babel/plugin-transform-parameters": {
@@ -876,9 +876,9 @@
 			"integrity": "sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-call-delegate": "^7.4.4",
-				"@babel/helper-get-function-arity": "^7.0.0",
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-call-delegate": "7.4.4",
+				"@babel/helper-get-function-arity": "7.0.0",
+				"@babel/helper-plugin-utils": "7.0.0"
 			}
 		},
 		"@babel/plugin-transform-property-literals": {
@@ -887,7 +887,7 @@
 			"integrity": "sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "7.0.0"
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
@@ -896,7 +896,7 @@
 			"integrity": "sha512-gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==",
 			"dev": true,
 			"requires": {
-				"regenerator-transform": "^0.14.0"
+				"regenerator-transform": "0.14.1"
 			}
 		},
 		"@babel/plugin-transform-reserved-words": {
@@ -905,7 +905,7 @@
 			"integrity": "sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "7.0.0"
 			}
 		},
 		"@babel/plugin-transform-shorthand-properties": {
@@ -914,7 +914,7 @@
 			"integrity": "sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "7.0.0"
 			}
 		},
 		"@babel/plugin-transform-spread": {
@@ -923,7 +923,7 @@
 			"integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "7.0.0"
 			}
 		},
 		"@babel/plugin-transform-sticky-regex": {
@@ -932,8 +932,8 @@
 			"integrity": "sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.0.0"
+				"@babel/helper-plugin-utils": "7.0.0",
+				"@babel/helper-regex": "7.5.5"
 			}
 		},
 		"@babel/plugin-transform-template-literals": {
@@ -942,8 +942,8 @@
 			"integrity": "sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.0.0",
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-annotate-as-pure": "7.0.0",
+				"@babel/helper-plugin-utils": "7.0.0"
 			}
 		},
 		"@babel/plugin-transform-typeof-symbol": {
@@ -952,7 +952,7 @@
 			"integrity": "sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "7.0.0"
 			}
 		},
 		"@babel/plugin-transform-unicode-regex": {
@@ -961,9 +961,9 @@
 			"integrity": "sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.4.4",
-				"regexpu-core": "^4.5.4"
+				"@babel/helper-plugin-utils": "7.0.0",
+				"@babel/helper-regex": "7.5.5",
+				"regexpu-core": "4.5.4"
 			}
 		},
 		"@babel/polyfill": {
@@ -971,8 +971,8 @@
 			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz",
 			"integrity": "sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==",
 			"requires": {
-				"core-js": "^2.6.5",
-				"regenerator-runtime": "^0.13.2"
+				"core-js": "2.6.9",
+				"regenerator-runtime": "0.13.2"
 			}
 		},
 		"@babel/preset-env": {
@@ -981,56 +981,56 @@
 			"integrity": "sha512-GMZQka/+INwsMz1A5UEql8tG015h5j/qjptpKY2gJ7giy8ohzU710YciJB5rcKsWGWHiW3RUnHib0E5/m3Tp3A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.0.0",
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
-				"@babel/plugin-proposal-dynamic-import": "^7.5.0",
-				"@babel/plugin-proposal-json-strings": "^7.2.0",
-				"@babel/plugin-proposal-object-rest-spread": "^7.5.5",
-				"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-				"@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
-				"@babel/plugin-syntax-async-generators": "^7.2.0",
-				"@babel/plugin-syntax-dynamic-import": "^7.2.0",
-				"@babel/plugin-syntax-json-strings": "^7.2.0",
-				"@babel/plugin-syntax-object-rest-spread": "^7.2.0",
-				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
-				"@babel/plugin-transform-arrow-functions": "^7.2.0",
-				"@babel/plugin-transform-async-to-generator": "^7.5.0",
-				"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-				"@babel/plugin-transform-block-scoping": "^7.5.5",
-				"@babel/plugin-transform-classes": "^7.5.5",
-				"@babel/plugin-transform-computed-properties": "^7.2.0",
-				"@babel/plugin-transform-destructuring": "^7.5.0",
-				"@babel/plugin-transform-dotall-regex": "^7.4.4",
-				"@babel/plugin-transform-duplicate-keys": "^7.5.0",
-				"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
-				"@babel/plugin-transform-for-of": "^7.4.4",
-				"@babel/plugin-transform-function-name": "^7.4.4",
-				"@babel/plugin-transform-literals": "^7.2.0",
-				"@babel/plugin-transform-member-expression-literals": "^7.2.0",
-				"@babel/plugin-transform-modules-amd": "^7.5.0",
-				"@babel/plugin-transform-modules-commonjs": "^7.5.0",
-				"@babel/plugin-transform-modules-systemjs": "^7.5.0",
-				"@babel/plugin-transform-modules-umd": "^7.2.0",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.4.5",
-				"@babel/plugin-transform-new-target": "^7.4.4",
-				"@babel/plugin-transform-object-super": "^7.5.5",
-				"@babel/plugin-transform-parameters": "^7.4.4",
-				"@babel/plugin-transform-property-literals": "^7.2.0",
-				"@babel/plugin-transform-regenerator": "^7.4.5",
-				"@babel/plugin-transform-reserved-words": "^7.2.0",
-				"@babel/plugin-transform-shorthand-properties": "^7.2.0",
-				"@babel/plugin-transform-spread": "^7.2.0",
-				"@babel/plugin-transform-sticky-regex": "^7.2.0",
-				"@babel/plugin-transform-template-literals": "^7.4.4",
-				"@babel/plugin-transform-typeof-symbol": "^7.2.0",
-				"@babel/plugin-transform-unicode-regex": "^7.4.4",
-				"@babel/types": "^7.5.5",
-				"browserslist": "^4.6.0",
-				"core-js-compat": "^3.1.1",
-				"invariant": "^2.2.2",
-				"js-levenshtein": "^1.1.3",
-				"semver": "^5.5.0"
+				"@babel/helper-module-imports": "7.0.0",
+				"@babel/helper-plugin-utils": "7.0.0",
+				"@babel/plugin-proposal-async-generator-functions": "7.2.0",
+				"@babel/plugin-proposal-dynamic-import": "7.5.0",
+				"@babel/plugin-proposal-json-strings": "7.2.0",
+				"@babel/plugin-proposal-object-rest-spread": "7.5.5",
+				"@babel/plugin-proposal-optional-catch-binding": "7.2.0",
+				"@babel/plugin-proposal-unicode-property-regex": "7.4.4",
+				"@babel/plugin-syntax-async-generators": "7.2.0",
+				"@babel/plugin-syntax-dynamic-import": "7.2.0",
+				"@babel/plugin-syntax-json-strings": "7.2.0",
+				"@babel/plugin-syntax-object-rest-spread": "7.2.0",
+				"@babel/plugin-syntax-optional-catch-binding": "7.2.0",
+				"@babel/plugin-transform-arrow-functions": "7.2.0",
+				"@babel/plugin-transform-async-to-generator": "7.5.0",
+				"@babel/plugin-transform-block-scoped-functions": "7.2.0",
+				"@babel/plugin-transform-block-scoping": "7.5.5",
+				"@babel/plugin-transform-classes": "7.5.5",
+				"@babel/plugin-transform-computed-properties": "7.2.0",
+				"@babel/plugin-transform-destructuring": "7.5.0",
+				"@babel/plugin-transform-dotall-regex": "7.4.4",
+				"@babel/plugin-transform-duplicate-keys": "7.5.0",
+				"@babel/plugin-transform-exponentiation-operator": "7.2.0",
+				"@babel/plugin-transform-for-of": "7.4.4",
+				"@babel/plugin-transform-function-name": "7.4.4",
+				"@babel/plugin-transform-literals": "7.2.0",
+				"@babel/plugin-transform-member-expression-literals": "7.2.0",
+				"@babel/plugin-transform-modules-amd": "7.5.0",
+				"@babel/plugin-transform-modules-commonjs": "7.5.0",
+				"@babel/plugin-transform-modules-systemjs": "7.5.0",
+				"@babel/plugin-transform-modules-umd": "7.2.0",
+				"@babel/plugin-transform-named-capturing-groups-regex": "7.4.5",
+				"@babel/plugin-transform-new-target": "7.4.4",
+				"@babel/plugin-transform-object-super": "7.5.5",
+				"@babel/plugin-transform-parameters": "7.4.4",
+				"@babel/plugin-transform-property-literals": "7.2.0",
+				"@babel/plugin-transform-regenerator": "7.4.5",
+				"@babel/plugin-transform-reserved-words": "7.2.0",
+				"@babel/plugin-transform-shorthand-properties": "7.2.0",
+				"@babel/plugin-transform-spread": "7.2.2",
+				"@babel/plugin-transform-sticky-regex": "7.2.0",
+				"@babel/plugin-transform-template-literals": "7.4.4",
+				"@babel/plugin-transform-typeof-symbol": "7.2.0",
+				"@babel/plugin-transform-unicode-regex": "7.4.4",
+				"@babel/types": "7.5.5",
+				"browserslist": "4.6.6",
+				"core-js-compat": "3.1.4",
+				"invariant": "2.2.4",
+				"js-levenshtein": "1.1.6",
+				"semver": "5.7.0"
 			},
 			"dependencies": {
 				"@babel/types": {
@@ -1039,9 +1039,9 @@
 					"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
 					"dev": true,
 					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.13",
-						"to-fast-properties": "^2.0.0"
+						"esutils": "2.0.2",
+						"lodash": "4.17.14",
+						"to-fast-properties": "2.0.0"
 					}
 				}
 			}
@@ -1052,9 +1052,9 @@
 			"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.4.4",
-				"@babel/types": "^7.4.4"
+				"@babel/code-frame": "7.0.0",
+				"@babel/parser": "7.5.0",
+				"@babel/types": "7.5.0"
 			}
 		},
 		"@babel/traverse": {
@@ -1063,15 +1063,15 @@
 			"integrity": "sha512-SnA9aLbyOCcnnbQEGwdfBggnc142h/rbqqsXcaATj2hZcegCl903pUD/lfpsNBlBSuWow/YDfRyJuWi2EPR5cg==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"@babel/generator": "^7.5.0",
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/helper-split-export-declaration": "^7.4.4",
-				"@babel/parser": "^7.5.0",
-				"@babel/types": "^7.5.0",
-				"debug": "^4.1.0",
-				"globals": "^11.1.0",
-				"lodash": "^4.17.11"
+				"@babel/code-frame": "7.0.0",
+				"@babel/generator": "7.5.0",
+				"@babel/helper-function-name": "7.1.0",
+				"@babel/helper-split-export-declaration": "7.4.4",
+				"@babel/parser": "7.5.0",
+				"@babel/types": "7.5.0",
+				"debug": "4.1.1",
+				"globals": "11.12.0",
+				"lodash": "4.17.14"
 			},
 			"dependencies": {
 				"debug": {
@@ -1080,7 +1080,7 @@
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"ms": {
@@ -1097,9 +1097,9 @@
 			"integrity": "sha512-UFpDVqRABKsW01bvw7/wSUe56uy6RXM5+VJibVVAybDGxEW25jdwiFJEf7ASvSaC7sN7rbE/l3cLp2izav+CtQ==",
 			"dev": true,
 			"requires": {
-				"esutils": "^2.0.2",
-				"lodash": "^4.17.11",
-				"to-fast-properties": "^2.0.0"
+				"esutils": "2.0.2",
+				"lodash": "4.17.14",
+				"to-fast-properties": "2.0.0"
 			}
 		},
 		"@cnakazawa/watch": {
@@ -1108,8 +1108,8 @@
 			"integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
 			"dev": true,
 			"requires": {
-				"exec-sh": "^0.3.2",
-				"minimist": "^1.2.0"
+				"exec-sh": "0.3.2",
+				"minimist": "1.2.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -1126,9 +1126,9 @@
 			"integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
 			"dev": true,
 			"requires": {
-				"@jest/source-map": "^24.3.0",
-				"chalk": "^2.0.1",
-				"slash": "^2.0.0"
+				"@jest/source-map": "24.3.0",
+				"chalk": "2.4.2",
+				"slash": "2.0.0"
 			}
 		},
 		"@jest/core": {
@@ -1137,33 +1137,33 @@
 			"integrity": "sha512-R9rhAJwCBQzaRnrRgAdVfnglUuATXdwTRsYqs6NMdVcAl5euG8LtWDe+fVkN27YfKVBW61IojVsXKaOmSnqd/A==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^24.7.1",
-				"@jest/reporters": "^24.8.0",
-				"@jest/test-result": "^24.8.0",
-				"@jest/transform": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"ansi-escapes": "^3.0.0",
-				"chalk": "^2.0.1",
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.1.15",
-				"jest-changed-files": "^24.8.0",
-				"jest-config": "^24.8.0",
-				"jest-haste-map": "^24.8.0",
-				"jest-message-util": "^24.8.0",
-				"jest-regex-util": "^24.3.0",
-				"jest-resolve-dependencies": "^24.8.0",
-				"jest-runner": "^24.8.0",
-				"jest-runtime": "^24.8.0",
-				"jest-snapshot": "^24.8.0",
-				"jest-util": "^24.8.0",
-				"jest-validate": "^24.8.0",
-				"jest-watcher": "^24.8.0",
-				"micromatch": "^3.1.10",
-				"p-each-series": "^1.0.0",
-				"pirates": "^4.0.1",
-				"realpath-native": "^1.1.0",
-				"rimraf": "^2.5.4",
-				"strip-ansi": "^5.0.0"
+				"@jest/console": "24.7.1",
+				"@jest/reporters": "24.8.0",
+				"@jest/test-result": "24.8.0",
+				"@jest/transform": "24.8.0",
+				"@jest/types": "24.8.0",
+				"ansi-escapes": "3.2.0",
+				"chalk": "2.4.2",
+				"exit": "0.1.2",
+				"graceful-fs": "4.2.0",
+				"jest-changed-files": "24.8.0",
+				"jest-config": "24.8.0",
+				"jest-haste-map": "24.8.1",
+				"jest-message-util": "24.8.0",
+				"jest-regex-util": "24.3.0",
+				"jest-resolve-dependencies": "24.8.0",
+				"jest-runner": "24.8.0",
+				"jest-runtime": "24.8.0",
+				"jest-snapshot": "24.8.0",
+				"jest-util": "24.8.0",
+				"jest-validate": "24.8.0",
+				"jest-watcher": "24.8.0",
+				"micromatch": "3.1.10",
+				"p-each-series": "1.0.0",
+				"pirates": "4.0.1",
+				"realpath-native": "1.1.0",
+				"rimraf": "2.6.3",
+				"strip-ansi": "5.2.0"
 			},
 			"dependencies": {
 				"braces": {
@@ -1172,16 +1172,16 @@
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.3",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -1190,7 +1190,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -1201,10 +1201,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -1213,7 +1213,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -1230,7 +1230,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -1239,7 +1239,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -1250,19 +1250,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.13",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					}
 				},
 				"to-regex-range": {
@@ -1271,8 +1271,8 @@
 					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 					"dev": true,
 					"requires": {
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1"
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1"
 					}
 				}
 			}
@@ -1283,10 +1283,10 @@
 			"integrity": "sha512-vlGt2HLg7qM+vtBrSkjDxk9K0YtRBi7HfRFaDxoRtyi+DyVChzhF20duvpdAnKVBV6W5tym8jm0U9EfXbDk1tw==",
 			"dev": true,
 			"requires": {
-				"@jest/fake-timers": "^24.8.0",
-				"@jest/transform": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"jest-mock": "^24.8.0"
+				"@jest/fake-timers": "24.8.0",
+				"@jest/transform": "24.8.0",
+				"@jest/types": "24.8.0",
+				"jest-mock": "24.8.0"
 			}
 		},
 		"@jest/fake-timers": {
@@ -1295,9 +1295,9 @@
 			"integrity": "sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
-				"jest-message-util": "^24.8.0",
-				"jest-mock": "^24.8.0"
+				"@jest/types": "24.8.0",
+				"jest-message-util": "24.8.0",
+				"jest-mock": "24.8.0"
 			}
 		},
 		"@jest/reporters": {
@@ -1306,27 +1306,27 @@
 			"integrity": "sha512-eZ9TyUYpyIIXfYCrw0UHUWUvE35vx5I92HGMgS93Pv7du+GHIzl+/vh8Qj9MCWFK/4TqyttVBPakWMOfZRIfxw==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^24.8.0",
-				"@jest/test-result": "^24.8.0",
-				"@jest/transform": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"chalk": "^2.0.1",
-				"exit": "^0.1.2",
-				"glob": "^7.1.2",
-				"istanbul-lib-coverage": "^2.0.2",
-				"istanbul-lib-instrument": "^3.0.1",
-				"istanbul-lib-report": "^2.0.4",
-				"istanbul-lib-source-maps": "^3.0.1",
-				"istanbul-reports": "^2.1.1",
-				"jest-haste-map": "^24.8.0",
-				"jest-resolve": "^24.8.0",
-				"jest-runtime": "^24.8.0",
-				"jest-util": "^24.8.0",
-				"jest-worker": "^24.6.0",
-				"node-notifier": "^5.2.1",
-				"slash": "^2.0.0",
-				"source-map": "^0.6.0",
-				"string-length": "^2.0.0"
+				"@jest/environment": "24.8.0",
+				"@jest/test-result": "24.8.0",
+				"@jest/transform": "24.8.0",
+				"@jest/types": "24.8.0",
+				"chalk": "2.4.2",
+				"exit": "0.1.2",
+				"glob": "7.1.4",
+				"istanbul-lib-coverage": "2.0.5",
+				"istanbul-lib-instrument": "3.3.0",
+				"istanbul-lib-report": "2.0.8",
+				"istanbul-lib-source-maps": "3.0.6",
+				"istanbul-reports": "2.2.6",
+				"jest-haste-map": "24.8.1",
+				"jest-resolve": "24.8.0",
+				"jest-runtime": "24.8.0",
+				"jest-util": "24.8.0",
+				"jest-worker": "24.6.0",
+				"node-notifier": "5.4.0",
+				"slash": "2.0.0",
+				"source-map": "0.6.1",
+				"string-length": "2.0.0"
 			}
 		},
 		"@jest/source-map": {
@@ -1335,9 +1335,9 @@
 			"integrity": "sha512-zALZt1t2ou8le/crCeeiRYzvdnTzaIlpOWaet45lNSqNJUnXbppUUFR4ZUAlzgDmKee4Q5P/tKXypI1RiHwgag==",
 			"dev": true,
 			"requires": {
-				"callsites": "^3.0.0",
-				"graceful-fs": "^4.1.15",
-				"source-map": "^0.6.0"
+				"callsites": "3.1.0",
+				"graceful-fs": "4.2.0",
+				"source-map": "0.6.1"
 			}
 		},
 		"@jest/test-result": {
@@ -1346,9 +1346,9 @@
 			"integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^24.7.1",
-				"@jest/types": "^24.8.0",
-				"@types/istanbul-lib-coverage": "^2.0.0"
+				"@jest/console": "24.7.1",
+				"@jest/types": "24.8.0",
+				"@types/istanbul-lib-coverage": "2.0.1"
 			}
 		},
 		"@jest/test-sequencer": {
@@ -1357,10 +1357,10 @@
 			"integrity": "sha512-OzL/2yHyPdCHXEzhoBuq37CE99nkme15eHkAzXRVqthreWZamEMA0WoetwstsQBCXABhczpK03JNbc4L01vvLg==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^24.8.0",
-				"jest-haste-map": "^24.8.0",
-				"jest-runner": "^24.8.0",
-				"jest-runtime": "^24.8.0"
+				"@jest/test-result": "24.8.0",
+				"jest-haste-map": "24.8.1",
+				"jest-runner": "24.8.0",
+				"jest-runtime": "24.8.0"
 			}
 		},
 		"@jest/transform": {
@@ -1369,20 +1369,20 @@
 			"integrity": "sha512-xBMfFUP7TortCs0O+Xtez2W7Zu1PLH9bvJgtraN1CDST6LBM/eTOZ9SfwS/lvV8yOfcDpFmwf9bq5cYbXvqsvA==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "^7.1.0",
-				"@jest/types": "^24.8.0",
-				"babel-plugin-istanbul": "^5.1.0",
-				"chalk": "^2.0.1",
-				"convert-source-map": "^1.4.0",
-				"fast-json-stable-stringify": "^2.0.0",
-				"graceful-fs": "^4.1.15",
-				"jest-haste-map": "^24.8.0",
-				"jest-regex-util": "^24.3.0",
-				"jest-util": "^24.8.0",
-				"micromatch": "^3.1.10",
-				"realpath-native": "^1.1.0",
-				"slash": "^2.0.0",
-				"source-map": "^0.6.1",
+				"@babel/core": "7.5.5",
+				"@jest/types": "24.8.0",
+				"babel-plugin-istanbul": "5.1.4",
+				"chalk": "2.4.2",
+				"convert-source-map": "1.6.0",
+				"fast-json-stable-stringify": "2.0.0",
+				"graceful-fs": "4.2.0",
+				"jest-haste-map": "24.8.1",
+				"jest-regex-util": "24.3.0",
+				"jest-util": "24.8.0",
+				"micromatch": "3.1.10",
+				"realpath-native": "1.1.0",
+				"slash": "2.0.0",
+				"source-map": "0.6.1",
 				"write-file-atomic": "2.4.1"
 			},
 			"dependencies": {
@@ -1392,16 +1392,16 @@
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.3",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -1410,7 +1410,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -1421,10 +1421,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -1433,7 +1433,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -1450,7 +1450,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -1459,7 +1459,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -1470,19 +1470,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.13",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					}
 				},
 				"to-regex-range": {
@@ -1491,8 +1491,8 @@
 					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 					"dev": true,
 					"requires": {
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1"
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1"
 					}
 				}
 			}
@@ -1503,9 +1503,9 @@
 			"integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
 			"dev": true,
 			"requires": {
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^1.1.1",
-				"@types/yargs": "^12.0.9"
+				"@types/istanbul-lib-coverage": "2.0.1",
+				"@types/istanbul-reports": "1.1.1",
+				"@types/yargs": "12.0.12"
 			}
 		},
 		"@textlint/ast-node-types": {
@@ -1519,11 +1519,11 @@
 			"integrity": "sha512-cfCCrFmiGY/yq0NuKNxIQvZFy9kY/1immpSpTngOnyIbD4+eJOG5mxphhHDv3CHL9GltO4GcKr54kGBg3RNdbg==",
 			"dev": true,
 			"requires": {
-				"@babel/parser": "^7.1.0",
-				"@babel/types": "^7.0.0",
-				"@types/babel__generator": "*",
-				"@types/babel__template": "*",
-				"@types/babel__traverse": "*"
+				"@babel/parser": "7.5.0",
+				"@babel/types": "7.5.0",
+				"@types/babel__generator": "7.0.2",
+				"@types/babel__template": "7.0.2",
+				"@types/babel__traverse": "7.0.7"
 			}
 		},
 		"@types/babel__generator": {
@@ -1532,7 +1532,7 @@
 			"integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.0.0"
+				"@babel/types": "7.5.0"
 			}
 		},
 		"@types/babel__template": {
@@ -1541,8 +1541,8 @@
 			"integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
 			"dev": true,
 			"requires": {
-				"@babel/parser": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/parser": "7.5.0",
+				"@babel/types": "7.5.0"
 			}
 		},
 		"@types/babel__traverse": {
@@ -1551,7 +1551,7 @@
 			"integrity": "sha512-CeBpmX1J8kWLcDEnI3Cl2Eo6RfbGvzUctA+CjZUhOKDFbLfcr7fc4usEqLNWetrlJd7RhAkyYe2czXop4fICpw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.3.0"
+				"@babel/types": "7.5.0"
 			}
 		},
 		"@types/eslint-visitor-keys": {
@@ -1570,9 +1570,9 @@
 			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
 			"integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
 			"requires": {
-				"@types/events": "*",
-				"@types/minimatch": "*",
-				"@types/node": "*"
+				"@types/events": "3.0.0",
+				"@types/minimatch": "3.0.3",
+				"@types/node": "12.6.2"
 			}
 		},
 		"@types/istanbul-lib-coverage": {
@@ -1587,7 +1587,7 @@
 			"integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
 			"dev": true,
 			"requires": {
-				"@types/istanbul-lib-coverage": "*"
+				"@types/istanbul-lib-coverage": "2.0.1"
 			}
 		},
 		"@types/istanbul-reports": {
@@ -1596,8 +1596,8 @@
 			"integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
 			"dev": true,
 			"requires": {
-				"@types/istanbul-lib-coverage": "*",
-				"@types/istanbul-lib-report": "*"
+				"@types/istanbul-lib-coverage": "2.0.1",
+				"@types/istanbul-lib-report": "1.1.1"
 			}
 		},
 		"@types/minimatch": {
@@ -1641,7 +1641,7 @@
 			"dev": true,
 			"requires": {
 				"@typescript-eslint/typescript-estree": "1.12.0",
-				"eslint-scope": "^4.0.0"
+				"eslint-scope": "4.0.3"
 			},
 			"dependencies": {
 				"eslint-scope": {
@@ -1650,8 +1650,8 @@
 					"integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
 					"dev": true,
 					"requires": {
-						"esrecurse": "^4.1.0",
-						"estraverse": "^4.1.1"
+						"esrecurse": "4.2.1",
+						"estraverse": "4.2.0"
 					}
 				}
 			}
@@ -1662,10 +1662,10 @@
 			"integrity": "sha512-0uzbaa9ZLCA5yMWJywnJJ7YVENKGWVUhJDV5UrMoldC5HoI54W5kkdPhTfmtFKpPFp93MIwmJj0/61ztvmz5Dw==",
 			"dev": true,
 			"requires": {
-				"@types/eslint-visitor-keys": "^1.0.0",
+				"@types/eslint-visitor-keys": "1.0.0",
 				"@typescript-eslint/experimental-utils": "1.12.0",
 				"@typescript-eslint/typescript-estree": "1.12.0",
-				"eslint-visitor-keys": "^1.0.0"
+				"eslint-visitor-keys": "1.0.0"
 			}
 		},
 		"@typescript-eslint/typescript-estree": {
@@ -1692,15 +1692,15 @@
 			"integrity": "sha512-am+04/0UX7ektcmvhYmrf84BDVAD8afFOf4asZjN84q8xzxFclbk5x0MtxuKGfp+zjN5WWPJn3fjFAWtDdIGSw==",
 			"dev": true,
 			"requires": {
-				"consolidate": "^0.15.1",
-				"hash-sum": "^1.0.2",
-				"lru-cache": "^4.1.2",
-				"merge-source-map": "^1.1.0",
-				"postcss": "^7.0.14",
-				"postcss-selector-parser": "^5.0.0",
+				"consolidate": "0.15.1",
+				"hash-sum": "1.0.2",
+				"lru-cache": "4.1.5",
+				"merge-source-map": "1.1.0",
+				"postcss": "7.0.17",
+				"postcss-selector-parser": "5.0.0",
 				"prettier": "1.16.3",
-				"source-map": "~0.6.1",
-				"vue-template-es2015-compiler": "^1.9.0"
+				"source-map": "0.6.1",
+				"vue-template-es2015-compiler": "1.9.1"
 			},
 			"dependencies": {
 				"cssesc": {
@@ -1715,9 +1715,9 @@
 					"integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
 					"dev": true,
 					"requires": {
-						"cssesc": "^2.0.0",
-						"indexes-of": "^1.0.1",
-						"uniq": "^1.0.1"
+						"cssesc": "2.0.0",
+						"indexes-of": "1.0.1",
+						"uniq": "1.0.1"
 					}
 				},
 				"prettier": {
@@ -1734,8 +1734,8 @@
 			"integrity": "sha512-yX4sxEIHh4M9yAbLA/ikpEnGKMNBCnoX98xE1RwxfhQVcn0MaXNSj1Qmac+ZydTj6VBSEVukchBogXBTwc+9iA==",
 			"dev": true,
 			"requires": {
-				"dom-event-types": "^1.0.0",
-				"lodash": "^4.17.4"
+				"dom-event-types": "1.0.0",
+				"lodash": "4.17.14"
 			}
 		},
 		"@vuedoc/md": {
@@ -1743,12 +1743,12 @@
 			"resolved": "https://registry.npmjs.org/@vuedoc/md/-/md-1.6.0.tgz",
 			"integrity": "sha512-BiWXI1p1ajT1f7cPofHkmcitcDocwu9Si3e6sgPe5fGSB519zO459iuK9EX0BJuguhpEvwkAKM9rT/PyxFd+Zw==",
 			"requires": {
-				"@vuedoc/parser": "^1.4.0",
-				"ast-to-markdown": "^0.2.2",
-				"deepmerge": "^3.0.0",
-				"markdown-to-ast": "^6.0.3",
-				"md-node-inject": "^0.1.1",
-				"mdast-util-to-string": "^1.0.5"
+				"@vuedoc/parser": "1.4.0",
+				"ast-to-markdown": "0.2.2",
+				"deepmerge": "3.3.0",
+				"markdown-to-ast": "6.0.3",
+				"md-node-inject": "0.1.1",
+				"mdast-util-to-string": "1.0.6"
 			}
 		},
 		"@vuedoc/parser": {
@@ -1756,9 +1756,9 @@
 			"resolved": "https://registry.npmjs.org/@vuedoc/parser/-/parser-1.4.0.tgz",
 			"integrity": "sha512-F2sV0OoLErI59h+ATQ7EEoV598msoUtZVS8wLnTmYQc1JmTgMcAEkERqeVdv4KT1D+ufP7EtQhpsKiY9LQQFdA==",
 			"requires": {
-				"cheerio": "^1.0.0-rc.2",
-				"espree": "^3.5.4",
-				"htmlparser2": "^3.9.2"
+				"cheerio": "1.0.0-rc.3",
+				"espree": "3.5.4",
+				"htmlparser2": "3.10.1"
 			}
 		},
 		"@webassemblyjs/ast": {
@@ -1812,7 +1812,7 @@
 			"dev": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.8.5",
-				"mamacro": "^0.0.3"
+				"mamacro": "0.0.3"
 			}
 		},
 		"@webassemblyjs/helper-wasm-bytecode": {
@@ -1839,7 +1839,7 @@
 			"integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
 			"dev": true,
 			"requires": {
-				"@xtuc/ieee754": "^1.2.0"
+				"@xtuc/ieee754": "1.2.0"
 			}
 		},
 		"@webassemblyjs/leb128": {
@@ -1973,8 +1973,8 @@
 			"integrity": "sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==",
 			"dev": true,
 			"requires": {
-				"acorn": "^6.0.1",
-				"acorn-walk": "^6.0.1"
+				"acorn": "6.2.0",
+				"acorn-walk": "6.2.0"
 			}
 		},
 		"acorn-jsx": {
@@ -1982,7 +1982,7 @@
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
 			"requires": {
-				"acorn": "^3.0.4"
+				"acorn": "3.3.0"
 			},
 			"dependencies": {
 				"acorn": {
@@ -2004,10 +2004,10 @@
 			"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
 			"dev": true,
 			"requires": {
-				"fast-deep-equal": "^2.0.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
-				"uri-js": "^4.2.2"
+				"fast-deep-equal": "2.0.1",
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.4.1",
+				"uri-js": "4.2.2"
 			}
 		},
 		"ajv-errors": {
@@ -2033,7 +2033,7 @@
 			"resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.1.0.tgz",
 			"integrity": "sha512-dzW9kHxH011uBsidTXd14JXgzye/YLb2LzeKZ4bsgl/Knwx8AtbSFkkGxagdNOoh0DlqHCmfiEjWKBaqjOanVw==",
 			"requires": {
-				"array-back": "^3.0.1"
+				"array-back": "3.1.0"
 			}
 		},
 		"ansi-escapes": {
@@ -2052,7 +2052,7 @@
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"requires": {
-				"color-convert": "^1.9.0"
+				"color-convert": "1.9.3"
 			}
 		},
 		"anymatch": {
@@ -2061,8 +2061,8 @@
 			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 			"dev": true,
 			"requires": {
-				"micromatch": "^3.1.4",
-				"normalize-path": "^2.1.1"
+				"micromatch": "3.1.10",
+				"normalize-path": "2.1.1"
 			},
 			"dependencies": {
 				"braces": {
@@ -2071,16 +2071,16 @@
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.3",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -2089,7 +2089,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -2100,10 +2100,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -2112,7 +2112,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -2129,7 +2129,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2138,7 +2138,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -2149,19 +2149,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.13",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					}
 				},
 				"to-regex-range": {
@@ -2170,8 +2170,8 @@
 					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 					"dev": true,
 					"requires": {
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1"
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1"
 					}
 				}
 			}
@@ -2188,8 +2188,8 @@
 			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 			"dev": true,
 			"requires": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^2.0.6"
+				"delegates": "1.0.0",
+				"readable-stream": "2.3.6"
 			},
 			"dependencies": {
 				"readable-stream": {
@@ -2198,13 +2198,13 @@
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.4",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.1",
+						"safe-buffer": "5.1.2",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"string_decoder": {
@@ -2213,7 +2213,7 @@
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "5.1.2"
 					}
 				}
 			}
@@ -2223,7 +2223,7 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"requires": {
-				"sprintf-js": "~1.0.2"
+				"sprintf-js": "1.0.3"
 			}
 		},
 		"arr-diff": {
@@ -2267,8 +2267,8 @@
 			"integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.7.0"
+				"define-properties": "1.1.3",
+				"es-abstract": "1.13.0"
 			}
 		},
 		"array-union": {
@@ -2276,7 +2276,7 @@
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 			"requires": {
-				"array-uniq": "^1.0.1"
+				"array-uniq": "1.0.3"
 			}
 		},
 		"array-uniq": {
@@ -2302,7 +2302,7 @@
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
 			"dev": true,
 			"requires": {
-				"safer-buffer": "~2.1.0"
+				"safer-buffer": "2.1.2"
 			}
 		},
 		"asn1.js": {
@@ -2311,9 +2311,9 @@
 			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0"
+				"bn.js": "4.11.8",
+				"inherits": "2.0.4",
+				"minimalistic-assert": "1.0.1"
 			}
 		},
 		"assert": {
@@ -2322,7 +2322,7 @@
 			"integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
 			"dev": true,
 			"requires": {
-				"object-assign": "^4.1.1",
+				"object-assign": "4.1.1",
 				"util": "0.10.3"
 			},
 			"dependencies": {
@@ -2402,12 +2402,12 @@
 			"integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^2.11.3",
-				"caniuse-lite": "^1.0.30000805",
-				"normalize-range": "^0.1.2",
-				"num2fraction": "^1.2.2",
-				"postcss": "^6.0.17",
-				"postcss-value-parser": "^3.2.3"
+				"browserslist": "2.11.3",
+				"caniuse-lite": "1.0.30000984",
+				"normalize-range": "0.1.2",
+				"num2fraction": "1.2.2",
+				"postcss": "6.0.23",
+				"postcss-value-parser": "3.3.1"
 			},
 			"dependencies": {
 				"browserslist": {
@@ -2416,8 +2416,8 @@
 					"integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
 					"dev": true,
 					"requires": {
-						"caniuse-lite": "^1.0.30000792",
-						"electron-to-chromium": "^1.3.30"
+						"caniuse-lite": "1.0.30000984",
+						"electron-to-chromium": "1.3.191"
 					}
 				},
 				"postcss": {
@@ -2426,9 +2426,9 @@
 					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
 					"dev": true,
 					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
+						"chalk": "2.4.2",
+						"source-map": "0.6.1",
+						"supports-color": "5.5.0"
 					}
 				},
 				"postcss-value-parser": {
@@ -2457,7 +2457,7 @@
 			"integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
 			"requires": {
 				"follow-redirects": "1.5.10",
-				"is-buffer": "^2.0.2"
+				"is-buffer": "2.0.3"
 			}
 		},
 		"babel-code-frame": {
@@ -2466,9 +2466,9 @@
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.1.3",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.2"
+				"chalk": "1.1.3",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -2489,11 +2489,11 @@
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
 					}
 				},
 				"js-tokens": {
@@ -2508,7 +2508,7 @@
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				},
 				"supports-color": {
@@ -2525,12 +2525,12 @@
 			"integrity": "sha512-UdsurWPtgiPgpJ06ryUnuaSXC2s0WoSZnQmEpbAH65XZSdwowgN5MvyP7e88nW07FYXv72erVtpBkxyDVKhH1Q==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.0.0",
-				"@babel/traverse": "^7.0.0",
-				"@babel/types": "^7.0.0",
+				"@babel/code-frame": "7.0.0",
+				"@babel/parser": "7.5.0",
+				"@babel/traverse": "7.5.0",
+				"@babel/types": "7.5.0",
 				"eslint-scope": "3.7.1",
-				"eslint-visitor-keys": "^1.0.0"
+				"eslint-visitor-keys": "1.0.0"
 			}
 		},
 		"babel-jest": {
@@ -2539,13 +2539,13 @@
 			"integrity": "sha512-+5/kaZt4I9efoXzPlZASyK/lN9qdRKmmUav9smVc0ruPQD7IsfucQ87gpOE8mn2jbDuS6M/YOW6n3v9ZoIfgnw==",
 			"dev": true,
 			"requires": {
-				"@jest/transform": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"@types/babel__core": "^7.1.0",
-				"babel-plugin-istanbul": "^5.1.0",
-				"babel-preset-jest": "^24.6.0",
-				"chalk": "^2.4.2",
-				"slash": "^2.0.0"
+				"@jest/transform": "24.8.0",
+				"@jest/types": "24.8.0",
+				"@types/babel__core": "7.1.2",
+				"babel-plugin-istanbul": "5.1.4",
+				"babel-preset-jest": "24.6.0",
+				"chalk": "2.4.2",
+				"slash": "2.0.0"
 			}
 		},
 		"babel-loader": {
@@ -2554,10 +2554,10 @@
 			"integrity": "sha512-4BmWKtBOBm13uoUwd08UwjZlaw3O9GWf456R9j+5YykFZ6LUIjIKLc0zEZf+hauxPOJs96C8k6FvYD09vWzhYw==",
 			"dev": true,
 			"requires": {
-				"find-cache-dir": "^2.0.0",
-				"loader-utils": "^1.0.2",
-				"mkdirp": "^0.5.1",
-				"pify": "^4.0.1"
+				"find-cache-dir": "2.1.0",
+				"loader-utils": "1.2.3",
+				"mkdirp": "0.5.1",
+				"pify": "4.0.1"
 			}
 		},
 		"babel-messages": {
@@ -2566,7 +2566,7 @@
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-dynamic-import-node": {
@@ -2575,7 +2575,7 @@
 			"integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
 			"dev": true,
 			"requires": {
-				"object.assign": "^4.1.0"
+				"object.assign": "4.1.0"
 			}
 		},
 		"babel-plugin-istanbul": {
@@ -2584,9 +2584,9 @@
 			"integrity": "sha512-dySz4VJMH+dpndj0wjJ8JPs/7i1TdSPb1nRrn56/92pKOF9VKC1FMFJmMXjzlGGusnCAqujP6PBCiKq0sVA+YQ==",
 			"dev": true,
 			"requires": {
-				"find-up": "^3.0.0",
-				"istanbul-lib-instrument": "^3.3.0",
-				"test-exclude": "^5.2.3"
+				"find-up": "3.0.0",
+				"istanbul-lib-instrument": "3.3.0",
+				"test-exclude": "5.2.3"
 			}
 		},
 		"babel-plugin-jest-hoist": {
@@ -2595,7 +2595,7 @@
 			"integrity": "sha512-3pKNH6hMt9SbOv0F3WVmy5CWQ4uogS3k0GY5XLyQHJ9EGpAT9XWkFd2ZiXXtkwFHdAHa5j7w7kfxSP5lAIwu7w==",
 			"dev": true,
 			"requires": {
-				"@types/babel__traverse": "^7.0.6"
+				"@types/babel__traverse": "7.0.7"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-commonjs": {
@@ -2604,10 +2604,10 @@
 			"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-strict-mode": "^6.24.1",
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-types": "^6.26.0"
+				"babel-plugin-transform-strict-mode": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-strict-mode": {
@@ -2616,8 +2616,8 @@
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-types": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-preset-jest": {
@@ -2626,8 +2626,8 @@
 			"integrity": "sha512-pdZqLEdmy1ZK5kyRUfvBb2IfTPb2BUvIJczlPspS8fWmBQslNNDBqVfh7BW5leOVJMDZKzjD8XEyABTk6gQ5yw==",
 			"dev": true,
 			"requires": {
-				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-				"babel-plugin-jest-hoist": "^24.6.0"
+				"@babel/plugin-syntax-object-rest-spread": "7.2.0",
+				"babel-plugin-jest-hoist": "24.6.0"
 			}
 		},
 		"babel-runtime": {
@@ -2636,8 +2636,8 @@
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"dev": true,
 			"requires": {
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.11.0"
+				"core-js": "2.6.9",
+				"regenerator-runtime": "0.11.1"
 			},
 			"dependencies": {
 				"regenerator-runtime": {
@@ -2654,11 +2654,11 @@
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"lodash": "^4.17.4"
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"lodash": "4.17.14"
 			}
 		},
 		"babel-traverse": {
@@ -2667,15 +2667,15 @@
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"debug": "^2.6.8",
-				"globals": "^9.18.0",
-				"invariant": "^2.2.2",
-				"lodash": "^4.17.4"
+				"babel-code-frame": "6.26.0",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"debug": "2.6.9",
+				"globals": "9.18.0",
+				"invariant": "2.2.4",
+				"lodash": "4.17.14"
 			},
 			"dependencies": {
 				"debug": {
@@ -2701,10 +2701,10 @@
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"esutils": "^2.0.2",
-				"lodash": "^4.17.4",
-				"to-fast-properties": "^1.0.3"
+				"babel-runtime": "6.26.0",
+				"esutils": "2.0.2",
+				"lodash": "4.17.14",
+				"to-fast-properties": "1.0.3"
 			},
 			"dependencies": {
 				"to-fast-properties": {
@@ -2737,13 +2737,13 @@
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
 			"dev": true,
 			"requires": {
-				"cache-base": "^1.0.1",
-				"class-utils": "^0.3.5",
-				"component-emitter": "^1.2.1",
-				"define-property": "^1.0.0",
-				"isobject": "^3.0.1",
-				"mixin-deep": "^1.2.0",
-				"pascalcase": "^0.1.1"
+				"cache-base": "1.0.1",
+				"class-utils": "0.3.6",
+				"component-emitter": "1.3.0",
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"mixin-deep": "1.3.2",
+				"pascalcase": "0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -2752,7 +2752,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -2761,7 +2761,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -2770,7 +2770,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -2779,9 +2779,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				}
 			}
@@ -2798,7 +2798,7 @@
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
 			"dev": true,
 			"requires": {
-				"tweetnacl": "^0.14.3"
+				"tweetnacl": "0.14.5"
 			}
 		},
 		"big.js": {
@@ -2819,7 +2819,7 @@
 			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
 			"dev": true,
 			"requires": {
-				"inherits": "~2.0.0"
+				"inherits": "2.0.4"
 			}
 		},
 		"bluebird": {
@@ -2848,7 +2848,7 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"requires": {
-				"balanced-match": "^1.0.0",
+				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -2857,7 +2857,7 @@
 			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
 			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
 			"requires": {
-				"fill-range": "^7.0.1"
+				"fill-range": "7.0.1"
 			}
 		},
 		"brorand": {
@@ -2895,12 +2895,12 @@
 			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
 			"dev": true,
 			"requires": {
-				"buffer-xor": "^1.0.3",
-				"cipher-base": "^1.0.0",
-				"create-hash": "^1.1.0",
-				"evp_bytestokey": "^1.0.3",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
+				"buffer-xor": "1.0.3",
+				"cipher-base": "1.0.4",
+				"create-hash": "1.2.0",
+				"evp_bytestokey": "1.0.3",
+				"inherits": "2.0.4",
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"browserify-cipher": {
@@ -2909,9 +2909,9 @@
 			"integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
 			"dev": true,
 			"requires": {
-				"browserify-aes": "^1.0.4",
-				"browserify-des": "^1.0.0",
-				"evp_bytestokey": "^1.0.0"
+				"browserify-aes": "1.2.0",
+				"browserify-des": "1.0.2",
+				"evp_bytestokey": "1.0.3"
 			}
 		},
 		"browserify-des": {
@@ -2920,10 +2920,10 @@
 			"integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
 			"dev": true,
 			"requires": {
-				"cipher-base": "^1.0.1",
-				"des.js": "^1.0.0",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.1.2"
+				"cipher-base": "1.0.4",
+				"des.js": "1.0.0",
+				"inherits": "2.0.4",
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"browserify-rsa": {
@@ -2932,8 +2932,8 @@
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.1.0",
-				"randombytes": "^2.0.1"
+				"bn.js": "4.11.8",
+				"randombytes": "2.1.0"
 			}
 		},
 		"browserify-sign": {
@@ -2942,13 +2942,13 @@
 			"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.1.1",
-				"browserify-rsa": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"create-hmac": "^1.1.2",
-				"elliptic": "^6.0.0",
-				"inherits": "^2.0.1",
-				"parse-asn1": "^5.0.0"
+				"bn.js": "4.11.8",
+				"browserify-rsa": "4.0.1",
+				"create-hash": "1.2.0",
+				"create-hmac": "1.1.7",
+				"elliptic": "6.5.0",
+				"inherits": "2.0.4",
+				"parse-asn1": "5.1.4"
 			}
 		},
 		"browserify-zlib": {
@@ -2957,7 +2957,7 @@
 			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
 			"dev": true,
 			"requires": {
-				"pako": "~1.0.5"
+				"pako": "1.0.10"
 			}
 		},
 		"browserslist": {
@@ -2966,9 +2966,9 @@
 			"integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30000984",
-				"electron-to-chromium": "^1.3.191",
-				"node-releases": "^1.1.25"
+				"caniuse-lite": "1.0.30000984",
+				"electron-to-chromium": "1.3.191",
+				"node-releases": "1.1.25"
 			}
 		},
 		"bser": {
@@ -2977,7 +2977,7 @@
 			"integrity": "sha512-8zsjWrQkkBoLK6uxASk1nJ2SKv97ltiGDo6A3wA0/yRPz+CwmEyDo0hUrhIuukG2JHpAl3bvFIixw2/3Hi0DOg==",
 			"dev": true,
 			"requires": {
-				"node-int64": "^0.4.0"
+				"node-int64": "0.4.0"
 			}
 		},
 		"buffer": {
@@ -2986,9 +2986,9 @@
 			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
 			"dev": true,
 			"requires": {
-				"base64-js": "^1.0.2",
-				"ieee754": "^1.1.4",
-				"isarray": "^1.0.0"
+				"base64-js": "1.3.0",
+				"ieee754": "1.1.13",
+				"isarray": "1.0.0"
 			}
 		},
 		"buffer-from": {
@@ -3015,20 +3015,20 @@
 			"integrity": "sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==",
 			"dev": true,
 			"requires": {
-				"bluebird": "^3.5.5",
-				"chownr": "^1.1.1",
-				"figgy-pudding": "^3.5.1",
-				"glob": "^7.1.4",
-				"graceful-fs": "^4.1.15",
-				"lru-cache": "^5.1.1",
-				"mississippi": "^3.0.0",
-				"mkdirp": "^0.5.1",
-				"move-concurrently": "^1.0.1",
-				"promise-inflight": "^1.0.1",
-				"rimraf": "^2.6.3",
-				"ssri": "^6.0.1",
-				"unique-filename": "^1.1.1",
-				"y18n": "^4.0.0"
+				"bluebird": "3.5.5",
+				"chownr": "1.1.2",
+				"figgy-pudding": "3.5.1",
+				"glob": "7.1.4",
+				"graceful-fs": "4.2.0",
+				"lru-cache": "5.1.1",
+				"mississippi": "3.0.0",
+				"mkdirp": "0.5.1",
+				"move-concurrently": "1.0.1",
+				"promise-inflight": "1.0.1",
+				"rimraf": "2.6.3",
+				"ssri": "6.0.1",
+				"unique-filename": "1.1.1",
+				"y18n": "4.0.0"
 			},
 			"dependencies": {
 				"lru-cache": {
@@ -3037,7 +3037,7 @@
 					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
 					"dev": true,
 					"requires": {
-						"yallist": "^3.0.2"
+						"yallist": "3.0.3"
 					}
 				},
 				"yallist": {
@@ -3054,15 +3054,15 @@
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
 			"dev": true,
 			"requires": {
-				"collection-visit": "^1.0.0",
-				"component-emitter": "^1.2.1",
-				"get-value": "^2.0.6",
-				"has-value": "^1.0.0",
-				"isobject": "^3.0.1",
-				"set-value": "^2.0.0",
-				"to-object-path": "^0.3.0",
-				"union-value": "^1.0.0",
-				"unset-value": "^1.0.0"
+				"collection-visit": "1.0.0",
+				"component-emitter": "1.3.0",
+				"get-value": "2.0.6",
+				"has-value": "1.0.0",
+				"isobject": "3.0.1",
+				"set-value": "2.0.1",
+				"to-object-path": "0.3.0",
+				"union-value": "1.0.1",
+				"unset-value": "1.0.0"
 			}
 		},
 		"cache-point": {
@@ -3070,9 +3070,9 @@
 			"resolved": "https://registry.npmjs.org/cache-point/-/cache-point-0.4.1.tgz",
 			"integrity": "sha512-4TgWfe9SF+bUy5cCql8gWHqKNrviufNwSYxLjf2utB0pY4+bdcuFwMmY1hDB+67Gz/L1vmhFNhePAjJTFBtV+Q==",
 			"requires": {
-				"array-back": "^2.0.0",
-				"fs-then-native": "^2.0.0",
-				"mkdirp2": "^1.0.3"
+				"array-back": "2.0.0",
+				"fs-then-native": "2.0.0",
+				"mkdirp2": "1.0.4"
 			},
 			"dependencies": {
 				"array-back": {
@@ -3080,7 +3080,7 @@
 					"resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
 					"integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
 					"requires": {
-						"typical": "^2.6.1"
+						"typical": "2.6.1"
 					}
 				}
 			}
@@ -3102,8 +3102,8 @@
 			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 			"dev": true,
 			"requires": {
-				"camelcase": "^2.0.0",
-				"map-obj": "^1.0.0"
+				"camelcase": "2.1.1",
+				"map-obj": "1.0.1"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -3126,7 +3126,7 @@
 			"integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
 			"dev": true,
 			"requires": {
-				"rsvp": "^4.8.4"
+				"rsvp": "4.8.5"
 			}
 		},
 		"caseless": {
@@ -3140,7 +3140,7 @@
 			"resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.11.tgz",
 			"integrity": "sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==",
 			"requires": {
-				"lodash": "^4.17.14"
+				"lodash": "4.17.14"
 			}
 		},
 		"ccount": {
@@ -3153,9 +3153,9 @@
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
+				"ansi-styles": "3.2.1",
+				"escape-string-regexp": "1.0.5",
+				"supports-color": "5.5.0"
 			}
 		},
 		"character-entities": {
@@ -3194,12 +3194,12 @@
 			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
 			"integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
 			"requires": {
-				"css-select": "~1.2.0",
-				"dom-serializer": "~0.1.1",
-				"entities": "~1.1.1",
-				"htmlparser2": "^3.9.1",
-				"lodash": "^4.15.0",
-				"parse5": "^3.0.1"
+				"css-select": "1.2.0",
+				"dom-serializer": "0.1.1",
+				"entities": "1.1.2",
+				"htmlparser2": "3.10.1",
+				"lodash": "4.17.14",
+				"parse5": "3.0.3"
 			}
 		},
 		"chokidar": {
@@ -3208,18 +3208,18 @@
 			"integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
 			"dev": true,
 			"requires": {
-				"anymatch": "^2.0.0",
-				"async-each": "^1.0.1",
-				"braces": "^2.3.2",
-				"fsevents": "^1.2.7",
-				"glob-parent": "^3.1.0",
-				"inherits": "^2.0.3",
-				"is-binary-path": "^1.0.0",
-				"is-glob": "^4.0.0",
-				"normalize-path": "^3.0.0",
-				"path-is-absolute": "^1.0.0",
-				"readdirp": "^2.2.1",
-				"upath": "^1.1.1"
+				"anymatch": "2.0.0",
+				"async-each": "1.0.3",
+				"braces": "2.3.2",
+				"fsevents": "1.2.9",
+				"glob-parent": "3.1.0",
+				"inherits": "2.0.4",
+				"is-binary-path": "1.0.1",
+				"is-glob": "4.0.1",
+				"normalize-path": "3.0.0",
+				"path-is-absolute": "1.0.1",
+				"readdirp": "2.2.1",
+				"upath": "1.1.2"
 			},
 			"dependencies": {
 				"braces": {
@@ -3228,16 +3228,16 @@
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.3",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
 					}
 				},
 				"extend-shallow": {
@@ -3246,7 +3246,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				},
 				"fill-range": {
@@ -3255,10 +3255,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
 					}
 				},
 				"glob-parent": {
@@ -3267,8 +3267,8 @@
 					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
 					"dev": true,
 					"requires": {
-						"is-glob": "^3.1.0",
-						"path-dirname": "^1.0.0"
+						"is-glob": "3.1.0",
+						"path-dirname": "1.0.2"
 					},
 					"dependencies": {
 						"is-glob": {
@@ -3277,7 +3277,7 @@
 							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 							"dev": true,
 							"requires": {
-								"is-extglob": "^2.1.0"
+								"is-extglob": "2.1.1"
 							}
 						}
 					}
@@ -3300,7 +3300,7 @@
 					"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^2.1.1"
+						"is-extglob": "2.1.1"
 					}
 				},
 				"is-number": {
@@ -3309,7 +3309,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					}
 				},
 				"kind-of": {
@@ -3318,7 +3318,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				},
 				"normalize-path": {
@@ -3333,8 +3333,8 @@
 					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 					"dev": true,
 					"requires": {
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1"
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1"
 					}
 				}
 			}
@@ -3351,7 +3351,7 @@
 			"integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
 			"dev": true,
 			"requires": {
-				"tslib": "^1.9.0"
+				"tslib": "1.10.0"
 			}
 		},
 		"ci-info": {
@@ -3366,8 +3366,8 @@
 			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
+				"inherits": "2.0.4",
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"circular-json": {
@@ -3382,10 +3382,10 @@
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
 			"dev": true,
 			"requires": {
-				"arr-union": "^3.1.0",
-				"define-property": "^0.2.5",
-				"isobject": "^3.0.0",
-				"static-extend": "^0.1.1"
+				"arr-union": "3.1.0",
+				"define-property": "0.2.5",
+				"isobject": "3.0.1",
+				"static-extend": "0.1.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -3394,7 +3394,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				}
 			}
@@ -3405,7 +3405,7 @@
 			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 			"dev": true,
 			"requires": {
-				"restore-cursor": "^2.0.0"
+				"restore-cursor": "2.0.0"
 			}
 		},
 		"cli-width": {
@@ -3419,9 +3419,9 @@
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
 			"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
 			"requires": {
-				"string-width": "^3.1.0",
-				"strip-ansi": "^5.2.0",
-				"wrap-ansi": "^5.1.0"
+				"string-width": "3.1.0",
+				"strip-ansi": "5.2.0",
+				"wrap-ansi": "5.1.0"
 			}
 		},
 		"clone": {
@@ -3436,10 +3436,10 @@
 			"integrity": "sha512-SZegPTKjCgpQH63E+eN6mVEEPdQBOUzjyJm5Pora4lrwWRFS8I0QAxV/KD6vV/i0WuijHZWQC1fMsPEdxfdVCQ==",
 			"dev": true,
 			"requires": {
-				"for-own": "^1.0.0",
-				"is-plain-object": "^2.0.4",
-				"kind-of": "^6.0.0",
-				"shallow-clone": "^1.0.0"
+				"for-own": "1.0.0",
+				"is-plain-object": "2.0.4",
+				"kind-of": "6.0.2",
+				"shallow-clone": "1.0.0"
 			}
 		},
 		"clone-regexp": {
@@ -3448,8 +3448,8 @@
 			"integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
 			"dev": true,
 			"requires": {
-				"is-regexp": "^1.0.0",
-				"is-supported-regexp-flag": "^1.0.0"
+				"is-regexp": "1.0.0",
+				"is-supported-regexp-flag": "1.0.1"
 			}
 		},
 		"co": {
@@ -3480,8 +3480,8 @@
 			"resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.3.tgz",
 			"integrity": "sha512-0y0rBgoX8IzIjBAUnO73SEtSb4Mhk3IoceWJq5zZSxb9mWORhWH8xLYo4EDSOE1jRBk1LhmfjqWFFt10h/+MEA==",
 			"requires": {
-				"stream-connect": "^1.0.2",
-				"stream-via": "^1.0.4"
+				"stream-connect": "1.0.2",
+				"stream-via": "1.0.4"
 			}
 		},
 		"collection-visit": {
@@ -3490,8 +3490,8 @@
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
 			"dev": true,
 			"requires": {
-				"map-visit": "^1.0.0",
-				"object-visit": "^1.0.0"
+				"map-visit": "1.0.0",
+				"object-visit": "1.0.1"
 			}
 		},
 		"color-convert": {
@@ -3513,7 +3513,7 @@
 			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
 			"dev": true,
 			"requires": {
-				"delayed-stream": "~1.0.0"
+				"delayed-stream": "1.0.0"
 			}
 		},
 		"command-line-args": {
@@ -3521,10 +3521,10 @@
 			"resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
 			"integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
 			"requires": {
-				"array-back": "^3.0.1",
-				"find-replace": "^3.0.0",
-				"lodash.camelcase": "^4.3.0",
-				"typical": "^4.0.0"
+				"array-back": "3.1.0",
+				"find-replace": "3.0.0",
+				"lodash.camelcase": "4.3.0",
+				"typical": "4.0.0"
 			},
 			"dependencies": {
 				"typical": {
@@ -3539,11 +3539,11 @@
 			"resolved": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.8.0.tgz",
 			"integrity": "sha512-Xw18HVx/QzQV3Sc5k1vy3kgtOeGmsKIqwtFFoyjI4bbcpSgnw2CWVULvtakyw4s6fhyAdI6soQQhXc2OzJy62g==",
 			"requires": {
-				"ansi-escape-sequences": "^4.0.0",
-				"array-back": "^2.0.0",
-				"command-line-args": "^5.0.0",
-				"command-line-usage": "^4.1.0",
-				"typical": "^2.6.1"
+				"ansi-escape-sequences": "4.1.0",
+				"array-back": "2.0.0",
+				"command-line-args": "5.1.1",
+				"command-line-usage": "4.1.0",
+				"typical": "2.6.1"
 			},
 			"dependencies": {
 				"array-back": {
@@ -3551,7 +3551,7 @@
 					"resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
 					"integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
 					"requires": {
-						"typical": "^2.6.1"
+						"typical": "2.6.1"
 					}
 				}
 			}
@@ -3561,10 +3561,10 @@
 			"resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.1.0.tgz",
 			"integrity": "sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==",
 			"requires": {
-				"ansi-escape-sequences": "^4.0.0",
-				"array-back": "^2.0.0",
-				"table-layout": "^0.4.2",
-				"typical": "^2.6.1"
+				"ansi-escape-sequences": "4.1.0",
+				"array-back": "2.0.0",
+				"table-layout": "0.4.5",
+				"typical": "2.6.1"
 			},
 			"dependencies": {
 				"array-back": {
@@ -3572,7 +3572,7 @@
 					"resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
 					"integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
 					"requires": {
-						"typical": "^2.6.1"
+						"typical": "2.6.1"
 					}
 				}
 			}
@@ -3616,10 +3616,10 @@
 			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 			"dev": true,
 			"requires": {
-				"buffer-from": "^1.0.0",
-				"inherits": "^2.0.3",
-				"readable-stream": "^2.2.2",
-				"typedarray": "^0.0.6"
+				"buffer-from": "1.1.1",
+				"inherits": "2.0.4",
+				"readable-stream": "2.3.6",
+				"typedarray": "0.0.6"
 			},
 			"dependencies": {
 				"readable-stream": {
@@ -3628,13 +3628,13 @@
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.4",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.1",
+						"safe-buffer": "5.1.2",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"string_decoder": {
@@ -3643,7 +3643,7 @@
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "5.1.2"
 					}
 				}
 			}
@@ -3654,9 +3654,9 @@
 			"integrity": "sha1-PemFVTE5R10yUCyDsC9gaE0kxV8=",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^2.0.1",
-				"is-whitespace": "^0.3.0",
-				"kind-of": "^3.0.2"
+				"extend-shallow": "2.0.1",
+				"is-whitespace": "0.3.0",
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -3665,7 +3665,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				},
 				"is-buffer": {
@@ -3680,7 +3680,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -3691,8 +3691,8 @@
 			"integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
 			"dev": true,
 			"requires": {
-				"ini": "^1.3.4",
-				"proto-list": "~1.2.1"
+				"ini": "1.3.5",
+				"proto-list": "1.2.4"
 			}
 		},
 		"config-master": {
@@ -3700,7 +3700,7 @@
 			"resolved": "https://registry.npmjs.org/config-master/-/config-master-3.1.0.tgz",
 			"integrity": "sha1-ZnZjWQUFooO/JqSE1oSJ10xUhdo=",
 			"requires": {
-				"walk-back": "^2.0.1"
+				"walk-back": "2.0.1"
 			},
 			"dependencies": {
 				"walk-back": {
@@ -3716,7 +3716,7 @@
 			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
 			"dev": true,
 			"requires": {
-				"date-now": "^0.1.4"
+				"date-now": "0.1.4"
 			}
 		},
 		"console-control-strings": {
@@ -3731,7 +3731,7 @@
 			"integrity": "sha512-DW46nrsMJgy9kqAbPt5rKaCr7uFtpo4mSUvLHIUbJEjm0vo+aY5QLwBUq3FK4tRnJr/X0Psc0C4jf/h+HtXSMw==",
 			"dev": true,
 			"requires": {
-				"bluebird": "^3.1.1"
+				"bluebird": "3.5.5"
 			}
 		},
 		"constants-browserify": {
@@ -3752,7 +3752,7 @@
 			"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "~5.1.1"
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"copy-concurrently": {
@@ -3761,12 +3761,12 @@
 			"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
 			"dev": true,
 			"requires": {
-				"aproba": "^1.1.1",
-				"fs-write-stream-atomic": "^1.0.8",
-				"iferr": "^0.1.5",
-				"mkdirp": "^0.5.1",
-				"rimraf": "^2.5.4",
-				"run-queue": "^1.0.0"
+				"aproba": "1.2.0",
+				"fs-write-stream-atomic": "1.0.10",
+				"iferr": "0.1.5",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.3",
+				"run-queue": "1.0.3"
 			}
 		},
 		"copy-descriptor": {
@@ -3786,9 +3786,9 @@
 			"integrity": "sha512-Z5zbO9f1d0YrJdoaQhphVAnKPimX92D6z8lCGphH89MNRxlL1prI9ExJPqVwP0/kgkQCv8c4GJGT8X16yUncOg==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.6.2",
+				"browserslist": "4.6.6",
 				"core-js-pure": "3.1.4",
-				"semver": "^6.1.1"
+				"semver": "6.2.0"
 			},
 			"dependencies": {
 				"semver": {
@@ -3817,10 +3817,10 @@
 			"integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
 			"dev": true,
 			"requires": {
-				"is-directory": "^0.3.1",
-				"js-yaml": "^3.9.0",
-				"parse-json": "^3.0.0",
-				"require-from-string": "^2.0.1"
+				"is-directory": "0.3.1",
+				"js-yaml": "3.13.1",
+				"parse-json": "3.0.0",
+				"require-from-string": "2.0.2"
 			},
 			"dependencies": {
 				"parse-json": {
@@ -3829,7 +3829,7 @@
 					"integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
 					"dev": true,
 					"requires": {
-						"error-ex": "^1.3.1"
+						"error-ex": "1.3.2"
 					}
 				}
 			}
@@ -3840,8 +3840,8 @@
 			"integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.1.0",
-				"elliptic": "^6.0.0"
+				"bn.js": "4.11.8",
+				"elliptic": "6.5.0"
 			}
 		},
 		"create-hash": {
@@ -3850,11 +3850,11 @@
 			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
 			"dev": true,
 			"requires": {
-				"cipher-base": "^1.0.1",
-				"inherits": "^2.0.1",
-				"md5.js": "^1.3.4",
-				"ripemd160": "^2.0.1",
-				"sha.js": "^2.4.0"
+				"cipher-base": "1.0.4",
+				"inherits": "2.0.4",
+				"md5.js": "1.3.5",
+				"ripemd160": "2.0.2",
+				"sha.js": "2.4.11"
 			}
 		},
 		"create-hmac": {
@@ -3863,12 +3863,12 @@
 			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
 			"dev": true,
 			"requires": {
-				"cipher-base": "^1.0.3",
-				"create-hash": "^1.1.0",
-				"inherits": "^2.0.1",
-				"ripemd160": "^2.0.0",
-				"safe-buffer": "^5.0.1",
-				"sha.js": "^2.4.8"
+				"cipher-base": "1.0.4",
+				"create-hash": "1.2.0",
+				"inherits": "2.0.4",
+				"ripemd160": "2.0.2",
+				"safe-buffer": "5.1.2",
+				"sha.js": "2.4.11"
 			}
 		},
 		"cross-env": {
@@ -3876,8 +3876,8 @@
 			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
 			"integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
 			"requires": {
-				"cross-spawn": "^6.0.5",
-				"is-windows": "^1.0.0"
+				"cross-spawn": "6.0.5",
+				"is-windows": "1.0.2"
 			}
 		},
 		"cross-spawn": {
@@ -3885,11 +3885,11 @@
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
 			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 			"requires": {
-				"nice-try": "^1.0.4",
-				"path-key": "^2.0.1",
-				"semver": "^5.5.0",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
+				"nice-try": "1.0.5",
+				"path-key": "2.0.1",
+				"semver": "5.7.0",
+				"shebang-command": "1.2.0",
+				"which": "1.3.1"
 			}
 		},
 		"crypt": {
@@ -3903,17 +3903,17 @@
 			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
 			"dev": true,
 			"requires": {
-				"browserify-cipher": "^1.0.0",
-				"browserify-sign": "^4.0.0",
-				"create-ecdh": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"create-hmac": "^1.1.0",
-				"diffie-hellman": "^5.0.0",
-				"inherits": "^2.0.1",
-				"pbkdf2": "^3.0.3",
-				"public-encrypt": "^4.0.0",
-				"randombytes": "^2.0.0",
-				"randomfill": "^1.0.3"
+				"browserify-cipher": "1.0.1",
+				"browserify-sign": "4.0.4",
+				"create-ecdh": "4.0.3",
+				"create-hash": "1.2.0",
+				"create-hmac": "1.1.7",
+				"diffie-hellman": "5.0.3",
+				"inherits": "2.0.4",
+				"pbkdf2": "3.0.17",
+				"public-encrypt": "4.0.3",
+				"randombytes": "2.1.0",
+				"randomfill": "1.0.4"
 			}
 		},
 		"css": {
@@ -3922,10 +3922,10 @@
 			"integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.3",
-				"source-map": "^0.6.1",
-				"source-map-resolve": "^0.5.2",
-				"urix": "^0.1.0"
+				"inherits": "2.0.4",
+				"source-map": "0.6.1",
+				"source-map-resolve": "0.5.2",
+				"urix": "0.1.0"
 			}
 		},
 		"css-loader": {
@@ -3934,18 +3934,18 @@
 			"integrity": "sha512-MuL8WsF/KSrHCBCYaozBKlx+r7vIfUaDTEreo7wR7Vv3J6N0z6fqWjRk3e/6wjneitXN1r/Y9FTK1psYNOBdJQ==",
 			"dev": true,
 			"requires": {
-				"camelcase": "^5.3.1",
-				"cssesc": "^3.0.0",
-				"icss-utils": "^4.1.1",
-				"loader-utils": "^1.2.3",
-				"normalize-path": "^3.0.0",
-				"postcss": "^7.0.17",
-				"postcss-modules-extract-imports": "^2.0.0",
-				"postcss-modules-local-by-default": "^3.0.2",
-				"postcss-modules-scope": "^2.1.0",
-				"postcss-modules-values": "^3.0.0",
-				"postcss-value-parser": "^4.0.0",
-				"schema-utils": "^2.0.0"
+				"camelcase": "5.3.1",
+				"cssesc": "3.0.0",
+				"icss-utils": "4.1.1",
+				"loader-utils": "1.2.3",
+				"normalize-path": "3.0.0",
+				"postcss": "7.0.17",
+				"postcss-modules-extract-imports": "2.0.0",
+				"postcss-modules-local-by-default": "3.0.2",
+				"postcss-modules-scope": "2.1.0",
+				"postcss-modules-values": "3.0.0",
+				"postcss-value-parser": "4.0.0",
+				"schema-utils": "2.0.1"
 			},
 			"dependencies": {
 				"normalize-path": {
@@ -3960,8 +3960,8 @@
 					"integrity": "sha512-HJFKJ4JixDpRur06QHwi8uu2kZbng318ahWEKgBjc0ZklcE4FDvmm2wghb448q0IRaABxIESt8vqPFvwgMB80A==",
 					"dev": true,
 					"requires": {
-						"ajv": "^6.1.0",
-						"ajv-keywords": "^3.1.0"
+						"ajv": "6.10.2",
+						"ajv-keywords": "3.4.1"
 					}
 				}
 			}
@@ -3971,10 +3971,10 @@
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
 			"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
 			"requires": {
-				"boolbase": "~1.0.0",
-				"css-what": "2.1",
+				"boolbase": "1.0.0",
+				"css-what": "2.1.3",
 				"domutils": "1.5.1",
-				"nth-check": "~1.0.1"
+				"nth-check": "1.0.2"
 			}
 		},
 		"css-what": {
@@ -4000,7 +4000,7 @@
 			"integrity": "sha512-wXsoRfsRfsLVNaVzoKdqvEmK/5PFaEXNspVT22Ots6K/cnJdpoDKuQFw+qlMiXnmaif1OgeC466X1zISgAOcGg==",
 			"dev": true,
 			"requires": {
-				"cssom": "~0.3.6"
+				"cssom": "0.3.8"
 			}
 		},
 		"currently-unhandled": {
@@ -4009,7 +4009,7 @@
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
 			"dev": true,
 			"requires": {
-				"array-find-index": "^1.0.1"
+				"array-find-index": "1.0.2"
 			}
 		},
 		"cyclist": {
@@ -4024,7 +4024,7 @@
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0"
+				"assert-plus": "1.0.0"
 			}
 		},
 		"data-urls": {
@@ -4033,9 +4033,9 @@
 			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
 			"dev": true,
 			"requires": {
-				"abab": "^2.0.0",
-				"whatwg-mimetype": "^2.2.0",
-				"whatwg-url": "^7.0.0"
+				"abab": "2.0.0",
+				"whatwg-mimetype": "2.3.0",
+				"whatwg-url": "7.0.0"
 			},
 			"dependencies": {
 				"whatwg-url": {
@@ -4044,9 +4044,9 @@
 					"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
 					"dev": true,
 					"requires": {
-						"lodash.sortby": "^4.7.0",
-						"tr46": "^1.0.1",
-						"webidl-conversions": "^4.0.2"
+						"lodash.sortby": "4.7.0",
+						"tr46": "1.0.1",
+						"webidl-conversions": "4.0.2"
 					}
 				}
 			}
@@ -4082,8 +4082,8 @@
 			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
 			"dev": true,
 			"requires": {
-				"decamelize": "^1.1.0",
-				"map-obj": "^1.0.0"
+				"decamelize": "1.2.0",
+				"map-obj": "1.0.1"
 			}
 		},
 		"decode-uri-component": {
@@ -4114,7 +4114,7 @@
 			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
 			"dev": true,
 			"requires": {
-				"object-keys": "^1.0.12"
+				"object-keys": "1.1.1"
 			}
 		},
 		"define-property": {
@@ -4123,8 +4123,8 @@
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
 			"dev": true,
 			"requires": {
-				"is-descriptor": "^1.0.2",
-				"isobject": "^3.0.1"
+				"is-descriptor": "1.0.2",
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"is-accessor-descriptor": {
@@ -4133,7 +4133,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -4142,7 +4142,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -4151,9 +4151,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				}
 			}
@@ -4163,13 +4163,13 @@
 			"resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
 			"integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
 			"requires": {
-				"@types/glob": "^7.1.1",
-				"globby": "^6.1.0",
-				"is-path-cwd": "^2.0.0",
-				"is-path-in-cwd": "^2.0.0",
-				"p-map": "^2.0.0",
-				"pify": "^4.0.1",
-				"rimraf": "^2.6.3"
+				"@types/glob": "7.1.1",
+				"globby": "6.1.0",
+				"is-path-cwd": "2.2.0",
+				"is-path-in-cwd": "2.1.0",
+				"p-map": "2.1.0",
+				"pify": "4.0.1",
+				"rimraf": "2.6.3"
 			}
 		},
 		"delayed-stream": {
@@ -4190,8 +4190,8 @@
 			"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0"
+				"inherits": "2.0.4",
+				"minimalistic-assert": "1.0.1"
 			}
 		},
 		"detect-file": {
@@ -4218,9 +4218,9 @@
 			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.1.0",
-				"miller-rabin": "^4.0.0",
-				"randombytes": "^2.0.0"
+				"bn.js": "4.11.8",
+				"miller-rabin": "4.0.1",
+				"randombytes": "2.1.0"
 			}
 		},
 		"dir-glob": {
@@ -4229,7 +4229,7 @@
 			"integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
 			"dev": true,
 			"requires": {
-				"path-type": "^3.0.0"
+				"path-type": "3.0.0"
 			}
 		},
 		"dlv": {
@@ -4243,18 +4243,18 @@
 			"resolved": "https://registry.npmjs.org/dmd/-/dmd-4.0.0.tgz",
 			"integrity": "sha512-J+4CgbQiMuJHiU9dvTVN8iOOZGeR3bef1wBqz6eVvvX17jkpkKVd8TeeutA/FJAeFbLQfXnyQ3o4qY7W+c5cxQ==",
 			"requires": {
-				"array-back": "^3.1.0",
-				"cache-point": "^0.4.1",
-				"common-sequence": "^1.0.2",
-				"file-set": "^2.0.0",
-				"handlebars": "^4.1.2",
-				"marked": "^0.6.2",
-				"object-get": "^2.1.0",
-				"reduce-flatten": "^2.0.0",
-				"reduce-unique": "^2.0.1",
-				"reduce-without": "^1.0.1",
-				"test-value": "^3.0.0",
-				"walk-back": "^3.0.1"
+				"array-back": "3.1.0",
+				"cache-point": "0.4.1",
+				"common-sequence": "1.0.2",
+				"file-set": "2.0.1",
+				"handlebars": "4.1.2",
+				"marked": "0.6.3",
+				"object-get": "2.1.0",
+				"reduce-flatten": "2.0.0",
+				"reduce-unique": "2.0.1",
+				"reduce-without": "1.0.1",
+				"test-value": "3.0.0",
+				"walk-back": "3.0.1"
 			},
 			"dependencies": {
 				"reduce-flatten": {
@@ -4270,7 +4270,7 @@
 			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
 			"dev": true,
 			"requires": {
-				"esutils": "^2.0.2"
+				"esutils": "2.0.2"
 			}
 		},
 		"dom-event-types": {
@@ -4284,8 +4284,8 @@
 			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
 			"integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
 			"requires": {
-				"domelementtype": "^1.3.0",
-				"entities": "^1.1.1"
+				"domelementtype": "1.3.1",
+				"entities": "1.1.2"
 			}
 		},
 		"domain-browser": {
@@ -4305,7 +4305,7 @@
 			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
 			"dev": true,
 			"requires": {
-				"webidl-conversions": "^4.0.2"
+				"webidl-conversions": "4.0.2"
 			}
 		},
 		"domhandler": {
@@ -4313,7 +4313,7 @@
 			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
 			"integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
 			"requires": {
-				"domelementtype": "1"
+				"domelementtype": "1.3.1"
 			}
 		},
 		"domutils": {
@@ -4321,8 +4321,8 @@
 			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
 			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
 			"requires": {
-				"dom-serializer": "0",
-				"domelementtype": "1"
+				"dom-serializer": "0.1.1",
+				"domelementtype": "1.3.1"
 			}
 		},
 		"dot-prop": {
@@ -4331,7 +4331,7 @@
 			"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
 			"dev": true,
 			"requires": {
-				"is-obj": "^1.0.0"
+				"is-obj": "1.0.1"
 			}
 		},
 		"duplexify": {
@@ -4340,10 +4340,10 @@
 			"integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
 			"dev": true,
 			"requires": {
-				"end-of-stream": "^1.0.0",
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.0",
-				"stream-shift": "^1.0.0"
+				"end-of-stream": "1.4.1",
+				"inherits": "2.0.4",
+				"readable-stream": "2.3.6",
+				"stream-shift": "1.0.0"
 			},
 			"dependencies": {
 				"readable-stream": {
@@ -4352,13 +4352,13 @@
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.4",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.1",
+						"safe-buffer": "5.1.2",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"string_decoder": {
@@ -4367,7 +4367,7 @@
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "5.1.2"
 					}
 				}
 			}
@@ -4378,8 +4378,8 @@
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
 			"dev": true,
 			"requires": {
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.1.0"
+				"jsbn": "0.1.1",
+				"safer-buffer": "2.1.2"
 			}
 		},
 		"editorconfig": {
@@ -4388,10 +4388,10 @@
 			"integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
 			"dev": true,
 			"requires": {
-				"commander": "^2.19.0",
-				"lru-cache": "^4.1.5",
-				"semver": "^5.6.0",
-				"sigmund": "^1.0.1"
+				"commander": "2.20.0",
+				"lru-cache": "4.1.5",
+				"semver": "5.7.0",
+				"sigmund": "1.0.1"
 			}
 		},
 		"electron-to-chromium": {
@@ -4406,13 +4406,13 @@
 			"integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.4.0",
-				"brorand": "^1.0.1",
-				"hash.js": "^1.0.0",
-				"hmac-drbg": "^1.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.0"
+				"bn.js": "4.11.8",
+				"brorand": "1.1.0",
+				"hash.js": "1.1.7",
+				"hmac-drbg": "1.0.1",
+				"inherits": "2.0.4",
+				"minimalistic-assert": "1.0.1",
+				"minimalistic-crypto-utils": "1.0.1"
 			}
 		},
 		"emoji-regex": {
@@ -4431,7 +4431,7 @@
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
 			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
 			"requires": {
-				"once": "^1.4.0"
+				"once": "1.4.0"
 			}
 		},
 		"enhanced-resolve": {
@@ -4440,9 +4440,9 @@
 			"integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"memory-fs": "^0.4.0",
-				"tapable": "^1.0.0"
+				"graceful-fs": "4.2.0",
+				"memory-fs": "0.4.1",
+				"tapable": "1.1.3"
 			}
 		},
 		"entities": {
@@ -4456,7 +4456,7 @@
 			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
 			"dev": true,
 			"requires": {
-				"prr": "~1.0.1"
+				"prr": "1.0.1"
 			}
 		},
 		"error-ex": {
@@ -4465,7 +4465,7 @@
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
 			"dev": true,
 			"requires": {
-				"is-arrayish": "^0.2.1"
+				"is-arrayish": "0.2.1"
 			}
 		},
 		"es-abstract": {
@@ -4474,12 +4474,12 @@
 			"integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
 			"dev": true,
 			"requires": {
-				"es-to-primitive": "^1.2.0",
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3",
-				"is-callable": "^1.1.4",
-				"is-regex": "^1.0.4",
-				"object-keys": "^1.0.12"
+				"es-to-primitive": "1.2.0",
+				"function-bind": "1.1.1",
+				"has": "1.0.3",
+				"is-callable": "1.1.4",
+				"is-regex": "1.0.4",
+				"object-keys": "1.1.1"
 			}
 		},
 		"es-to-primitive": {
@@ -4488,9 +4488,9 @@
 			"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
 			"dev": true,
 			"requires": {
-				"is-callable": "^1.1.4",
-				"is-date-object": "^1.0.1",
-				"is-symbol": "^1.0.2"
+				"is-callable": "1.1.4",
+				"is-date-object": "1.0.1",
+				"is-symbol": "1.0.2"
 			}
 		},
 		"escape-string-regexp": {
@@ -4504,11 +4504,11 @@
 			"integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
 			"dev": true,
 			"requires": {
-				"esprima": "^3.1.3",
-				"estraverse": "^4.2.0",
-				"esutils": "^2.0.2",
-				"optionator": "^0.8.1",
-				"source-map": "~0.6.1"
+				"esprima": "3.1.3",
+				"estraverse": "4.2.0",
+				"esutils": "2.0.2",
+				"optionator": "0.8.2",
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
 				"esprima": {
@@ -4525,42 +4525,42 @@
 			"integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"ajv": "^6.9.1",
-				"chalk": "^2.1.0",
-				"cross-spawn": "^6.0.5",
-				"debug": "^4.0.1",
-				"doctrine": "^3.0.0",
-				"eslint-scope": "^4.0.3",
-				"eslint-utils": "^1.3.1",
-				"eslint-visitor-keys": "^1.0.0",
-				"espree": "^5.0.1",
-				"esquery": "^1.0.1",
-				"esutils": "^2.0.2",
-				"file-entry-cache": "^5.0.1",
-				"functional-red-black-tree": "^1.0.1",
-				"glob": "^7.1.2",
-				"globals": "^11.7.0",
-				"ignore": "^4.0.6",
-				"import-fresh": "^3.0.0",
-				"imurmurhash": "^0.1.4",
-				"inquirer": "^6.2.2",
-				"js-yaml": "^3.13.0",
-				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"levn": "^0.3.0",
-				"lodash": "^4.17.11",
-				"minimatch": "^3.0.4",
-				"mkdirp": "^0.5.1",
-				"natural-compare": "^1.4.0",
-				"optionator": "^0.8.2",
-				"path-is-inside": "^1.0.2",
-				"progress": "^2.0.0",
-				"regexpp": "^2.0.1",
-				"semver": "^5.5.1",
-				"strip-ansi": "^4.0.0",
-				"strip-json-comments": "^2.0.1",
-				"table": "^5.2.3",
-				"text-table": "^0.2.0"
+				"@babel/code-frame": "7.0.0",
+				"ajv": "6.10.2",
+				"chalk": "2.4.2",
+				"cross-spawn": "6.0.5",
+				"debug": "4.1.1",
+				"doctrine": "3.0.0",
+				"eslint-scope": "4.0.3",
+				"eslint-utils": "1.4.0",
+				"eslint-visitor-keys": "1.0.0",
+				"espree": "5.0.1",
+				"esquery": "1.0.1",
+				"esutils": "2.0.2",
+				"file-entry-cache": "5.0.1",
+				"functional-red-black-tree": "1.0.1",
+				"glob": "7.1.4",
+				"globals": "11.12.0",
+				"ignore": "4.0.6",
+				"import-fresh": "3.1.0",
+				"imurmurhash": "0.1.4",
+				"inquirer": "6.5.0",
+				"js-yaml": "3.13.1",
+				"json-stable-stringify-without-jsonify": "1.0.1",
+				"levn": "0.3.0",
+				"lodash": "4.17.14",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"optionator": "0.8.2",
+				"path-is-inside": "1.0.2",
+				"progress": "2.0.3",
+				"regexpp": "2.0.1",
+				"semver": "5.7.0",
+				"strip-ansi": "4.0.0",
+				"strip-json-comments": "2.0.1",
+				"table": "5.4.1",
+				"text-table": "0.2.0"
 			},
 			"dependencies": {
 				"acorn-jsx": {
@@ -4581,7 +4581,7 @@
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"eslint-scope": {
@@ -4590,8 +4590,8 @@
 					"integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
 					"dev": true,
 					"requires": {
-						"esrecurse": "^4.1.0",
-						"estraverse": "^4.1.1"
+						"esrecurse": "4.2.1",
+						"estraverse": "4.2.0"
 					}
 				},
 				"espree": {
@@ -4600,9 +4600,9 @@
 					"integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
 					"dev": true,
 					"requires": {
-						"acorn": "^6.0.7",
-						"acorn-jsx": "^5.0.0",
-						"eslint-visitor-keys": "^1.0.0"
+						"acorn": "6.2.0",
+						"acorn-jsx": "5.0.1",
+						"eslint-visitor-keys": "1.0.0"
 					}
 				},
 				"ms": {
@@ -4617,7 +4617,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				},
 				"strip-json-comments": {
@@ -4640,12 +4640,12 @@
 			"integrity": "sha1-J9UE3IN/fK3b8gGy6EpO5zC6Pvo=",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
+				"chalk": "2.4.2",
 				"coalescy": "1.0.0",
-				"extend": "^3.0.0",
-				"minimist": "^1.2.0",
-				"strip-ansi": "^4.0.0",
-				"text-table": "^0.2.0"
+				"extend": "3.0.2",
+				"minimist": "1.2.0",
+				"strip-ansi": "4.0.0",
+				"text-table": "0.2.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -4666,7 +4666,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				}
 			}
@@ -4677,8 +4677,8 @@
 			"integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
 			"dev": true,
 			"requires": {
-				"debug": "^2.6.9",
-				"resolve": "^1.5.0"
+				"debug": "2.6.9",
+				"resolve": "1.11.1"
 			},
 			"dependencies": {
 				"debug": {
@@ -4698,11 +4698,11 @@
 			"integrity": "sha512-RLgV9hoCVsMLvOxCuNjdqOrUqIj9oJg8hF44vzJaYqsAHuY9G2YAeN3joQ9nxP0p5Th9iFSIpKo+SD8KISxXRg==",
 			"dev": true,
 			"requires": {
-				"loader-fs-cache": "^1.0.0",
-				"loader-utils": "^1.0.2",
-				"object-assign": "^4.0.1",
-				"object-hash": "^1.1.4",
-				"rimraf": "^2.6.1"
+				"loader-fs-cache": "1.0.2",
+				"loader-utils": "1.2.3",
+				"object-assign": "4.1.1",
+				"object-hash": "1.3.1",
+				"rimraf": "2.6.3"
 			}
 		},
 		"eslint-module-utils": {
@@ -4711,8 +4711,8 @@
 			"integrity": "sha512-H6DOj+ejw7Tesdgbfs4jeS4YMFrT8uI8xwd1gtQqXssaR0EQ26L+2O/w6wkYFy2MymON0fTwHmXBvvfLNZVZEw==",
 			"dev": true,
 			"requires": {
-				"debug": "^2.6.8",
-				"pkg-dir": "^2.0.0"
+				"debug": "2.6.9",
+				"pkg-dir": "2.0.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -4730,7 +4730,7 @@
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"locate-path": "^2.0.0"
+						"locate-path": "2.0.0"
 					}
 				},
 				"locate-path": {
@@ -4739,8 +4739,8 @@
 					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 					"dev": true,
 					"requires": {
-						"p-locate": "^2.0.0",
-						"path-exists": "^3.0.0"
+						"p-locate": "2.0.0",
+						"path-exists": "3.0.0"
 					}
 				},
 				"p-limit": {
@@ -4749,7 +4749,7 @@
 					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
 					"dev": true,
 					"requires": {
-						"p-try": "^1.0.0"
+						"p-try": "1.0.0"
 					}
 				},
 				"p-locate": {
@@ -4758,7 +4758,7 @@
 					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 					"dev": true,
 					"requires": {
-						"p-limit": "^1.1.0"
+						"p-limit": "1.3.0"
 					}
 				},
 				"p-try": {
@@ -4773,7 +4773,7 @@
 					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 					"dev": true,
 					"requires": {
-						"find-up": "^2.1.0"
+						"find-up": "2.1.0"
 					}
 				}
 			}
@@ -4784,8 +4784,8 @@
 			"integrity": "sha512-XfFmgFdIUDgvaRAlaXUkxrRg5JSADoRC8IkKLc/cISeR3yHVMefFHQZpcyXXEUUPHfy5DwviBcrfqlyqEwlQVw==",
 			"dev": true,
 			"requires": {
-				"eslint-utils": "^1.3.0",
-				"regexpp": "^2.0.1"
+				"eslint-utils": "1.4.0",
+				"regexpp": "2.0.1"
 			}
 		},
 		"eslint-plugin-import": {
@@ -4794,17 +4794,17 @@
 			"integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
 			"dev": true,
 			"requires": {
-				"array-includes": "^3.0.3",
-				"contains-path": "^0.1.0",
-				"debug": "^2.6.9",
+				"array-includes": "3.0.3",
+				"contains-path": "0.1.0",
+				"debug": "2.6.9",
 				"doctrine": "1.5.0",
-				"eslint-import-resolver-node": "^0.3.2",
-				"eslint-module-utils": "^2.4.0",
-				"has": "^1.0.3",
-				"minimatch": "^3.0.4",
-				"object.values": "^1.1.0",
-				"read-pkg-up": "^2.0.0",
-				"resolve": "^1.11.0"
+				"eslint-import-resolver-node": "0.3.2",
+				"eslint-module-utils": "2.4.1",
+				"has": "1.0.3",
+				"minimatch": "3.0.4",
+				"object.values": "1.1.0",
+				"read-pkg-up": "2.0.0",
+				"resolve": "1.11.1"
 			},
 			"dependencies": {
 				"debug": {
@@ -4822,8 +4822,8 @@
 					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
 					"dev": true,
 					"requires": {
-						"esutils": "^2.0.2",
-						"isarray": "^1.0.0"
+						"esutils": "2.0.2",
+						"isarray": "1.0.0"
 					}
 				},
 				"find-up": {
@@ -4832,7 +4832,7 @@
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"locate-path": "^2.0.0"
+						"locate-path": "2.0.0"
 					}
 				},
 				"load-json-file": {
@@ -4841,10 +4841,10 @@
 					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"strip-bom": "^3.0.0"
+						"graceful-fs": "4.2.0",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"strip-bom": "3.0.0"
 					}
 				},
 				"locate-path": {
@@ -4853,8 +4853,8 @@
 					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 					"dev": true,
 					"requires": {
-						"p-locate": "^2.0.0",
-						"path-exists": "^3.0.0"
+						"p-locate": "2.0.0",
+						"path-exists": "3.0.0"
 					}
 				},
 				"p-limit": {
@@ -4863,7 +4863,7 @@
 					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
 					"dev": true,
 					"requires": {
-						"p-try": "^1.0.0"
+						"p-try": "1.0.0"
 					}
 				},
 				"p-locate": {
@@ -4872,7 +4872,7 @@
 					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 					"dev": true,
 					"requires": {
-						"p-limit": "^1.1.0"
+						"p-limit": "1.3.0"
 					}
 				},
 				"p-try": {
@@ -4887,7 +4887,7 @@
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 					"dev": true,
 					"requires": {
-						"error-ex": "^1.2.0"
+						"error-ex": "1.3.2"
 					}
 				},
 				"path-type": {
@@ -4896,7 +4896,7 @@
 					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
 					"dev": true,
 					"requires": {
-						"pify": "^2.0.0"
+						"pify": "2.3.0"
 					}
 				},
 				"pify": {
@@ -4911,9 +4911,9 @@
 					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "^2.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^2.0.0"
+						"load-json-file": "2.0.0",
+						"normalize-package-data": "2.5.0",
+						"path-type": "2.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -4922,8 +4922,8 @@
 					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
 					"dev": true,
 					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^2.0.0"
+						"find-up": "2.1.0",
+						"read-pkg": "2.0.0"
 					}
 				}
 			}
@@ -4934,12 +4934,12 @@
 			"integrity": "sha512-ZwQYGm6EoV2cfLpE1wxJWsfnKUIXfM/KM09/TlorkukgCAwmkgajEJnPCmyzoFPQQkmvo5DrW/nyKutNIw36Mw==",
 			"dev": true,
 			"requires": {
-				"eslint-plugin-es": "^1.4.0",
-				"eslint-utils": "^1.3.1",
-				"ignore": "^5.1.1",
-				"minimatch": "^3.0.4",
-				"resolve": "^1.10.1",
-				"semver": "^6.1.0"
+				"eslint-plugin-es": "1.4.0",
+				"eslint-utils": "1.4.0",
+				"ignore": "5.1.2",
+				"minimatch": "3.0.4",
+				"resolve": "1.11.1",
+				"semver": "6.2.0"
 			},
 			"dependencies": {
 				"ignore": {
@@ -4974,7 +4974,7 @@
 			"integrity": "sha512-mGwMqbbJf0+VvpGR5Lllq0PMxvTdrZ/ZPjmhkacrCHbubJeJOt+T6E3HUzAifa2Mxi7RSdJfC9HFpOeSYVMMIw==",
 			"dev": true,
 			"requires": {
-				"vue-eslint-parser": "^5.0.0"
+				"vue-eslint-parser": "5.0.0"
 			}
 		},
 		"eslint-scope": {
@@ -4983,8 +4983,8 @@
 			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
 			"dev": true,
 			"requires": {
-				"esrecurse": "^4.1.0",
-				"estraverse": "^4.1.1"
+				"esrecurse": "4.2.1",
+				"estraverse": "4.2.0"
 			}
 		},
 		"eslint-utils": {
@@ -4993,7 +4993,7 @@
 			"integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
 			"dev": true,
 			"requires": {
-				"eslint-visitor-keys": "^1.0.0"
+				"eslint-visitor-keys": "1.0.0"
 			}
 		},
 		"eslint-visitor-keys": {
@@ -5007,8 +5007,8 @@
 			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
 			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
 			"requires": {
-				"acorn": "^5.5.0",
-				"acorn-jsx": "^3.0.0"
+				"acorn": "5.7.3",
+				"acorn-jsx": "3.0.1"
 			},
 			"dependencies": {
 				"acorn": {
@@ -5029,7 +5029,7 @@
 			"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
 			"dev": true,
 			"requires": {
-				"estraverse": "^4.0.0"
+				"estraverse": "4.2.0"
 			}
 		},
 		"esrecurse": {
@@ -5038,7 +5038,7 @@
 			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
 			"dev": true,
 			"requires": {
-				"estraverse": "^4.1.0"
+				"estraverse": "4.2.0"
 			}
 		},
 		"estraverse": {
@@ -5065,8 +5065,8 @@
 			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
 			"dev": true,
 			"requires": {
-				"md5.js": "^1.3.4",
-				"safe-buffer": "^5.1.1"
+				"md5.js": "1.3.5",
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"exec-sh": {
@@ -5080,13 +5080,13 @@
 			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
 			"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
 			"requires": {
-				"cross-spawn": "^6.0.0",
-				"get-stream": "^4.0.0",
-				"is-stream": "^1.1.0",
-				"npm-run-path": "^2.0.0",
-				"p-finally": "^1.0.0",
-				"signal-exit": "^3.0.0",
-				"strip-eof": "^1.0.0"
+				"cross-spawn": "6.0.5",
+				"get-stream": "4.1.0",
+				"is-stream": "1.1.0",
+				"npm-run-path": "2.0.2",
+				"p-finally": "1.0.0",
+				"signal-exit": "3.0.2",
+				"strip-eof": "1.0.0"
 			}
 		},
 		"execall": {
@@ -5095,7 +5095,7 @@
 			"integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
 			"dev": true,
 			"requires": {
-				"clone-regexp": "^1.0.0"
+				"clone-regexp": "1.0.1"
 			}
 		},
 		"exit": {
@@ -5110,13 +5110,13 @@
 			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 			"dev": true,
 			"requires": {
-				"debug": "^2.3.3",
-				"define-property": "^0.2.5",
-				"extend-shallow": "^2.0.1",
-				"posix-character-classes": "^0.1.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
+				"debug": "2.6.9",
+				"define-property": "0.2.5",
+				"extend-shallow": "2.0.1",
+				"posix-character-classes": "0.1.1",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
 			},
 			"dependencies": {
 				"debug": {
@@ -5134,7 +5134,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"extend-shallow": {
@@ -5143,7 +5143,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -5154,7 +5154,7 @@
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"dev": true,
 			"requires": {
-				"fill-range": "^2.1.0"
+				"fill-range": "2.2.4"
 			},
 			"dependencies": {
 				"fill-range": {
@@ -5163,11 +5163,11 @@
 					"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
 					"dev": true,
 					"requires": {
-						"is-number": "^2.1.0",
-						"isobject": "^2.0.0",
-						"randomatic": "^3.0.0",
-						"repeat-element": "^1.1.2",
-						"repeat-string": "^1.5.2"
+						"is-number": "2.1.0",
+						"isobject": "2.1.0",
+						"randomatic": "3.1.1",
+						"repeat-element": "1.1.3",
+						"repeat-string": "1.6.1"
 					}
 				},
 				"is-buffer": {
@@ -5182,7 +5182,7 @@
 					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					}
 				},
 				"isobject": {
@@ -5200,7 +5200,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -5211,7 +5211,7 @@
 			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
 			"dev": true,
 			"requires": {
-				"homedir-polyfill": "^1.0.1"
+				"homedir-polyfill": "1.0.3"
 			}
 		},
 		"expect": {
@@ -5220,12 +5220,12 @@
 			"integrity": "sha512-/zYvP8iMDrzaaxHVa724eJBCKqSHmO0FA7EDkBiRHxg6OipmMn1fN+C8T9L9K8yr7UONkOifu6+LLH+z76CnaA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
-				"ansi-styles": "^3.2.0",
-				"jest-get-type": "^24.8.0",
-				"jest-matcher-utils": "^24.8.0",
-				"jest-message-util": "^24.8.0",
-				"jest-regex-util": "^24.3.0"
+				"@jest/types": "24.8.0",
+				"ansi-styles": "3.2.1",
+				"jest-get-type": "24.8.0",
+				"jest-matcher-utils": "24.8.0",
+				"jest-message-util": "24.8.0",
+				"jest-regex-util": "24.3.0"
 			}
 		},
 		"extend": {
@@ -5239,8 +5239,8 @@
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 			"dev": true,
 			"requires": {
-				"assign-symbols": "^1.0.0",
-				"is-extendable": "^1.0.1"
+				"assign-symbols": "1.0.0",
+				"is-extendable": "1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -5249,7 +5249,7 @@
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
-						"is-plain-object": "^2.0.4"
+						"is-plain-object": "2.0.4"
 					}
 				}
 			}
@@ -5260,9 +5260,9 @@
 			"integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
 			"dev": true,
 			"requires": {
-				"chardet": "^0.7.0",
-				"iconv-lite": "^0.4.24",
-				"tmp": "^0.0.33"
+				"chardet": "0.7.0",
+				"iconv-lite": "0.4.24",
+				"tmp": "0.0.33"
 			}
 		},
 		"extglob": {
@@ -5271,14 +5271,14 @@
 			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 			"dev": true,
 			"requires": {
-				"array-unique": "^0.3.2",
-				"define-property": "^1.0.0",
-				"expand-brackets": "^2.1.4",
-				"extend-shallow": "^2.0.1",
-				"fragment-cache": "^0.2.1",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
+				"array-unique": "0.3.2",
+				"define-property": "1.0.0",
+				"expand-brackets": "2.1.4",
+				"extend-shallow": "2.0.1",
+				"fragment-cache": "0.2.1",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -5287,7 +5287,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				},
 				"extend-shallow": {
@@ -5296,7 +5296,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -5305,7 +5305,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -5314,7 +5314,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -5323,9 +5323,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				}
 			}
@@ -5336,7 +5336,7 @@
 			"integrity": "sha1-HqffLnx8brmSL6COitrqSG9vj5I=",
 			"dev": true,
 			"requires": {
-				"css": "^2.1.0"
+				"css": "2.2.4"
 			}
 		},
 		"extsprintf": {
@@ -5369,7 +5369,7 @@
 			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
 			"dev": true,
 			"requires": {
-				"bser": "^2.0.0"
+				"bser": "2.1.0"
 			}
 		},
 		"fecha": {
@@ -5389,7 +5389,7 @@
 			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "^1.0.5"
+				"escape-string-regexp": "1.0.5"
 			}
 		},
 		"file-entry-cache": {
@@ -5398,7 +5398,7 @@
 			"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
 			"dev": true,
 			"requires": {
-				"flat-cache": "^2.0.1"
+				"flat-cache": "2.0.1"
 			}
 		},
 		"file-loader": {
@@ -5407,8 +5407,8 @@
 			"integrity": "sha512-ajDk1nlByoalZAGR4b0H6oD+EGlWnyW1qbSxzaUc7RFiqmn+RbXQQRbTc72jsiUIlVusJ4Et58ltds8ZwTfnAw==",
 			"dev": true,
 			"requires": {
-				"loader-utils": "^1.2.3",
-				"schema-utils": "^2.0.0"
+				"loader-utils": "1.2.3",
+				"schema-utils": "2.0.1"
 			},
 			"dependencies": {
 				"schema-utils": {
@@ -5417,8 +5417,8 @@
 					"integrity": "sha512-HJFKJ4JixDpRur06QHwi8uu2kZbng318ahWEKgBjc0ZklcE4FDvmm2wghb448q0IRaABxIESt8vqPFvwgMB80A==",
 					"dev": true,
 					"requires": {
-						"ajv": "^6.1.0",
-						"ajv-keywords": "^3.1.0"
+						"ajv": "6.10.2",
+						"ajv-keywords": "3.4.1"
 					}
 				}
 			}
@@ -5428,8 +5428,8 @@
 			"resolved": "https://registry.npmjs.org/file-set/-/file-set-2.0.1.tgz",
 			"integrity": "sha512-XgOUUpgR6FbbfYcniLw0qm1Am7PnNYIAkd+eXxRt42LiYhjaso0WiuQ+VmrNdtwotyM+cLCfZ56AZrySP3QnKA==",
 			"requires": {
-				"array-back": "^2.0.0",
-				"glob": "^7.1.3"
+				"array-back": "2.0.0",
+				"glob": "7.1.4"
 			},
 			"dependencies": {
 				"array-back": {
@@ -5437,7 +5437,7 @@
 					"resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
 					"integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
 					"requires": {
-						"typical": "^2.6.1"
+						"typical": "2.6.1"
 					}
 				}
 			}
@@ -5453,7 +5453,7 @@
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
 			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
 			"requires": {
-				"to-regex-range": "^5.0.1"
+				"to-regex-range": "5.0.1"
 			}
 		},
 		"find-babel-config": {
@@ -5462,8 +5462,8 @@
 			"integrity": "sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==",
 			"dev": true,
 			"requires": {
-				"json5": "^0.5.1",
-				"path-exists": "^3.0.0"
+				"json5": "0.5.1",
+				"path-exists": "3.0.0"
 			},
 			"dependencies": {
 				"json5": {
@@ -5480,9 +5480,9 @@
 			"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
 			"dev": true,
 			"requires": {
-				"commondir": "^1.0.1",
-				"make-dir": "^2.0.0",
-				"pkg-dir": "^3.0.0"
+				"commondir": "1.0.1",
+				"make-dir": "2.1.0",
+				"pkg-dir": "3.0.0"
 			}
 		},
 		"find-replace": {
@@ -5490,7 +5490,7 @@
 			"resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
 			"integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
 			"requires": {
-				"array-back": "^3.0.1"
+				"array-back": "3.1.0"
 			}
 		},
 		"find-up": {
@@ -5498,7 +5498,7 @@
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
 			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 			"requires": {
-				"locate-path": "^3.0.0"
+				"locate-path": "3.0.0"
 			}
 		},
 		"findup-sync": {
@@ -5507,10 +5507,10 @@
 			"integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
 			"dev": true,
 			"requires": {
-				"detect-file": "^1.0.0",
-				"is-glob": "^4.0.0",
-				"micromatch": "^3.0.4",
-				"resolve-dir": "^1.0.1"
+				"detect-file": "1.0.0",
+				"is-glob": "4.0.1",
+				"micromatch": "3.1.10",
+				"resolve-dir": "1.0.1"
 			},
 			"dependencies": {
 				"braces": {
@@ -5519,16 +5519,16 @@
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.3",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -5537,7 +5537,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -5548,10 +5548,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -5560,7 +5560,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -5583,7 +5583,7 @@
 					"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^2.1.1"
+						"is-extglob": "2.1.1"
 					}
 				},
 				"is-number": {
@@ -5592,7 +5592,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -5601,7 +5601,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -5612,19 +5612,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.13",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					}
 				},
 				"to-regex-range": {
@@ -5633,8 +5633,8 @@
 					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 					"dev": true,
 					"requires": {
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1"
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1"
 					}
 				}
 			}
@@ -5645,7 +5645,7 @@
 			"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
 			"dev": true,
 			"requires": {
-				"flatted": "^2.0.0",
+				"flatted": "2.0.1",
 				"rimraf": "2.6.3",
 				"write": "1.0.3"
 			}
@@ -5662,8 +5662,8 @@
 			"integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.3",
-				"readable-stream": "^2.3.6"
+				"inherits": "2.0.4",
+				"readable-stream": "2.3.6"
 			},
 			"dependencies": {
 				"readable-stream": {
@@ -5672,13 +5672,13 @@
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.4",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.1",
+						"safe-buffer": "5.1.2",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"string_decoder": {
@@ -5687,7 +5687,7 @@
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "5.1.2"
 					}
 				}
 			}
@@ -5697,7 +5697,7 @@
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
 			"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
 			"requires": {
-				"debug": "=3.1.0"
+				"debug": "3.1.0"
 			}
 		},
 		"for-in": {
@@ -5712,7 +5712,7 @@
 			"integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
 			"dev": true,
 			"requires": {
-				"for-in": "^1.0.1"
+				"for-in": "1.0.2"
 			}
 		},
 		"forever-agent": {
@@ -5727,9 +5727,9 @@
 			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
 			"dev": true,
 			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.6",
-				"mime-types": "^2.1.12"
+				"asynckit": "0.4.0",
+				"combined-stream": "1.0.8",
+				"mime-types": "2.1.24"
 			}
 		},
 		"fragment-cache": {
@@ -5738,7 +5738,7 @@
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
 			"dev": true,
 			"requires": {
-				"map-cache": "^0.2.2"
+				"map-cache": "0.2.2"
 			}
 		},
 		"from2": {
@@ -5747,8 +5747,8 @@
 			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.0"
+				"inherits": "2.0.4",
+				"readable-stream": "2.3.6"
 			},
 			"dependencies": {
 				"readable-stream": {
@@ -5757,13 +5757,13 @@
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.4",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.1",
+						"safe-buffer": "5.1.2",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"string_decoder": {
@@ -5772,7 +5772,7 @@
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "5.1.2"
 					}
 				}
 			}
@@ -5782,7 +5782,7 @@
 			"resolved": "https://registry.npmjs.org/front-matter/-/front-matter-3.0.2.tgz",
 			"integrity": "sha512-iBGZaWyzqgsrPGsqrXZP6N4hp5FzSKDi18nfAoYpgz3qK5sAwFv/ojmn3VS60SOgLvq6CtojNqy0y6ZNz05IzQ==",
 			"requires": {
-				"js-yaml": "^3.13.1"
+				"js-yaml": "3.13.1"
 			}
 		},
 		"fs-then-native": {
@@ -5796,10 +5796,10 @@
 			"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"iferr": "^0.1.5",
-				"imurmurhash": "^0.1.4",
-				"readable-stream": "1 || 2"
+				"graceful-fs": "4.2.0",
+				"iferr": "0.1.5",
+				"imurmurhash": "0.1.4",
+				"readable-stream": "2.3.6"
 			},
 			"dependencies": {
 				"readable-stream": {
@@ -5808,13 +5808,13 @@
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.4",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.1",
+						"safe-buffer": "5.1.2",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"string_decoder": {
@@ -5823,7 +5823,7 @@
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "5.1.2"
 					}
 				}
 			}
@@ -5845,8 +5845,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"nan": "^2.12.1",
-				"node-pre-gyp": "^0.12.0"
+				"nan": "2.14.0",
+				"node-pre-gyp": "0.12.0"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -6392,10 +6392,10 @@
 			"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"inherits": "~2.0.0",
-				"mkdirp": ">=0.5 0",
-				"rimraf": "2"
+				"graceful-fs": "4.2.0",
+				"inherits": "2.0.4",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.3"
 			}
 		},
 		"function-bind": {
@@ -6415,14 +6415,14 @@
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 			"dev": true,
 			"requires": {
-				"aproba": "^1.0.3",
-				"console-control-strings": "^1.0.0",
-				"has-unicode": "^2.0.0",
-				"object-assign": "^4.1.0",
-				"signal-exit": "^3.0.0",
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wide-align": "^1.1.0"
+				"aproba": "1.2.0",
+				"console-control-strings": "1.1.0",
+				"has-unicode": "2.0.1",
+				"object-assign": "4.1.1",
+				"signal-exit": "3.0.2",
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1",
+				"wide-align": "1.1.3"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -6437,7 +6437,7 @@
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"number-is-nan": "1.0.1"
 					}
 				},
 				"string-width": {
@@ -6446,9 +6446,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				},
 				"strip-ansi": {
@@ -6457,7 +6457,7 @@
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				}
 			}
@@ -6468,7 +6468,7 @@
 			"integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
 			"dev": true,
 			"requires": {
-				"globule": "^1.0.0"
+				"globule": "1.2.1"
 			}
 		},
 		"get-caller-file": {
@@ -6487,7 +6487,7 @@
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
 			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
 			"requires": {
-				"pump": "^3.0.0"
+				"pump": "3.0.0"
 			}
 		},
 		"get-value": {
@@ -6502,7 +6502,7 @@
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0"
+				"assert-plus": "1.0.0"
 			}
 		},
 		"glob": {
@@ -6510,12 +6510,12 @@
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
 			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
 			"requires": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
+				"fs.realpath": "1.0.0",
+				"inflight": "1.0.6",
+				"inherits": "2.0.4",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
 			}
 		},
 		"glob-base": {
@@ -6524,8 +6524,8 @@
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
 			"dev": true,
 			"requires": {
-				"glob-parent": "^2.0.0",
-				"is-glob": "^2.0.0"
+				"glob-parent": "2.0.0",
+				"is-glob": "2.0.1"
 			}
 		},
 		"glob-parent": {
@@ -6534,7 +6534,7 @@
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
 			"dev": true,
 			"requires": {
-				"is-glob": "^2.0.0"
+				"is-glob": "2.0.1"
 			}
 		},
 		"global-modules": {
@@ -6543,7 +6543,7 @@
 			"integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
 			"dev": true,
 			"requires": {
-				"global-prefix": "^3.0.0"
+				"global-prefix": "3.0.0"
 			},
 			"dependencies": {
 				"global-prefix": {
@@ -6552,9 +6552,9 @@
 					"integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
 					"dev": true,
 					"requires": {
-						"ini": "^1.3.5",
-						"kind-of": "^6.0.2",
-						"which": "^1.3.1"
+						"ini": "1.3.5",
+						"kind-of": "6.0.2",
+						"which": "1.3.1"
 					}
 				}
 			}
@@ -6565,11 +6565,11 @@
 			"integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
 			"dev": true,
 			"requires": {
-				"expand-tilde": "^2.0.2",
-				"homedir-polyfill": "^1.0.1",
-				"ini": "^1.3.4",
-				"is-windows": "^1.0.1",
-				"which": "^1.2.14"
+				"expand-tilde": "2.0.2",
+				"homedir-polyfill": "1.0.3",
+				"ini": "1.3.5",
+				"is-windows": "1.0.2",
+				"which": "1.3.1"
 			}
 		},
 		"globals": {
@@ -6583,11 +6583,11 @@
 			"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
 			"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 			"requires": {
-				"array-union": "^1.0.1",
-				"glob": "^7.0.3",
-				"object-assign": "^4.0.1",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
+				"array-union": "1.0.2",
+				"glob": "7.1.4",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
 			},
 			"dependencies": {
 				"pify": {
@@ -6609,9 +6609,9 @@
 			"integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
 			"dev": true,
 			"requires": {
-				"glob": "~7.1.1",
-				"lodash": "~4.17.10",
-				"minimatch": "~3.0.2"
+				"glob": "7.1.4",
+				"lodash": "4.17.14",
+				"minimatch": "3.0.4"
 			}
 		},
 		"gonzales-pe": {
@@ -6620,7 +6620,7 @@
 			"integrity": "sha512-v0Ts/8IsSbh9n1OJRnSfa7Nlxi4AkXIsWB6vPept8FDbL4bXn3FNuxjYtO/nmBGu7GDkL9MFeGebeSu6l55EPQ==",
 			"dev": true,
 			"requires": {
-				"minimist": "1.1.x"
+				"minimist": "1.1.3"
 			},
 			"dependencies": {
 				"minimist": {
@@ -6652,10 +6652,10 @@
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
 			"integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
 			"requires": {
-				"neo-async": "^2.6.0",
-				"optimist": "^0.6.1",
-				"source-map": "^0.6.1",
-				"uglify-js": "^3.1.4"
+				"neo-async": "2.6.1",
+				"optimist": "0.6.1",
+				"source-map": "0.6.1",
+				"uglify-js": "3.6.0"
 			}
 		},
 		"har-schema": {
@@ -6670,8 +6670,8 @@
 			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
 			"dev": true,
 			"requires": {
-				"ajv": "^6.5.5",
-				"har-schema": "^2.0.0"
+				"ajv": "6.10.2",
+				"har-schema": "2.0.0"
 			}
 		},
 		"has": {
@@ -6679,7 +6679,7 @@
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
 			"requires": {
-				"function-bind": "^1.1.1"
+				"function-bind": "1.1.1"
 			}
 		},
 		"has-ansi": {
@@ -6688,7 +6688,7 @@
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^2.0.0"
+				"ansi-regex": "2.1.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -6722,9 +6722,9 @@
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
 			"dev": true,
 			"requires": {
-				"get-value": "^2.0.6",
-				"has-values": "^1.0.0",
-				"isobject": "^3.0.0"
+				"get-value": "2.0.6",
+				"has-values": "1.0.0",
+				"isobject": "3.0.1"
 			}
 		},
 		"has-values": {
@@ -6733,8 +6733,8 @@
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
 			"dev": true,
 			"requires": {
-				"is-number": "^3.0.0",
-				"kind-of": "^4.0.0"
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
 			},
 			"dependencies": {
 				"is-buffer": {
@@ -6749,7 +6749,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -6758,7 +6758,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -6769,7 +6769,7 @@
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -6780,8 +6780,8 @@
 			"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
+				"inherits": "2.0.4",
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"hash-sum": {
@@ -6796,14 +6796,9 @@
 			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.3",
-				"minimalistic-assert": "^1.0.1"
+				"inherits": "2.0.4",
+				"minimalistic-assert": "1.0.1"
 			}
-		},
-		"hashtag-regex": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/hashtag-regex/-/hashtag-regex-2.0.0.tgz",
-			"integrity": "sha512-6qWo1g10ggwyorTjMEswX/z8DkODD1XnfjBjndIAj7rnUOgVlwYQz4UPQU9yBz2jBGd3Im1D1wlzzI/o6Q1Ptw=="
 		},
 		"he": {
 			"version": "1.2.0",
@@ -6817,9 +6812,9 @@
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
 			"dev": true,
 			"requires": {
-				"hash.js": "^1.0.3",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.1"
+				"hash.js": "1.1.7",
+				"minimalistic-assert": "1.0.1",
+				"minimalistic-crypto-utils": "1.0.1"
 			}
 		},
 		"homedir-polyfill": {
@@ -6828,7 +6823,7 @@
 			"integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
 			"dev": true,
 			"requires": {
-				"parse-passwd": "^1.0.0"
+				"parse-passwd": "1.0.0"
 			}
 		},
 		"hosted-git-info": {
@@ -6843,7 +6838,7 @@
 			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
 			"dev": true,
 			"requires": {
-				"whatwg-encoding": "^1.0.1"
+				"whatwg-encoding": "1.0.5"
 			}
 		},
 		"html-tags": {
@@ -6857,12 +6852,12 @@
 			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
 			"integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
 			"requires": {
-				"domelementtype": "^1.3.1",
-				"domhandler": "^2.3.0",
-				"domutils": "^1.5.1",
-				"entities": "^1.1.1",
-				"inherits": "^2.0.1",
-				"readable-stream": "^3.1.1"
+				"domelementtype": "1.3.1",
+				"domhandler": "2.4.2",
+				"domutils": "1.5.1",
+				"entities": "1.1.2",
+				"inherits": "2.0.4",
+				"readable-stream": "3.4.0"
 			}
 		},
 		"http-signature": {
@@ -6871,9 +6866,9 @@
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
+				"assert-plus": "1.0.0",
+				"jsprim": "1.4.1",
+				"sshpk": "1.16.1"
 			}
 		},
 		"https-browserify": {
@@ -6888,7 +6883,7 @@
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 			"dev": true,
 			"requires": {
-				"safer-buffer": ">= 2.1.2 < 3"
+				"safer-buffer": "2.1.2"
 			}
 		},
 		"icss-utils": {
@@ -6897,7 +6892,7 @@
 			"integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
 			"dev": true,
 			"requires": {
-				"postcss": "^7.0.14"
+				"postcss": "7.0.17"
 			}
 		},
 		"ieee754": {
@@ -6924,8 +6919,8 @@
 			"integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
 			"dev": true,
 			"requires": {
-				"parent-module": "^1.0.0",
-				"resolve-from": "^4.0.0"
+				"parent-module": "1.0.1",
+				"resolve-from": "4.0.0"
 			}
 		},
 		"import-local": {
@@ -6934,8 +6929,8 @@
 			"integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
 			"dev": true,
 			"requires": {
-				"pkg-dir": "^3.0.0",
-				"resolve-cwd": "^2.0.0"
+				"pkg-dir": "3.0.0",
+				"resolve-cwd": "2.0.0"
 			}
 		},
 		"imurmurhash": {
@@ -6956,7 +6951,7 @@
 			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
 			"dev": true,
 			"requires": {
-				"repeating": "^2.0.0"
+				"repeating": "2.0.1"
 			}
 		},
 		"indexes-of": {
@@ -6970,8 +6965,8 @@
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"requires": {
-				"once": "^1.3.0",
-				"wrappy": "1"
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
 			}
 		},
 		"inherits": {
@@ -6991,19 +6986,19 @@
 			"integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "^3.2.0",
-				"chalk": "^2.4.2",
-				"cli-cursor": "^2.1.0",
-				"cli-width": "^2.0.0",
-				"external-editor": "^3.0.3",
-				"figures": "^2.0.0",
-				"lodash": "^4.17.12",
+				"ansi-escapes": "3.2.0",
+				"chalk": "2.4.2",
+				"cli-cursor": "2.1.0",
+				"cli-width": "2.2.0",
+				"external-editor": "3.1.0",
+				"figures": "2.0.0",
+				"lodash": "4.17.14",
 				"mute-stream": "0.0.7",
-				"run-async": "^2.2.0",
-				"rxjs": "^6.4.0",
-				"string-width": "^2.1.0",
-				"strip-ansi": "^5.1.0",
-				"through": "^2.3.6"
+				"run-async": "2.3.0",
+				"rxjs": "6.5.2",
+				"string-width": "2.1.1",
+				"strip-ansi": "5.2.0",
+				"through": "2.3.8"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -7018,8 +7013,8 @@
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
 					},
 					"dependencies": {
 						"strip-ansi": {
@@ -7028,7 +7023,7 @@
 							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 							"dev": true,
 							"requires": {
-								"ansi-regex": "^3.0.0"
+								"ansi-regex": "3.0.0"
 							}
 						}
 					}
@@ -7047,7 +7042,7 @@
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
 			"dev": true,
 			"requires": {
-				"loose-envify": "^1.0.0"
+				"loose-envify": "1.4.0"
 			}
 		},
 		"invert-kv": {
@@ -7061,7 +7056,7 @@
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"is-buffer": {
@@ -7076,7 +7071,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -7096,8 +7091,8 @@
 			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz",
 			"integrity": "sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==",
 			"requires": {
-				"is-alphabetical": "^1.0.0",
-				"is-decimal": "^1.0.0"
+				"is-alphabetical": "1.0.3",
+				"is-decimal": "1.0.3"
 			}
 		},
 		"is-arrayish": {
@@ -7112,7 +7107,7 @@
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
 			"dev": true,
 			"requires": {
-				"binary-extensions": "^1.0.0"
+				"binary-extensions": "1.13.1"
 			}
 		},
 		"is-buffer": {
@@ -7132,7 +7127,7 @@
 			"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
 			"dev": true,
 			"requires": {
-				"ci-info": "^2.0.0"
+				"ci-info": "2.0.0"
 			}
 		},
 		"is-data-descriptor": {
@@ -7141,7 +7136,7 @@
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"is-buffer": {
@@ -7156,7 +7151,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -7178,9 +7173,9 @@
 			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 			"dev": true,
 			"requires": {
-				"is-accessor-descriptor": "^0.1.6",
-				"is-data-descriptor": "^0.1.4",
-				"kind-of": "^5.0.0"
+				"is-accessor-descriptor": "0.1.6",
+				"is-data-descriptor": "0.1.4",
+				"kind-of": "5.1.0"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -7209,7 +7204,7 @@
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
 			"dev": true,
 			"requires": {
-				"is-primitive": "^2.0.0"
+				"is-primitive": "2.0.0"
 			}
 		},
 		"is-extendable": {
@@ -7230,7 +7225,7 @@
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"dev": true,
 			"requires": {
-				"number-is-nan": "^1.0.0"
+				"number-is-nan": "1.0.1"
 			}
 		},
 		"is-fullwidth-code-point": {
@@ -7250,7 +7245,7 @@
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "^1.0.0"
+				"is-extglob": "1.0.0"
 			}
 		},
 		"is-hexadecimal": {
@@ -7279,7 +7274,7 @@
 			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
 			"integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
 			"requires": {
-				"is-path-inside": "^2.1.0"
+				"is-path-inside": "2.1.0"
 			}
 		},
 		"is-path-inside": {
@@ -7287,7 +7282,7 @@
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
 			"integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
 			"requires": {
-				"path-is-inside": "^1.0.2"
+				"path-is-inside": "1.0.2"
 			}
 		},
 		"is-plain-obj": {
@@ -7301,7 +7296,7 @@
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
 			"dev": true,
 			"requires": {
-				"isobject": "^3.0.1"
+				"isobject": "3.0.1"
 			}
 		},
 		"is-posix-bracket": {
@@ -7328,7 +7323,7 @@
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.1"
+				"has": "1.0.3"
 			}
 		},
 		"is-regexp": {
@@ -7354,7 +7349,7 @@
 			"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
 			"dev": true,
 			"requires": {
-				"has-symbols": "^1.0.0"
+				"has-symbols": "1.0.0"
 			}
 		},
 		"is-typedarray": {
@@ -7431,13 +7426,13 @@
 			"integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
 			"dev": true,
 			"requires": {
-				"@babel/generator": "^7.4.0",
-				"@babel/parser": "^7.4.3",
-				"@babel/template": "^7.4.0",
-				"@babel/traverse": "^7.4.3",
-				"@babel/types": "^7.4.0",
-				"istanbul-lib-coverage": "^2.0.5",
-				"semver": "^6.0.0"
+				"@babel/generator": "7.5.0",
+				"@babel/parser": "7.5.0",
+				"@babel/template": "7.4.4",
+				"@babel/traverse": "7.5.0",
+				"@babel/types": "7.5.0",
+				"istanbul-lib-coverage": "2.0.5",
+				"semver": "6.2.0"
 			},
 			"dependencies": {
 				"semver": {
@@ -7454,9 +7449,9 @@
 			"integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
 			"dev": true,
 			"requires": {
-				"istanbul-lib-coverage": "^2.0.5",
-				"make-dir": "^2.1.0",
-				"supports-color": "^6.1.0"
+				"istanbul-lib-coverage": "2.0.5",
+				"make-dir": "2.1.0",
+				"supports-color": "6.1.0"
 			},
 			"dependencies": {
 				"supports-color": {
@@ -7465,7 +7460,7 @@
 					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -7476,11 +7471,11 @@
 			"integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
 			"dev": true,
 			"requires": {
-				"debug": "^4.1.1",
-				"istanbul-lib-coverage": "^2.0.5",
-				"make-dir": "^2.1.0",
-				"rimraf": "^2.6.3",
-				"source-map": "^0.6.1"
+				"debug": "4.1.1",
+				"istanbul-lib-coverage": "2.0.5",
+				"make-dir": "2.1.0",
+				"rimraf": "2.6.3",
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
 				"debug": {
@@ -7489,7 +7484,7 @@
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"ms": {
@@ -7506,7 +7501,7 @@
 			"integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
 			"dev": true,
 			"requires": {
-				"handlebars": "^4.1.2"
+				"handlebars": "4.1.2"
 			}
 		},
 		"jest": {
@@ -7515,8 +7510,8 @@
 			"integrity": "sha512-o0HM90RKFRNWmAWvlyV8i5jGZ97pFwkeVoGvPW1EtLTgJc2+jcuqcbbqcSZLE/3f2S5pt0y2ZBETuhpWNl1Reg==",
 			"dev": true,
 			"requires": {
-				"import-local": "^2.0.0",
-				"jest-cli": "^24.8.0"
+				"import-local": "2.0.0",
+				"jest-cli": "24.8.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -7531,9 +7526,9 @@
 					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"dev": true,
 					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0",
-						"wrap-ansi": "^2.0.0"
+						"string-width": "2.1.1",
+						"strip-ansi": "4.0.0",
+						"wrap-ansi": "2.1.0"
 					}
 				},
 				"get-caller-file": {
@@ -7548,19 +7543,19 @@
 					"integrity": "sha512-+p6J00jSMPQ116ZLlHJJvdf8wbjNbZdeSX9ptfHX06/MSNaXmKihQzx5vQcw0q2G6JsdVkUIdWbOWtSnaYs3yA==",
 					"dev": true,
 					"requires": {
-						"@jest/core": "^24.8.0",
-						"@jest/test-result": "^24.8.0",
-						"@jest/types": "^24.8.0",
-						"chalk": "^2.0.1",
-						"exit": "^0.1.2",
-						"import-local": "^2.0.0",
-						"is-ci": "^2.0.0",
-						"jest-config": "^24.8.0",
-						"jest-util": "^24.8.0",
-						"jest-validate": "^24.8.0",
-						"prompts": "^2.0.1",
-						"realpath-native": "^1.1.0",
-						"yargs": "^12.0.2"
+						"@jest/core": "24.8.0",
+						"@jest/test-result": "24.8.0",
+						"@jest/types": "24.8.0",
+						"chalk": "2.4.2",
+						"exit": "0.1.2",
+						"import-local": "2.0.0",
+						"is-ci": "2.0.0",
+						"jest-config": "24.8.0",
+						"jest-util": "24.8.0",
+						"jest-validate": "24.8.0",
+						"prompts": "2.1.0",
+						"realpath-native": "1.1.0",
+						"yargs": "12.0.5"
 					}
 				},
 				"require-main-filename": {
@@ -7575,8 +7570,8 @@
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -7585,7 +7580,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				},
 				"wrap-ansi": {
@@ -7594,8 +7589,8 @@
 					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 					"dev": true,
 					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1"
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -7610,7 +7605,7 @@
 							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 							"dev": true,
 							"requires": {
-								"number-is-nan": "^1.0.0"
+								"number-is-nan": "1.0.1"
 							}
 						},
 						"string-width": {
@@ -7619,9 +7614,9 @@
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"dev": true,
 							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
 							}
 						},
 						"strip-ansi": {
@@ -7630,7 +7625,7 @@
 							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 							"dev": true,
 							"requires": {
-								"ansi-regex": "^2.0.0"
+								"ansi-regex": "2.1.1"
 							}
 						}
 					}
@@ -7641,18 +7636,18 @@
 					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
 					"dev": true,
 					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.2.0",
-						"find-up": "^3.0.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^3.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1 || ^4.0.0",
-						"yargs-parser": "^11.1.1"
+						"cliui": "4.1.0",
+						"decamelize": "1.2.0",
+						"find-up": "3.0.0",
+						"get-caller-file": "1.0.3",
+						"os-locale": "3.1.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "4.0.0",
+						"yargs-parser": "11.1.1"
 					}
 				},
 				"yargs-parser": {
@@ -7661,8 +7656,8 @@
 					"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
 					"dev": true,
 					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
+						"camelcase": "5.3.1",
+						"decamelize": "1.2.0"
 					}
 				}
 			}
@@ -7673,9 +7668,9 @@
 			"integrity": "sha512-qgANC1Yrivsq+UrLXsvJefBKVoCsKB0Hv+mBb6NMjjZ90wwxCDmU3hsCXBya30cH+LnPYjwgcU65i6yJ5Nfuug==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
-				"execa": "^1.0.0",
-				"throat": "^4.0.0"
+				"@jest/types": "24.8.0",
+				"execa": "1.0.0",
+				"throat": "4.1.0"
 			}
 		},
 		"jest-config": {
@@ -7684,23 +7679,23 @@
 			"integrity": "sha512-Czl3Nn2uEzVGsOeaewGWoDPD8GStxCpAe0zOYs2x2l0fZAgPbCr3uwUkgNKV3LwE13VXythM946cd5rdGkkBZw==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "^7.1.0",
-				"@jest/test-sequencer": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"babel-jest": "^24.8.0",
-				"chalk": "^2.0.1",
-				"glob": "^7.1.1",
-				"jest-environment-jsdom": "^24.8.0",
-				"jest-environment-node": "^24.8.0",
-				"jest-get-type": "^24.8.0",
-				"jest-jasmine2": "^24.8.0",
-				"jest-regex-util": "^24.3.0",
-				"jest-resolve": "^24.8.0",
-				"jest-util": "^24.8.0",
-				"jest-validate": "^24.8.0",
-				"micromatch": "^3.1.10",
-				"pretty-format": "^24.8.0",
-				"realpath-native": "^1.1.0"
+				"@babel/core": "7.5.5",
+				"@jest/test-sequencer": "24.8.0",
+				"@jest/types": "24.8.0",
+				"babel-jest": "24.8.0",
+				"chalk": "2.4.2",
+				"glob": "7.1.4",
+				"jest-environment-jsdom": "24.8.0",
+				"jest-environment-node": "24.8.0",
+				"jest-get-type": "24.8.0",
+				"jest-jasmine2": "24.8.0",
+				"jest-regex-util": "24.3.0",
+				"jest-resolve": "24.8.0",
+				"jest-util": "24.8.0",
+				"jest-validate": "24.8.0",
+				"micromatch": "3.1.10",
+				"pretty-format": "24.8.0",
+				"realpath-native": "1.1.0"
 			},
 			"dependencies": {
 				"braces": {
@@ -7709,16 +7704,16 @@
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.3",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -7727,7 +7722,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -7738,10 +7733,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -7750,7 +7745,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -7767,7 +7762,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -7776,7 +7771,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -7787,19 +7782,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.13",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					}
 				},
 				"to-regex-range": {
@@ -7808,8 +7803,8 @@
 					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 					"dev": true,
 					"requires": {
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1"
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1"
 					}
 				}
 			}
@@ -7820,10 +7815,10 @@
 			"integrity": "sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"diff-sequences": "^24.3.0",
-				"jest-get-type": "^24.8.0",
-				"pretty-format": "^24.8.0"
+				"chalk": "2.4.2",
+				"diff-sequences": "24.3.0",
+				"jest-get-type": "24.8.0",
+				"pretty-format": "24.8.0"
 			}
 		},
 		"jest-docblock": {
@@ -7832,7 +7827,7 @@
 			"integrity": "sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==",
 			"dev": true,
 			"requires": {
-				"detect-newline": "^2.1.0"
+				"detect-newline": "2.1.0"
 			}
 		},
 		"jest-each": {
@@ -7841,11 +7836,11 @@
 			"integrity": "sha512-NrwK9gaL5+XgrgoCsd9svsoWdVkK4gnvyhcpzd6m487tXHqIdYeykgq3MKI1u4I+5Zf0tofr70at9dWJDeb+BA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
-				"chalk": "^2.0.1",
-				"jest-get-type": "^24.8.0",
-				"jest-util": "^24.8.0",
-				"pretty-format": "^24.8.0"
+				"@jest/types": "24.8.0",
+				"chalk": "2.4.2",
+				"jest-get-type": "24.8.0",
+				"jest-util": "24.8.0",
+				"pretty-format": "24.8.0"
 			}
 		},
 		"jest-environment-jsdom": {
@@ -7854,12 +7849,12 @@
 			"integrity": "sha512-qbvgLmR7PpwjoFjM/sbuqHJt/NCkviuq9vus9NBn/76hhSidO+Z6Bn9tU8friecegbJL8gzZQEMZBQlFWDCwAQ==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^24.8.0",
-				"@jest/fake-timers": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"jest-mock": "^24.8.0",
-				"jest-util": "^24.8.0",
-				"jsdom": "^11.5.1"
+				"@jest/environment": "24.8.0",
+				"@jest/fake-timers": "24.8.0",
+				"@jest/types": "24.8.0",
+				"jest-mock": "24.8.0",
+				"jest-util": "24.8.0",
+				"jsdom": "11.12.0"
 			}
 		},
 		"jest-environment-node": {
@@ -7868,11 +7863,11 @@
 			"integrity": "sha512-vIGUEScd1cdDgR6sqn2M08sJTRLQp6Dk/eIkCeO4PFHxZMOgy+uYLPMC4ix3PEfM5Au/x3uQ/5Tl0DpXXZsJ/Q==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^24.8.0",
-				"@jest/fake-timers": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"jest-mock": "^24.8.0",
-				"jest-util": "^24.8.0"
+				"@jest/environment": "24.8.0",
+				"@jest/fake-timers": "24.8.0",
+				"@jest/types": "24.8.0",
+				"jest-mock": "24.8.0",
+				"jest-util": "24.8.0"
 			}
 		},
 		"jest-get-type": {
@@ -7887,18 +7882,18 @@
 			"integrity": "sha512-SwaxMGVdAZk3ernAx2Uv2sorA7jm3Kx+lR0grp6rMmnY06Kn/urtKx1LPN2mGTea4fCT38impYT28FfcLUhX0g==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
-				"anymatch": "^2.0.0",
-				"fb-watchman": "^2.0.0",
-				"fsevents": "^1.2.7",
-				"graceful-fs": "^4.1.15",
-				"invariant": "^2.2.4",
-				"jest-serializer": "^24.4.0",
-				"jest-util": "^24.8.0",
-				"jest-worker": "^24.6.0",
-				"micromatch": "^3.1.10",
-				"sane": "^4.0.3",
-				"walker": "^1.0.7"
+				"@jest/types": "24.8.0",
+				"anymatch": "2.0.0",
+				"fb-watchman": "2.0.0",
+				"fsevents": "1.2.9",
+				"graceful-fs": "4.2.0",
+				"invariant": "2.2.4",
+				"jest-serializer": "24.4.0",
+				"jest-util": "24.8.0",
+				"jest-worker": "24.6.0",
+				"micromatch": "3.1.10",
+				"sane": "4.1.0",
+				"walker": "1.0.7"
 			},
 			"dependencies": {
 				"braces": {
@@ -7907,16 +7902,16 @@
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.3",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -7925,7 +7920,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -7936,10 +7931,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -7948,7 +7943,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -7965,7 +7960,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -7974,7 +7969,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -7985,19 +7980,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.13",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					}
 				},
 				"to-regex-range": {
@@ -8006,8 +8001,8 @@
 					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 					"dev": true,
 					"requires": {
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1"
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1"
 					}
 				}
 			}
@@ -8018,22 +8013,22 @@
 			"integrity": "sha512-cEky88npEE5LKd5jPpTdDCLvKkdyklnaRycBXL6GNmpxe41F0WN44+i7lpQKa/hcbXaQ+rc9RMaM4dsebrYong==",
 			"dev": true,
 			"requires": {
-				"@babel/traverse": "^7.1.0",
-				"@jest/environment": "^24.8.0",
-				"@jest/test-result": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"chalk": "^2.0.1",
-				"co": "^4.6.0",
-				"expect": "^24.8.0",
-				"is-generator-fn": "^2.0.0",
-				"jest-each": "^24.8.0",
-				"jest-matcher-utils": "^24.8.0",
-				"jest-message-util": "^24.8.0",
-				"jest-runtime": "^24.8.0",
-				"jest-snapshot": "^24.8.0",
-				"jest-util": "^24.8.0",
-				"pretty-format": "^24.8.0",
-				"throat": "^4.0.0"
+				"@babel/traverse": "7.5.0",
+				"@jest/environment": "24.8.0",
+				"@jest/test-result": "24.8.0",
+				"@jest/types": "24.8.0",
+				"chalk": "2.4.2",
+				"co": "4.6.0",
+				"expect": "24.8.0",
+				"is-generator-fn": "2.1.0",
+				"jest-each": "24.8.0",
+				"jest-matcher-utils": "24.8.0",
+				"jest-message-util": "24.8.0",
+				"jest-runtime": "24.8.0",
+				"jest-snapshot": "24.8.0",
+				"jest-util": "24.8.0",
+				"pretty-format": "24.8.0",
+				"throat": "4.1.0"
 			}
 		},
 		"jest-leak-detector": {
@@ -8042,7 +8037,7 @@
 			"integrity": "sha512-cG0yRSK8A831LN8lIHxI3AblB40uhv0z+SsQdW3GoMMVcK+sJwrIIyax5tu3eHHNJ8Fu6IMDpnLda2jhn2pD/g==",
 			"dev": true,
 			"requires": {
-				"pretty-format": "^24.8.0"
+				"pretty-format": "24.8.0"
 			}
 		},
 		"jest-matcher-utils": {
@@ -8051,10 +8046,10 @@
 			"integrity": "sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"jest-diff": "^24.8.0",
-				"jest-get-type": "^24.8.0",
-				"pretty-format": "^24.8.0"
+				"chalk": "2.4.2",
+				"jest-diff": "24.8.0",
+				"jest-get-type": "24.8.0",
+				"pretty-format": "24.8.0"
 			}
 		},
 		"jest-message-util": {
@@ -8063,14 +8058,14 @@
 			"integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"@jest/test-result": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"@types/stack-utils": "^1.0.1",
-				"chalk": "^2.0.1",
-				"micromatch": "^3.1.10",
-				"slash": "^2.0.0",
-				"stack-utils": "^1.0.1"
+				"@babel/code-frame": "7.0.0",
+				"@jest/test-result": "24.8.0",
+				"@jest/types": "24.8.0",
+				"@types/stack-utils": "1.0.1",
+				"chalk": "2.4.2",
+				"micromatch": "3.1.10",
+				"slash": "2.0.0",
+				"stack-utils": "1.0.2"
 			},
 			"dependencies": {
 				"braces": {
@@ -8079,16 +8074,16 @@
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.3",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -8097,7 +8092,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -8108,10 +8103,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -8120,7 +8115,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -8137,7 +8132,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -8146,7 +8141,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -8157,19 +8152,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.13",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					}
 				},
 				"to-regex-range": {
@@ -8178,8 +8173,8 @@
 					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 					"dev": true,
 					"requires": {
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1"
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1"
 					}
 				}
 			}
@@ -8190,7 +8185,7 @@
 			"integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0"
+				"@jest/types": "24.8.0"
 			}
 		},
 		"jest-pnp-resolver": {
@@ -8211,11 +8206,11 @@
 			"integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
-				"browser-resolve": "^1.11.3",
-				"chalk": "^2.0.1",
-				"jest-pnp-resolver": "^1.2.1",
-				"realpath-native": "^1.1.0"
+				"@jest/types": "24.8.0",
+				"browser-resolve": "1.11.3",
+				"chalk": "2.4.2",
+				"jest-pnp-resolver": "1.2.1",
+				"realpath-native": "1.1.0"
 			}
 		},
 		"jest-resolve-dependencies": {
@@ -8224,9 +8219,9 @@
 			"integrity": "sha512-hyK1qfIf/krV+fSNyhyJeq3elVMhK9Eijlwy+j5jqmZ9QsxwKBiP6qukQxaHtK8k6zql/KYWwCTQ+fDGTIJauw==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
-				"jest-regex-util": "^24.3.0",
-				"jest-snapshot": "^24.8.0"
+				"@jest/types": "24.8.0",
+				"jest-regex-util": "24.3.0",
+				"jest-snapshot": "24.8.0"
 			}
 		},
 		"jest-runner": {
@@ -8235,25 +8230,25 @@
 			"integrity": "sha512-utFqC5BaA3JmznbissSs95X1ZF+d+4WuOWwpM9+Ak356YtMhHE/GXUondZdcyAAOTBEsRGAgH/0TwLzfI9h7ow==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^24.7.1",
-				"@jest/environment": "^24.8.0",
-				"@jest/test-result": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"chalk": "^2.4.2",
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.1.15",
-				"jest-config": "^24.8.0",
-				"jest-docblock": "^24.3.0",
-				"jest-haste-map": "^24.8.0",
-				"jest-jasmine2": "^24.8.0",
-				"jest-leak-detector": "^24.8.0",
-				"jest-message-util": "^24.8.0",
-				"jest-resolve": "^24.8.0",
-				"jest-runtime": "^24.8.0",
-				"jest-util": "^24.8.0",
-				"jest-worker": "^24.6.0",
-				"source-map-support": "^0.5.6",
-				"throat": "^4.0.0"
+				"@jest/console": "24.7.1",
+				"@jest/environment": "24.8.0",
+				"@jest/test-result": "24.8.0",
+				"@jest/types": "24.8.0",
+				"chalk": "2.4.2",
+				"exit": "0.1.2",
+				"graceful-fs": "4.2.0",
+				"jest-config": "24.8.0",
+				"jest-docblock": "24.3.0",
+				"jest-haste-map": "24.8.1",
+				"jest-jasmine2": "24.8.0",
+				"jest-leak-detector": "24.8.0",
+				"jest-message-util": "24.8.0",
+				"jest-resolve": "24.8.0",
+				"jest-runtime": "24.8.0",
+				"jest-util": "24.8.0",
+				"jest-worker": "24.6.0",
+				"source-map-support": "0.5.12",
+				"throat": "4.1.0"
 			}
 		},
 		"jest-runtime": {
@@ -8262,29 +8257,29 @@
 			"integrity": "sha512-Mq0aIXhvO/3bX44ccT+czU1/57IgOMyy80oM0XR/nyD5zgBcesF84BPabZi39pJVA6UXw+fY2Q1N+4BiVUBWOA==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^24.7.1",
-				"@jest/environment": "^24.8.0",
-				"@jest/source-map": "^24.3.0",
-				"@jest/transform": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"@types/yargs": "^12.0.2",
-				"chalk": "^2.0.1",
-				"exit": "^0.1.2",
-				"glob": "^7.1.3",
-				"graceful-fs": "^4.1.15",
-				"jest-config": "^24.8.0",
-				"jest-haste-map": "^24.8.0",
-				"jest-message-util": "^24.8.0",
-				"jest-mock": "^24.8.0",
-				"jest-regex-util": "^24.3.0",
-				"jest-resolve": "^24.8.0",
-				"jest-snapshot": "^24.8.0",
-				"jest-util": "^24.8.0",
-				"jest-validate": "^24.8.0",
-				"realpath-native": "^1.1.0",
-				"slash": "^2.0.0",
-				"strip-bom": "^3.0.0",
-				"yargs": "^12.0.2"
+				"@jest/console": "24.7.1",
+				"@jest/environment": "24.8.0",
+				"@jest/source-map": "24.3.0",
+				"@jest/transform": "24.8.0",
+				"@jest/types": "24.8.0",
+				"@types/yargs": "12.0.12",
+				"chalk": "2.4.2",
+				"exit": "0.1.2",
+				"glob": "7.1.4",
+				"graceful-fs": "4.2.0",
+				"jest-config": "24.8.0",
+				"jest-haste-map": "24.8.1",
+				"jest-message-util": "24.8.0",
+				"jest-mock": "24.8.0",
+				"jest-regex-util": "24.3.0",
+				"jest-resolve": "24.8.0",
+				"jest-snapshot": "24.8.0",
+				"jest-util": "24.8.0",
+				"jest-validate": "24.8.0",
+				"realpath-native": "1.1.0",
+				"slash": "2.0.0",
+				"strip-bom": "3.0.0",
+				"yargs": "12.0.5"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -8299,9 +8294,9 @@
 					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"dev": true,
 					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0",
-						"wrap-ansi": "^2.0.0"
+						"string-width": "2.1.1",
+						"strip-ansi": "4.0.0",
+						"wrap-ansi": "2.1.0"
 					}
 				},
 				"get-caller-file": {
@@ -8322,8 +8317,8 @@
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -8332,7 +8327,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				},
 				"wrap-ansi": {
@@ -8341,8 +8336,8 @@
 					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 					"dev": true,
 					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1"
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -8357,7 +8352,7 @@
 							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 							"dev": true,
 							"requires": {
-								"number-is-nan": "^1.0.0"
+								"number-is-nan": "1.0.1"
 							}
 						},
 						"string-width": {
@@ -8366,9 +8361,9 @@
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"dev": true,
 							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
+								"code-point-at": "1.1.0",
+								"is-fullwidth-code-point": "1.0.0",
+								"strip-ansi": "3.0.1"
 							}
 						},
 						"strip-ansi": {
@@ -8377,7 +8372,7 @@
 							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 							"dev": true,
 							"requires": {
-								"ansi-regex": "^2.0.0"
+								"ansi-regex": "2.1.1"
 							}
 						}
 					}
@@ -8388,18 +8383,18 @@
 					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
 					"dev": true,
 					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.2.0",
-						"find-up": "^3.0.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^3.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1 || ^4.0.0",
-						"yargs-parser": "^11.1.1"
+						"cliui": "4.1.0",
+						"decamelize": "1.2.0",
+						"find-up": "3.0.0",
+						"get-caller-file": "1.0.3",
+						"os-locale": "3.1.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "4.0.0",
+						"yargs-parser": "11.1.1"
 					}
 				},
 				"yargs-parser": {
@@ -8408,8 +8403,8 @@
 					"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
 					"dev": true,
 					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
+						"camelcase": "5.3.1",
+						"decamelize": "1.2.0"
 					}
 				}
 			}
@@ -8435,18 +8430,18 @@
 			"integrity": "sha512-5ehtWoc8oU9/cAPe6fez6QofVJLBKyqkY2+TlKTOf0VllBB/mqUNdARdcjlZrs9F1Cv+/HKoCS/BknT0+tmfPg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.0.0",
-				"@jest/types": "^24.8.0",
-				"chalk": "^2.0.1",
-				"expect": "^24.8.0",
-				"jest-diff": "^24.8.0",
-				"jest-matcher-utils": "^24.8.0",
-				"jest-message-util": "^24.8.0",
-				"jest-resolve": "^24.8.0",
-				"mkdirp": "^0.5.1",
-				"natural-compare": "^1.4.0",
-				"pretty-format": "^24.8.0",
-				"semver": "^5.5.0"
+				"@babel/types": "7.5.0",
+				"@jest/types": "24.8.0",
+				"chalk": "2.4.2",
+				"expect": "24.8.0",
+				"jest-diff": "24.8.0",
+				"jest-matcher-utils": "24.8.0",
+				"jest-message-util": "24.8.0",
+				"jest-resolve": "24.8.0",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"pretty-format": "24.8.0",
+				"semver": "5.7.0"
 			}
 		},
 		"jest-util": {
@@ -8455,18 +8450,18 @@
 			"integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^24.7.1",
-				"@jest/fake-timers": "^24.8.0",
-				"@jest/source-map": "^24.3.0",
-				"@jest/test-result": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"callsites": "^3.0.0",
-				"chalk": "^2.0.1",
-				"graceful-fs": "^4.1.15",
-				"is-ci": "^2.0.0",
-				"mkdirp": "^0.5.1",
-				"slash": "^2.0.0",
-				"source-map": "^0.6.0"
+				"@jest/console": "24.7.1",
+				"@jest/fake-timers": "24.8.0",
+				"@jest/source-map": "24.3.0",
+				"@jest/test-result": "24.8.0",
+				"@jest/types": "24.8.0",
+				"callsites": "3.1.0",
+				"chalk": "2.4.2",
+				"graceful-fs": "4.2.0",
+				"is-ci": "2.0.0",
+				"mkdirp": "0.5.1",
+				"slash": "2.0.0",
+				"source-map": "0.6.1"
 			}
 		},
 		"jest-validate": {
@@ -8475,12 +8470,12 @@
 			"integrity": "sha512-+/N7VOEMW1Vzsrk3UWBDYTExTPwf68tavEPKDnJzrC6UlHtUDU/fuEdXqFoHzv9XnQ+zW6X3qMZhJ3YexfeLDA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
-				"camelcase": "^5.0.0",
-				"chalk": "^2.0.1",
-				"jest-get-type": "^24.8.0",
-				"leven": "^2.1.0",
-				"pretty-format": "^24.8.0"
+				"@jest/types": "24.8.0",
+				"camelcase": "5.3.1",
+				"chalk": "2.4.2",
+				"jest-get-type": "24.8.0",
+				"leven": "2.1.0",
+				"pretty-format": "24.8.0"
 			}
 		},
 		"jest-watcher": {
@@ -8489,13 +8484,13 @@
 			"integrity": "sha512-SBjwHt5NedQoVu54M5GEx7cl7IGEFFznvd/HNT8ier7cCAx/Qgu9ZMlaTQkvK22G1YOpcWBLQPFSImmxdn3DAw==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"@types/yargs": "^12.0.9",
-				"ansi-escapes": "^3.0.0",
-				"chalk": "^2.0.1",
-				"jest-util": "^24.8.0",
-				"string-length": "^2.0.0"
+				"@jest/test-result": "24.8.0",
+				"@jest/types": "24.8.0",
+				"@types/yargs": "12.0.12",
+				"ansi-escapes": "3.2.0",
+				"chalk": "2.4.2",
+				"jest-util": "24.8.0",
+				"string-length": "2.0.0"
 			}
 		},
 		"jest-worker": {
@@ -8504,8 +8499,8 @@
 			"integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
 			"dev": true,
 			"requires": {
-				"merge-stream": "^1.0.1",
-				"supports-color": "^6.1.0"
+				"merge-stream": "1.0.1",
+				"supports-color": "6.1.0"
 			},
 			"dependencies": {
 				"supports-color": {
@@ -8514,7 +8509,7 @@
 					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -8537,11 +8532,11 @@
 			"integrity": "sha512-OMwf/tPDpE/BLlYKqZOhqWsd3/z2N3KOlyn1wsCRGFwViE8LOQTcDtathQvHvZc+q+zWmcNAbwKSC+iJoMaH2Q==",
 			"dev": true,
 			"requires": {
-				"config-chain": "^1.1.12",
-				"editorconfig": "^0.15.3",
-				"glob": "^7.1.3",
-				"mkdirp": "~0.5.1",
-				"nopt": "~4.0.1"
+				"config-chain": "1.1.12",
+				"editorconfig": "0.15.3",
+				"glob": "7.1.4",
+				"mkdirp": "0.5.1",
+				"nopt": "4.0.1"
 			}
 		},
 		"js-levenshtein": {
@@ -8560,8 +8555,8 @@
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
 			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
 			"requires": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
+				"argparse": "1.0.10",
+				"esprima": "4.0.1"
 			}
 		},
 		"js2xmlparser": {
@@ -8569,7 +8564,7 @@
 			"resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.0.tgz",
 			"integrity": "sha512-WuNgdZOXVmBk5kUPMcTcVUpbGRzLfNkv7+7APq7WiDihpXVKrgxo6wwRpRl9OQeEBgKCVk9mR7RbzrnNWC8oBw==",
 			"requires": {
-				"xmlcreate": "^2.0.0"
+				"xmlcreate": "2.0.1"
 			}
 		},
 		"jsbn": {
@@ -8583,20 +8578,20 @@
 			"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.3.tgz",
 			"integrity": "sha512-Yf1ZKA3r9nvtMWHO1kEuMZTlHOF8uoQ0vyo5eH7SQy5YeIiHM+B0DgKnn+X6y6KDYZcF7G2SPkKF+JORCXWE/A==",
 			"requires": {
-				"@babel/parser": "^7.4.4",
-				"bluebird": "^3.5.4",
-				"catharsis": "^0.8.11",
-				"escape-string-regexp": "^2.0.0",
-				"js2xmlparser": "^4.0.0",
-				"klaw": "^3.0.0",
-				"markdown-it": "^8.4.2",
-				"markdown-it-anchor": "^5.0.2",
-				"marked": "^0.7.0",
-				"mkdirp": "^0.5.1",
-				"requizzle": "^0.2.3",
-				"strip-json-comments": "^3.0.1",
+				"@babel/parser": "7.5.0",
+				"bluebird": "3.5.5",
+				"catharsis": "0.8.11",
+				"escape-string-regexp": "2.0.0",
+				"js2xmlparser": "4.0.0",
+				"klaw": "3.0.0",
+				"markdown-it": "8.4.2",
+				"markdown-it-anchor": "5.2.4",
+				"marked": "0.7.0",
+				"mkdirp": "0.5.1",
+				"requizzle": "0.2.3",
+				"strip-json-comments": "3.0.1",
 				"taffydb": "2.6.2",
-				"underscore": "~1.9.1"
+				"underscore": "1.9.1"
 			},
 			"dependencies": {
 				"escape-string-regexp": {
@@ -8616,15 +8611,15 @@
 			"resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-5.0.2.tgz",
 			"integrity": "sha512-nC5uvd907gbqTRinrHeX5EBNw2Yc/0/7qONbRu5R5wrq/1OaRHtqDWGLDu+6BFI6RyuEgp87IH/IdOz4CdN6RA==",
 			"requires": {
-				"array-back": "^3.1.0",
-				"cache-point": "^0.4.1",
-				"collect-all": "^1.0.3",
-				"file-set": "^2.0.1",
-				"fs-then-native": "^2.0.0",
-				"jsdoc": "^3.6.2",
-				"object-to-spawn-args": "^1.1.1",
-				"temp-path": "^1.0.0",
-				"walk-back": "^3.0.1"
+				"array-back": "3.1.0",
+				"cache-point": "0.4.1",
+				"collect-all": "1.0.3",
+				"file-set": "2.0.1",
+				"fs-then-native": "2.0.0",
+				"jsdoc": "3.6.3",
+				"object-to-spawn-args": "1.1.1",
+				"temp-path": "1.0.0",
+				"walk-back": "3.0.1"
 			}
 		},
 		"jsdoc-parse": {
@@ -8632,12 +8627,12 @@
 			"resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-3.0.1.tgz",
 			"integrity": "sha512-btZLp4wYl90vcAfgk4hoGQbO17iBVrhh3LJRMKZNtZgniO3F8H2CjxXld0owBIB1XxN+j3bAcWZnZKMnSj3iMA==",
 			"requires": {
-				"array-back": "^2.0.0",
-				"lodash.omit": "^4.5.0",
-				"lodash.pick": "^4.4.0",
-				"reduce-extract": "^1.0.0",
-				"sort-array": "^2.0.0",
-				"test-value": "^3.0.0"
+				"array-back": "2.0.0",
+				"lodash.omit": "4.5.0",
+				"lodash.pick": "4.4.0",
+				"reduce-extract": "1.0.0",
+				"sort-array": "2.0.0",
+				"test-value": "3.0.0"
 			},
 			"dependencies": {
 				"array-back": {
@@ -8645,7 +8640,7 @@
 					"resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
 					"integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
 					"requires": {
-						"typical": "^2.6.1"
+						"typical": "2.6.1"
 					}
 				}
 			}
@@ -8655,13 +8650,13 @@
 			"resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-5.0.0.tgz",
 			"integrity": "sha512-3gKEnbay7dSdyvtMDDkUf4r7pmBVgs3aqeT0Cg/ngTILPpJUzf8iKgASIo5psF007L45OIJtIuRX5VL/YUXKaA==",
 			"requires": {
-				"array-back": "^3.1.0",
-				"command-line-tool": "^0.8.0",
-				"config-master": "^3.1.0",
-				"dmd": "^4.0.0",
-				"jsdoc-api": "^5.0.1",
-				"jsdoc-parse": "^3.0.1",
-				"walk-back": "^3.0.1"
+				"array-back": "3.1.0",
+				"command-line-tool": "0.8.0",
+				"config-master": "3.1.0",
+				"dmd": "4.0.0",
+				"jsdoc-api": "5.0.2",
+				"jsdoc-parse": "3.0.1",
+				"walk-back": "3.0.1"
 			}
 		},
 		"jsdom": {
@@ -8670,32 +8665,32 @@
 			"integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
 			"dev": true,
 			"requires": {
-				"abab": "^2.0.0",
-				"acorn": "^5.5.3",
-				"acorn-globals": "^4.1.0",
-				"array-equal": "^1.0.0",
-				"cssom": ">= 0.3.2 < 0.4.0",
-				"cssstyle": "^1.0.0",
-				"data-urls": "^1.0.0",
-				"domexception": "^1.0.1",
-				"escodegen": "^1.9.1",
-				"html-encoding-sniffer": "^1.0.2",
-				"left-pad": "^1.3.0",
-				"nwsapi": "^2.0.7",
+				"abab": "2.0.0",
+				"acorn": "5.7.3",
+				"acorn-globals": "4.3.2",
+				"array-equal": "1.0.0",
+				"cssom": "0.3.8",
+				"cssstyle": "1.3.0",
+				"data-urls": "1.1.0",
+				"domexception": "1.0.1",
+				"escodegen": "1.11.1",
+				"html-encoding-sniffer": "1.0.2",
+				"left-pad": "1.3.0",
+				"nwsapi": "2.1.4",
 				"parse5": "4.0.0",
-				"pn": "^1.1.0",
-				"request": "^2.87.0",
-				"request-promise-native": "^1.0.5",
-				"sax": "^1.2.4",
-				"symbol-tree": "^3.2.2",
-				"tough-cookie": "^2.3.4",
-				"w3c-hr-time": "^1.0.1",
-				"webidl-conversions": "^4.0.2",
-				"whatwg-encoding": "^1.0.3",
-				"whatwg-mimetype": "^2.1.0",
-				"whatwg-url": "^6.4.1",
-				"ws": "^5.2.0",
-				"xml-name-validator": "^3.0.0"
+				"pn": "1.1.0",
+				"request": "2.88.0",
+				"request-promise-native": "1.0.7",
+				"sax": "1.2.4",
+				"symbol-tree": "3.2.4",
+				"tough-cookie": "2.5.0",
+				"w3c-hr-time": "1.0.1",
+				"webidl-conversions": "4.0.2",
+				"whatwg-encoding": "1.0.5",
+				"whatwg-mimetype": "2.3.0",
+				"whatwg-url": "6.5.0",
+				"ws": "5.2.2",
+				"xml-name-validator": "3.0.0"
 			},
 			"dependencies": {
 				"acorn": {
@@ -8754,7 +8749,7 @@
 			"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
 			"dev": true,
 			"requires": {
-				"minimist": "^1.2.0"
+				"minimist": "1.2.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -8788,7 +8783,7 @@
 			"resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
 			"integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
 			"requires": {
-				"graceful-fs": "^4.1.9"
+				"graceful-fs": "4.2.0"
 			}
 		},
 		"kleur": {
@@ -8808,7 +8803,7 @@
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
 			"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
 			"requires": {
-				"invert-kv": "^2.0.0"
+				"invert-kv": "2.0.0"
 			}
 		},
 		"left-pad": {
@@ -8829,8 +8824,8 @@
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2"
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2"
 			}
 		},
 		"linkify-it": {
@@ -8838,7 +8833,7 @@
 			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
 			"integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
 			"requires": {
-				"uc.micro": "^1.0.1"
+				"uc.micro": "1.0.6"
 			}
 		},
 		"linkifyjs": {
@@ -8846,9 +8841,9 @@
 			"resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-2.1.8.tgz",
 			"integrity": "sha512-j3QpiEr4UYzN5foKhrr9Sr06VI9vSlI4HisDWt+7Mq+TWDwpJ6H/LLpogYsXcyUIJLVhGblXXdUnblHsVNMPpg==",
 			"requires": {
-				"jquery": "^3.3.1",
-				"react": "^16.4.2",
-				"react-dom": "^16.4.2"
+				"jquery": "3.4.1",
+				"react": "16.8.6",
+				"react-dom": "16.8.6"
 			}
 		},
 		"load-json-file": {
@@ -8857,10 +8852,10 @@
 			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"parse-json": "^4.0.0",
-				"pify": "^3.0.0",
-				"strip-bom": "^3.0.0"
+				"graceful-fs": "4.2.0",
+				"parse-json": "4.0.0",
+				"pify": "3.0.0",
+				"strip-bom": "3.0.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -8877,7 +8872,7 @@
 			"integrity": "sha512-70IzT/0/L+M20jUlEqZhZyArTU6VKLRTYRDAYN26g4jfzpJqjipLL3/hgYpySqI9PwsVRHHFja0LfEmsx9X2Cw==",
 			"dev": true,
 			"requires": {
-				"find-cache-dir": "^0.1.1",
+				"find-cache-dir": "0.1.1",
 				"mkdirp": "0.5.1"
 			},
 			"dependencies": {
@@ -8887,9 +8882,9 @@
 					"integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
 					"dev": true,
 					"requires": {
-						"commondir": "^1.0.1",
-						"mkdirp": "^0.5.1",
-						"pkg-dir": "^1.0.0"
+						"commondir": "1.0.1",
+						"mkdirp": "0.5.1",
+						"pkg-dir": "1.0.0"
 					}
 				},
 				"find-up": {
@@ -8898,8 +8893,8 @@
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"dev": true,
 					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"path-exists": {
@@ -8908,7 +8903,7 @@
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "^2.0.0"
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"pkg-dir": {
@@ -8917,7 +8912,7 @@
 					"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
 					"dev": true,
 					"requires": {
-						"find-up": "^1.0.0"
+						"find-up": "1.1.2"
 					}
 				}
 			}
@@ -8934,9 +8929,9 @@
 			"integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
 			"dev": true,
 			"requires": {
-				"big.js": "^5.2.2",
-				"emojis-list": "^2.0.0",
-				"json5": "^1.0.1"
+				"big.js": "5.2.2",
+				"emojis-list": "2.1.0",
+				"json5": "1.0.1"
 			},
 			"dependencies": {
 				"json5": {
@@ -8945,7 +8940,7 @@
 					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
 					"dev": true,
 					"requires": {
-						"minimist": "^1.2.0"
+						"minimist": "1.2.0"
 					}
 				},
 				"minimist": {
@@ -8961,8 +8956,8 @@
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
 			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
 			"requires": {
-				"p-locate": "^3.0.0",
-				"path-exists": "^3.0.0"
+				"p-locate": "3.0.0",
+				"path-exists": "3.0.0"
 			}
 		},
 		"lodash": {
@@ -9020,7 +9015,7 @@
 			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1"
+				"chalk": "2.4.2"
 			}
 		},
 		"loglevel": {
@@ -9035,8 +9030,8 @@
 			"integrity": "sha1-akAhj9x64V/HbD0PPmdsRlOIYD4=",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.1.3",
-				"loglevel": "^1.4.1"
+				"chalk": "1.1.3",
+				"loglevel": "1.6.3"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -9057,11 +9052,11 @@
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -9070,7 +9065,7 @@
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				},
 				"supports-color": {
@@ -9091,7 +9086,7 @@
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
 			"requires": {
-				"js-tokens": "^3.0.0 || ^4.0.0"
+				"js-tokens": "4.0.0"
 			}
 		},
 		"loud-rejection": {
@@ -9100,8 +9095,8 @@
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
 			"dev": true,
 			"requires": {
-				"currently-unhandled": "^0.4.1",
-				"signal-exit": "^3.0.0"
+				"currently-unhandled": "0.4.1",
+				"signal-exit": "3.0.2"
 			}
 		},
 		"lru-cache": {
@@ -9110,8 +9105,8 @@
 			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
 			"dev": true,
 			"requires": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
+				"pseudomap": "1.0.2",
+				"yallist": "2.1.2"
 			}
 		},
 		"make-dir": {
@@ -9120,8 +9115,8 @@
 			"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
 			"dev": true,
 			"requires": {
-				"pify": "^4.0.1",
-				"semver": "^5.6.0"
+				"pify": "4.0.1",
+				"semver": "5.7.0"
 			}
 		},
 		"makeerror": {
@@ -9130,7 +9125,7 @@
 			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
 			"dev": true,
 			"requires": {
-				"tmpl": "1.0.x"
+				"tmpl": "1.0.4"
 			}
 		},
 		"mamacro": {
@@ -9144,7 +9139,7 @@
 			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
 			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
 			"requires": {
-				"p-defer": "^1.0.0"
+				"p-defer": "1.0.0"
 			}
 		},
 		"map-cache": {
@@ -9165,7 +9160,7 @@
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
 			"dev": true,
 			"requires": {
-				"object-visit": "^1.0.0"
+				"object-visit": "1.0.1"
 			}
 		},
 		"markdown-escapes": {
@@ -9178,11 +9173,11 @@
 			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
 			"integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
 			"requires": {
-				"argparse": "^1.0.7",
-				"entities": "~1.1.1",
-				"linkify-it": "^2.0.0",
-				"mdurl": "^1.0.1",
-				"uc.micro": "^1.0.5"
+				"argparse": "1.0.10",
+				"entities": "1.1.2",
+				"linkify-it": "2.2.0",
+				"mdurl": "1.0.1",
+				"uc.micro": "1.0.6"
 			}
 		},
 		"markdown-it-anchor": {
@@ -9200,11 +9195,11 @@
 			"resolved": "https://registry.npmjs.org/markdown-to-ast/-/markdown-to-ast-6.0.3.tgz",
 			"integrity": "sha512-P4YX5PTcFY0Bg5oWGRJ4o9Wq7TGqapO71zBKIjhnrqeEFzKk7srHtIYgaQAA8eofi/4EucDF3O3dJ/BUIi3FTA==",
 			"requires": {
-				"@textlint/ast-node-types": "^4.0.0",
-				"debug": "^2.1.3",
-				"remark": "^7.0.1",
-				"structured-source": "^3.0.2",
-				"traverse": "^0.6.6"
+				"@textlint/ast-node-types": "4.2.3",
+				"debug": "2.6.9",
+				"remark": "7.0.1",
+				"structured-source": "3.0.2",
+				"traverse": "0.6.6"
 			},
 			"dependencies": {
 				"debug": {
@@ -9244,9 +9239,9 @@
 			"resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
 			"integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
 			"requires": {
-				"charenc": "~0.0.1",
-				"crypt": "~0.0.1",
-				"is-buffer": "~1.1.1"
+				"charenc": "0.0.2",
+				"crypt": "0.0.2",
+				"is-buffer": "1.1.6"
 			},
 			"dependencies": {
 				"is-buffer": {
@@ -9262,9 +9257,9 @@
 			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
 			"dev": true,
 			"requires": {
-				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.1.2"
+				"hash-base": "3.0.4",
+				"inherits": "2.0.4",
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"mdast-util-compact": {
@@ -9272,7 +9267,7 @@
 			"resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.3.tgz",
 			"integrity": "sha512-nRiU5GpNy62rZppDKbLwhhtw5DXoFMqw9UNZFmlPsNaQCZ//WLjGKUwWMdJrUH+Se7UvtO2gXtAMe0g/N+eI5w==",
 			"requires": {
-				"unist-util-visit": "^1.1.0"
+				"unist-util-visit": "1.4.1"
 			}
 		},
 		"mdast-util-to-string": {
@@ -9290,9 +9285,9 @@
 			"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
 			"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
 			"requires": {
-				"map-age-cleaner": "^0.1.1",
-				"mimic-fn": "^2.0.0",
-				"p-is-promise": "^2.0.0"
+				"map-age-cleaner": "0.1.3",
+				"mimic-fn": "2.1.0",
+				"p-is-promise": "2.1.0"
 			}
 		},
 		"memory-fs": {
@@ -9301,8 +9296,8 @@
 			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
 			"dev": true,
 			"requires": {
-				"errno": "^0.1.3",
-				"readable-stream": "^2.0.1"
+				"errno": "0.1.7",
+				"readable-stream": "2.3.6"
 			},
 			"dependencies": {
 				"readable-stream": {
@@ -9311,13 +9306,13 @@
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.4",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.1",
+						"safe-buffer": "5.1.2",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"string_decoder": {
@@ -9326,7 +9321,7 @@
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "5.1.2"
 					}
 				}
 			}
@@ -9337,16 +9332,16 @@
 			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 			"dev": true,
 			"requires": {
-				"camelcase-keys": "^2.0.0",
-				"decamelize": "^1.1.2",
-				"loud-rejection": "^1.0.0",
-				"map-obj": "^1.0.1",
-				"minimist": "^1.1.3",
-				"normalize-package-data": "^2.3.4",
-				"object-assign": "^4.0.1",
-				"read-pkg-up": "^1.0.1",
-				"redent": "^1.0.0",
-				"trim-newlines": "^1.0.0"
+				"camelcase-keys": "2.1.0",
+				"decamelize": "1.2.0",
+				"loud-rejection": "1.6.0",
+				"map-obj": "1.0.1",
+				"minimist": "1.2.0",
+				"normalize-package-data": "2.5.0",
+				"object-assign": "4.1.1",
+				"read-pkg-up": "1.0.1",
+				"redent": "1.0.0",
+				"trim-newlines": "1.0.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -9355,8 +9350,8 @@
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"dev": true,
 					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"load-json-file": {
@@ -9365,11 +9360,11 @@
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
+						"graceful-fs": "4.2.0",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"strip-bom": "2.0.0"
 					}
 				},
 				"minimist": {
@@ -9384,7 +9379,7 @@
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 					"dev": true,
 					"requires": {
-						"error-ex": "^1.2.0"
+						"error-ex": "1.3.2"
 					}
 				},
 				"path-exists": {
@@ -9393,7 +9388,7 @@
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "^2.0.0"
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"path-type": {
@@ -9402,9 +9397,9 @@
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"graceful-fs": "4.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"pify": {
@@ -9419,9 +9414,9 @@
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "^1.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
+						"load-json-file": "1.1.0",
+						"normalize-package-data": "2.5.0",
+						"path-type": "1.1.0"
 					}
 				},
 				"read-pkg-up": {
@@ -9430,8 +9425,8 @@
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 					"dev": true,
 					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
+						"find-up": "1.1.2",
+						"read-pkg": "1.1.0"
 					}
 				},
 				"strip-bom": {
@@ -9440,7 +9435,7 @@
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"dev": true,
 					"requires": {
-						"is-utf8": "^0.2.0"
+						"is-utf8": "0.2.1"
 					}
 				}
 			}
@@ -9451,7 +9446,7 @@
 			"integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
 			"dev": true,
 			"requires": {
-				"source-map": "^0.6.1"
+				"source-map": "0.6.1"
 			}
 		},
 		"merge-stream": {
@@ -9460,7 +9455,7 @@
 			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "^2.0.1"
+				"readable-stream": "2.3.6"
 			},
 			"dependencies": {
 				"readable-stream": {
@@ -9469,13 +9464,13 @@
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.4",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.1",
+						"safe-buffer": "5.1.2",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"string_decoder": {
@@ -9484,7 +9479,7 @@
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "5.1.2"
 					}
 				}
 			}
@@ -9494,8 +9489,8 @@
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
 			"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
 			"requires": {
-				"braces": "^3.0.1",
-				"picomatch": "^2.0.5"
+				"braces": "3.0.2",
+				"picomatch": "2.0.7"
 			}
 		},
 		"miller-rabin": {
@@ -9504,8 +9499,8 @@
 			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.0.0",
-				"brorand": "^1.0.1"
+				"bn.js": "4.11.8",
+				"brorand": "1.1.0"
 			}
 		},
 		"mime-db": {
@@ -9545,7 +9540,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"requires": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "1.1.11"
 			}
 		},
 		"minimist": {
@@ -9559,8 +9554,8 @@
 			"integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
 			"dev": true,
 			"requires": {
-				"arrify": "^1.0.1",
-				"is-plain-obj": "^1.1.0"
+				"arrify": "1.0.1",
+				"is-plain-obj": "1.1.0"
 			}
 		},
 		"mississippi": {
@@ -9569,16 +9564,16 @@
 			"integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
 			"dev": true,
 			"requires": {
-				"concat-stream": "^1.5.0",
-				"duplexify": "^3.4.2",
-				"end-of-stream": "^1.1.0",
-				"flush-write-stream": "^1.0.0",
-				"from2": "^2.1.0",
-				"parallel-transform": "^1.1.0",
-				"pump": "^3.0.0",
-				"pumpify": "^1.3.3",
-				"stream-each": "^1.1.0",
-				"through2": "^2.0.0"
+				"concat-stream": "1.6.2",
+				"duplexify": "3.7.1",
+				"end-of-stream": "1.4.1",
+				"flush-write-stream": "1.1.1",
+				"from2": "2.3.0",
+				"parallel-transform": "1.1.0",
+				"pump": "3.0.0",
+				"pumpify": "1.5.1",
+				"stream-each": "1.2.3",
+				"through2": "2.0.5"
 			}
 		},
 		"mixin-deep": {
@@ -9587,8 +9582,8 @@
 			"integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
 			"dev": true,
 			"requires": {
-				"for-in": "^1.0.2",
-				"is-extendable": "^1.0.1"
+				"for-in": "1.0.2",
+				"is-extendable": "1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -9597,7 +9592,7 @@
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
-						"is-plain-object": "^2.0.4"
+						"is-plain-object": "2.0.4"
 					}
 				}
 			}
@@ -9608,8 +9603,8 @@
 			"integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
 			"dev": true,
 			"requires": {
-				"for-in": "^0.1.3",
-				"is-extendable": "^0.1.1"
+				"for-in": "0.1.8",
+				"is-extendable": "0.1.1"
 			},
 			"dependencies": {
 				"for-in": {
@@ -9646,12 +9641,12 @@
 			"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
 			"dev": true,
 			"requires": {
-				"aproba": "^1.1.1",
-				"copy-concurrently": "^1.0.0",
-				"fs-write-stream-atomic": "^1.0.8",
-				"mkdirp": "^0.5.1",
-				"rimraf": "^2.5.4",
-				"run-queue": "^1.0.3"
+				"aproba": "1.2.0",
+				"copy-concurrently": "1.0.5",
+				"fs-write-stream-atomic": "1.0.10",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.3",
+				"run-queue": "1.0.3"
 			}
 		},
 		"ms": {
@@ -9677,17 +9672,17 @@
 			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
 			"dev": true,
 			"requires": {
-				"arr-diff": "^4.0.0",
-				"array-unique": "^0.3.2",
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"fragment-cache": "^0.2.1",
-				"is-windows": "^1.0.2",
-				"kind-of": "^6.0.2",
-				"object.pick": "^1.3.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
+				"arr-diff": "4.0.0",
+				"array-unique": "0.3.2",
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"fragment-cache": "0.2.1",
+				"is-windows": "1.0.2",
+				"kind-of": "6.0.2",
+				"object.pick": "1.3.0",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
 			}
 		},
 		"natural-compare": {
@@ -9706,7 +9701,7 @@
 			"resolved": "https://registry.npmjs.org/nextcloud-axios/-/nextcloud-axios-0.2.0.tgz",
 			"integrity": "sha512-OLDeZfub4pMkIKeXAPGqtFyV/xBbuOO5CSRgLvkT1O+HD4XZKP8+ywhbzXNBxA0ywLnMax3VsmPfQ7lvgy1m0w==",
 			"requires": {
-				"axios": "^0.19.0"
+				"axios": "0.19.0"
 			}
 		},
 		"nextcloud-vue": {
@@ -9714,17 +9709,17 @@
 			"resolved": "https://registry.npmjs.org/nextcloud-vue/-/nextcloud-vue-0.11.5.tgz",
 			"integrity": "sha512-pcwnOhEjTDNvo+GcG8neeaVVhbKe114y3m83fs+w/9wRxbUrR1XFQDwgvXbCGEpqkYN/0JilDHloOAgEhoQuhw==",
 			"requires": {
-				"@babel/polyfill": "^7.4.4",
-				"hammerjs": "^2.0.8",
-				"md5": "^2.2.1",
-				"nextcloud-axios": "^0.2.0",
-				"v-tooltip": "^2.0.0-rc.33",
-				"vue": "^2.6.7",
-				"vue-click-outside": "^1.0.7",
-				"vue-multiselect": "^2.1.3",
-				"vue-visible": "^1.0.2",
-				"vue2-datepicker": "^2.10.0",
-				"vuepress-jsdoc": "^1.7.3"
+				"@babel/polyfill": "7.4.4",
+				"hammerjs": "2.0.8",
+				"md5": "2.2.1",
+				"nextcloud-axios": "0.2.0",
+				"v-tooltip": "2.0.2",
+				"vue": "2.6.10",
+				"vue-click-outside": "1.0.7",
+				"vue-multiselect": "2.1.6",
+				"vue-visible": "1.0.2",
+				"vue2-datepicker": "2.12.0",
+				"vuepress-jsdoc": "1.7.3"
 			},
 			"dependencies": {
 				"v-tooltip": {
@@ -9732,9 +9727,9 @@
 					"resolved": "https://registry.npmjs.org/v-tooltip/-/v-tooltip-2.0.2.tgz",
 					"integrity": "sha512-xQ+qzOFfywkLdjHknRPgMMupQNS8yJtf9Utd5Dxiu/0n4HtrxqsgDtN2MLZ0LKbburtSAQgyypuE/snM8bBZhw==",
 					"requires": {
-						"lodash": "^4.17.11",
-						"popper.js": "^1.15.0",
-						"vue-resize": "^0.4.5"
+						"lodash": "4.17.14",
+						"popper.js": "1.15.0",
+						"vue-resize": "0.4.5"
 					}
 				}
 			}
@@ -9750,8 +9745,8 @@
 			"integrity": "sha512-obRu6/f7S024ysheAjoYFEEBqqDWv4LOMNJEuO8vMeEw2AT4z+NCzO4hlc2lhI4vATzbCQv6kke9FVdx0RbCOw==",
 			"dev": true,
 			"requires": {
-				"clone": "2.x",
-				"lodash": "4.x"
+				"clone": "2.1.2",
+				"lodash": "4.17.14"
 			}
 		},
 		"node-gyp": {
@@ -9760,18 +9755,18 @@
 			"integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
 			"dev": true,
 			"requires": {
-				"fstream": "^1.0.0",
-				"glob": "^7.0.3",
-				"graceful-fs": "^4.1.2",
-				"mkdirp": "^0.5.0",
-				"nopt": "2 || 3",
-				"npmlog": "0 || 1 || 2 || 3 || 4",
-				"osenv": "0",
-				"request": "^2.87.0",
-				"rimraf": "2",
-				"semver": "~5.3.0",
-				"tar": "^2.0.0",
-				"which": "1"
+				"fstream": "1.0.12",
+				"glob": "7.1.4",
+				"graceful-fs": "4.2.0",
+				"mkdirp": "0.5.1",
+				"nopt": "3.0.6",
+				"npmlog": "4.1.2",
+				"osenv": "0.1.5",
+				"request": "2.88.0",
+				"rimraf": "2.6.3",
+				"semver": "5.3.0",
+				"tar": "2.2.2",
+				"which": "1.3.1"
 			},
 			"dependencies": {
 				"nopt": {
@@ -9780,7 +9775,7 @@
 					"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
 					"dev": true,
 					"requires": {
-						"abbrev": "1"
+						"abbrev": "1.1.1"
 					}
 				},
 				"semver": {
@@ -9803,29 +9798,29 @@
 			"integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
 			"dev": true,
 			"requires": {
-				"assert": "^1.1.1",
-				"browserify-zlib": "^0.2.0",
-				"buffer": "^4.3.0",
-				"console-browserify": "^1.1.0",
-				"constants-browserify": "^1.0.0",
-				"crypto-browserify": "^3.11.0",
-				"domain-browser": "^1.1.1",
-				"events": "^3.0.0",
-				"https-browserify": "^1.0.0",
-				"os-browserify": "^0.3.0",
+				"assert": "1.5.0",
+				"browserify-zlib": "0.2.0",
+				"buffer": "4.9.1",
+				"console-browserify": "1.1.0",
+				"constants-browserify": "1.0.0",
+				"crypto-browserify": "3.12.0",
+				"domain-browser": "1.2.0",
+				"events": "3.0.0",
+				"https-browserify": "1.0.0",
+				"os-browserify": "0.3.0",
 				"path-browserify": "0.0.1",
-				"process": "^0.11.10",
-				"punycode": "^1.2.4",
-				"querystring-es3": "^0.2.0",
-				"readable-stream": "^2.3.3",
-				"stream-browserify": "^2.0.1",
-				"stream-http": "^2.7.2",
-				"string_decoder": "^1.0.0",
-				"timers-browserify": "^2.0.4",
+				"process": "0.11.10",
+				"punycode": "1.4.1",
+				"querystring-es3": "0.2.1",
+				"readable-stream": "2.3.6",
+				"stream-browserify": "2.0.2",
+				"stream-http": "2.8.3",
+				"string_decoder": "1.2.0",
+				"timers-browserify": "2.0.10",
 				"tty-browserify": "0.0.0",
-				"url": "^0.11.0",
-				"util": "^0.11.0",
-				"vm-browserify": "^1.0.1"
+				"url": "0.11.0",
+				"util": "0.11.1",
+				"vm-browserify": "1.1.0"
 			},
 			"dependencies": {
 				"punycode": {
@@ -9840,13 +9835,13 @@
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.4",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.1",
+						"safe-buffer": "5.1.2",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
 					},
 					"dependencies": {
 						"string_decoder": {
@@ -9855,7 +9850,7 @@
 							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"dev": true,
 							"requires": {
-								"safe-buffer": "~5.1.0"
+								"safe-buffer": "5.1.2"
 							}
 						}
 					}
@@ -9874,11 +9869,11 @@
 			"integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
 			"dev": true,
 			"requires": {
-				"growly": "^1.3.0",
-				"is-wsl": "^1.1.0",
-				"semver": "^5.5.0",
-				"shellwords": "^0.1.1",
-				"which": "^1.3.0"
+				"growly": "1.3.0",
+				"is-wsl": "1.1.0",
+				"semver": "5.7.0",
+				"shellwords": "0.1.1",
+				"which": "1.3.1"
 			}
 		},
 		"node-releases": {
@@ -9887,7 +9882,7 @@
 			"integrity": "sha512-fI5BXuk83lKEoZDdH3gRhtsNgh05/wZacuXkgbiYkceE7+QIMXOg98n9ZV7mz27B+kFHnqHcUpscZZlGRSmTpQ==",
 			"dev": true,
 			"requires": {
-				"semver": "^5.3.0"
+				"semver": "5.7.0"
 			}
 		},
 		"node-sass": {
@@ -9896,23 +9891,23 @@
 			"integrity": "sha512-A1Iv4oN+Iel6EPv77/HddXErL2a+gZ4uBeZUy+a8O35CFYTXhgA8MgLCWBtwpGZdCvTvQ9d+bQxX/QC36GDPpQ==",
 			"dev": true,
 			"requires": {
-				"async-foreach": "^0.1.3",
-				"chalk": "^1.1.1",
-				"cross-spawn": "^3.0.0",
-				"gaze": "^1.0.0",
-				"get-stdin": "^4.0.1",
-				"glob": "^7.0.3",
-				"in-publish": "^2.0.0",
-				"lodash": "^4.17.11",
-				"meow": "^3.7.0",
-				"mkdirp": "^0.5.1",
-				"nan": "^2.13.2",
-				"node-gyp": "^3.8.0",
-				"npmlog": "^4.0.0",
-				"request": "^2.88.0",
-				"sass-graph": "^2.2.4",
-				"stdout-stream": "^1.4.0",
-				"true-case-path": "^1.0.2"
+				"async-foreach": "0.1.3",
+				"chalk": "1.1.3",
+				"cross-spawn": "3.0.1",
+				"gaze": "1.1.3",
+				"get-stdin": "4.0.1",
+				"glob": "7.1.4",
+				"in-publish": "2.0.0",
+				"lodash": "4.17.14",
+				"meow": "3.7.0",
+				"mkdirp": "0.5.1",
+				"nan": "2.14.0",
+				"node-gyp": "3.8.0",
+				"npmlog": "4.1.2",
+				"request": "2.88.0",
+				"sass-graph": "2.2.4",
+				"stdout-stream": "1.4.1",
+				"true-case-path": "1.0.3"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -9933,11 +9928,11 @@
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
 					}
 				},
 				"cross-spawn": {
@@ -9946,8 +9941,8 @@
 					"integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
 					"dev": true,
 					"requires": {
-						"lru-cache": "^4.0.1",
-						"which": "^1.2.9"
+						"lru-cache": "4.1.5",
+						"which": "1.3.1"
 					}
 				},
 				"strip-ansi": {
@@ -9956,7 +9951,7 @@
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				},
 				"supports-color": {
@@ -9973,8 +9968,8 @@
 			"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 			"dev": true,
 			"requires": {
-				"abbrev": "1",
-				"osenv": "^0.1.4"
+				"abbrev": "1.1.1",
+				"osenv": "0.1.5"
 			}
 		},
 		"normalize-package-data": {
@@ -9983,10 +9978,10 @@
 			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
 			"dev": true,
 			"requires": {
-				"hosted-git-info": "^2.1.4",
-				"resolve": "^1.10.0",
-				"semver": "2 || 3 || 4 || 5",
-				"validate-npm-package-license": "^3.0.1"
+				"hosted-git-info": "2.7.1",
+				"resolve": "1.11.1",
+				"semver": "5.7.0",
+				"validate-npm-package-license": "3.0.4"
 			}
 		},
 		"normalize-path": {
@@ -9995,7 +9990,7 @@
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 			"dev": true,
 			"requires": {
-				"remove-trailing-separator": "^1.0.1"
+				"remove-trailing-separator": "1.1.0"
 			}
 		},
 		"normalize-range": {
@@ -10015,7 +10010,7 @@
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"requires": {
-				"path-key": "^2.0.0"
+				"path-key": "2.0.1"
 			}
 		},
 		"npmlog": {
@@ -10024,10 +10019,10 @@
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 			"dev": true,
 			"requires": {
-				"are-we-there-yet": "~1.1.2",
-				"console-control-strings": "~1.1.0",
-				"gauge": "~2.7.3",
-				"set-blocking": "~2.0.0"
+				"are-we-there-yet": "1.1.5",
+				"console-control-strings": "1.1.0",
+				"gauge": "2.7.4",
+				"set-blocking": "2.0.0"
 			}
 		},
 		"nth-check": {
@@ -10035,7 +10030,7 @@
 			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
 			"integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
 			"requires": {
-				"boolbase": "~1.0.0"
+				"boolbase": "1.0.0"
 			}
 		},
 		"num2fraction": {
@@ -10073,9 +10068,9 @@
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
 			"dev": true,
 			"requires": {
-				"copy-descriptor": "^0.1.0",
-				"define-property": "^0.2.5",
-				"kind-of": "^3.0.3"
+				"copy-descriptor": "0.1.1",
+				"define-property": "0.2.5",
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -10084,7 +10079,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"is-buffer": {
@@ -10099,7 +10094,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -10132,7 +10127,7 @@
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
 			"dev": true,
 			"requires": {
-				"isobject": "^3.0.0"
+				"isobject": "3.0.1"
 			}
 		},
 		"object.assign": {
@@ -10141,10 +10136,10 @@
 			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"function-bind": "^1.1.1",
-				"has-symbols": "^1.0.0",
-				"object-keys": "^1.0.11"
+				"define-properties": "1.1.3",
+				"function-bind": "1.1.1",
+				"has-symbols": "1.0.0",
+				"object-keys": "1.1.1"
 			}
 		},
 		"object.getownpropertydescriptors": {
@@ -10153,8 +10148,8 @@
 			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.5.1"
+				"define-properties": "1.1.3",
+				"es-abstract": "1.13.0"
 			}
 		},
 		"object.omit": {
@@ -10163,8 +10158,8 @@
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
 			"dev": true,
 			"requires": {
-				"for-own": "^0.1.4",
-				"is-extendable": "^0.1.1"
+				"for-own": "0.1.5",
+				"is-extendable": "0.1.1"
 			},
 			"dependencies": {
 				"for-own": {
@@ -10173,7 +10168,7 @@
 					"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
 					"dev": true,
 					"requires": {
-						"for-in": "^1.0.1"
+						"for-in": "1.0.2"
 					}
 				}
 			}
@@ -10184,7 +10179,7 @@
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
 			"dev": true,
 			"requires": {
-				"isobject": "^3.0.1"
+				"isobject": "3.0.1"
 			}
 		},
 		"object.values": {
@@ -10193,10 +10188,10 @@
 			"integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.12.0",
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3"
+				"define-properties": "1.1.3",
+				"es-abstract": "1.13.0",
+				"function-bind": "1.1.1",
+				"has": "1.0.3"
 			}
 		},
 		"once": {
@@ -10204,7 +10199,7 @@
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
-				"wrappy": "1"
+				"wrappy": "1.0.2"
 			}
 		},
 		"onetime": {
@@ -10213,7 +10208,7 @@
 			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "^1.0.0"
+				"mimic-fn": "1.2.0"
 			},
 			"dependencies": {
 				"mimic-fn": {
@@ -10229,8 +10224,8 @@
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
 			"requires": {
-				"minimist": "~0.0.1",
-				"wordwrap": "~0.0.2"
+				"minimist": "0.0.10",
+				"wordwrap": "0.0.3"
 			}
 		},
 		"optionator": {
@@ -10239,12 +10234,12 @@
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"dev": true,
 			"requires": {
-				"deep-is": "~0.1.3",
-				"fast-levenshtein": "~2.0.4",
-				"levn": "~0.3.0",
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2",
-				"wordwrap": "~1.0.0"
+				"deep-is": "0.1.3",
+				"fast-levenshtein": "2.0.6",
+				"levn": "0.3.0",
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2",
+				"wordwrap": "1.0.0"
 			},
 			"dependencies": {
 				"wordwrap": {
@@ -10272,9 +10267,9 @@
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
 			"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
 			"requires": {
-				"execa": "^1.0.0",
-				"lcid": "^2.0.0",
-				"mem": "^4.0.0"
+				"execa": "1.0.0",
+				"lcid": "2.0.0",
+				"mem": "4.3.0"
 			}
 		},
 		"os-tmpdir": {
@@ -10289,8 +10284,8 @@
 			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 			"dev": true,
 			"requires": {
-				"os-homedir": "^1.0.0",
-				"os-tmpdir": "^1.0.0"
+				"os-homedir": "1.0.2",
+				"os-tmpdir": "1.0.2"
 			}
 		},
 		"p-defer": {
@@ -10304,7 +10299,7 @@
 			"integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
 			"dev": true,
 			"requires": {
-				"p-reduce": "^1.0.0"
+				"p-reduce": "1.0.0"
 			}
 		},
 		"p-finally": {
@@ -10322,7 +10317,7 @@
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
 			"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
 			"requires": {
-				"p-try": "^2.0.0"
+				"p-try": "2.2.0"
 			}
 		},
 		"p-locate": {
@@ -10330,7 +10325,7 @@
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
 			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 			"requires": {
-				"p-limit": "^2.0.0"
+				"p-limit": "2.2.0"
 			}
 		},
 		"p-map": {
@@ -10361,9 +10356,9 @@
 			"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
 			"dev": true,
 			"requires": {
-				"cyclist": "~0.2.2",
-				"inherits": "^2.0.3",
-				"readable-stream": "^2.1.5"
+				"cyclist": "0.2.2",
+				"inherits": "2.0.4",
+				"readable-stream": "2.3.6"
 			},
 			"dependencies": {
 				"readable-stream": {
@@ -10372,13 +10367,13 @@
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.4",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.1",
+						"safe-buffer": "5.1.2",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"string_decoder": {
@@ -10387,7 +10382,7 @@
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "5.1.2"
 					}
 				}
 			}
@@ -10398,7 +10393,7 @@
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
 			"dev": true,
 			"requires": {
-				"callsites": "^3.0.0"
+				"callsites": "3.1.0"
 			}
 		},
 		"parse-asn1": {
@@ -10407,12 +10402,12 @@
 			"integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
 			"dev": true,
 			"requires": {
-				"asn1.js": "^4.0.0",
-				"browserify-aes": "^1.0.0",
-				"create-hash": "^1.1.0",
-				"evp_bytestokey": "^1.0.0",
-				"pbkdf2": "^3.0.3",
-				"safe-buffer": "^5.1.1"
+				"asn1.js": "4.10.1",
+				"browserify-aes": "1.2.0",
+				"create-hash": "1.2.0",
+				"evp_bytestokey": "1.0.3",
+				"pbkdf2": "3.0.17",
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"parse-entities": {
@@ -10420,12 +10415,12 @@
 			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
 			"integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
 			"requires": {
-				"character-entities": "^1.0.0",
-				"character-entities-legacy": "^1.0.0",
-				"character-reference-invalid": "^1.0.0",
-				"is-alphanumerical": "^1.0.0",
-				"is-decimal": "^1.0.0",
-				"is-hexadecimal": "^1.0.0"
+				"character-entities": "1.2.3",
+				"character-entities-legacy": "1.1.3",
+				"character-reference-invalid": "1.1.3",
+				"is-alphanumerical": "1.0.3",
+				"is-decimal": "1.0.3",
+				"is-hexadecimal": "1.0.3"
 			}
 		},
 		"parse-glob": {
@@ -10434,10 +10429,10 @@
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
 			"dev": true,
 			"requires": {
-				"glob-base": "^0.3.0",
-				"is-dotfile": "^1.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.0"
+				"glob-base": "0.3.0",
+				"is-dotfile": "1.0.3",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1"
 			}
 		},
 		"parse-json": {
@@ -10446,8 +10441,8 @@
 			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 			"dev": true,
 			"requires": {
-				"error-ex": "^1.3.1",
-				"json-parse-better-errors": "^1.0.1"
+				"error-ex": "1.3.2",
+				"json-parse-better-errors": "1.0.2"
 			}
 		},
 		"parse-passwd": {
@@ -10461,7 +10456,7 @@
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
 			"integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
 			"requires": {
-				"@types/node": "*"
+				"@types/node": "12.6.2"
 			}
 		},
 		"pascalcase": {
@@ -10514,7 +10509,7 @@
 			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 			"dev": true,
 			"requires": {
-				"pify": "^3.0.0"
+				"pify": "3.0.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -10531,11 +10526,11 @@
 			"integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
 			"dev": true,
 			"requires": {
-				"create-hash": "^1.1.2",
-				"create-hmac": "^1.1.4",
-				"ripemd160": "^2.0.1",
-				"safe-buffer": "^5.0.1",
-				"sha.js": "^2.4.8"
+				"create-hash": "1.2.0",
+				"create-hmac": "1.1.7",
+				"ripemd160": "2.0.2",
+				"safe-buffer": "5.1.2",
+				"sha.js": "2.4.11"
 			}
 		},
 		"performance-now": {
@@ -10564,7 +10559,7 @@
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 			"requires": {
-				"pinkie": "^2.0.0"
+				"pinkie": "2.0.4"
 			}
 		},
 		"pirates": {
@@ -10573,7 +10568,7 @@
 			"integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
 			"dev": true,
 			"requires": {
-				"node-modules-regexp": "^1.0.0"
+				"node-modules-regexp": "1.0.0"
 			}
 		},
 		"pkg-dir": {
@@ -10582,7 +10577,7 @@
 			"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
 			"dev": true,
 			"requires": {
-				"find-up": "^3.0.0"
+				"find-up": "3.0.0"
 			}
 		},
 		"pn": {
@@ -10608,9 +10603,9 @@
 			"integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.4.2",
-				"source-map": "^0.6.1",
-				"supports-color": "^6.1.0"
+				"chalk": "2.4.2",
+				"source-map": "0.6.1",
+				"supports-color": "6.1.0"
 			},
 			"dependencies": {
 				"supports-color": {
@@ -10619,7 +10614,7 @@
 					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -10630,9 +10625,9 @@
 			"integrity": "sha512-KxKUpj7AY7nlCbLcTOYxdfJnGE7QFAfU2n95ADj1Q90RM/pOLdz8k3n4avOyRFs7MDQHcRzJQWM1dehCwJxisQ==",
 			"dev": true,
 			"requires": {
-				"htmlparser2": "^3.9.2",
-				"remark": "^8.0.0",
-				"unist-util-find-all-after": "^1.0.1"
+				"htmlparser2": "3.10.1",
+				"remark": "8.0.0",
+				"unist-util-find-all-after": "1.0.4"
 			},
 			"dependencies": {
 				"remark": {
@@ -10641,9 +10636,9 @@
 					"integrity": "sha512-K0PTsaZvJlXTl9DN6qYlvjTkqSZBFELhROZMrblm2rB+085flN84nz4g/BscKRMqDvhzlK1oQ/xnWQumdeNZYw==",
 					"dev": true,
 					"requires": {
-						"remark-parse": "^4.0.0",
-						"remark-stringify": "^4.0.0",
-						"unified": "^6.0.0"
+						"remark-parse": "4.0.0",
+						"remark-stringify": "4.0.0",
+						"unified": "6.2.0"
 					}
 				},
 				"remark-parse": {
@@ -10652,21 +10647,21 @@
 					"integrity": "sha512-XZgICP2gJ1MHU7+vQaRM+VA9HEL3X253uwUM/BGgx3iv6TH2B3bF3B8q00DKcyP9YrJV+/7WOWEWBFF/u8cIsw==",
 					"dev": true,
 					"requires": {
-						"collapse-white-space": "^1.0.2",
-						"is-alphabetical": "^1.0.0",
-						"is-decimal": "^1.0.0",
-						"is-whitespace-character": "^1.0.0",
-						"is-word-character": "^1.0.0",
-						"markdown-escapes": "^1.0.0",
-						"parse-entities": "^1.0.2",
-						"repeat-string": "^1.5.4",
-						"state-toggle": "^1.0.0",
+						"collapse-white-space": "1.0.5",
+						"is-alphabetical": "1.0.3",
+						"is-decimal": "1.0.3",
+						"is-whitespace-character": "1.0.3",
+						"is-word-character": "1.0.3",
+						"markdown-escapes": "1.0.3",
+						"parse-entities": "1.2.2",
+						"repeat-string": "1.6.1",
+						"state-toggle": "1.0.2",
 						"trim": "0.0.1",
-						"trim-trailing-lines": "^1.0.0",
-						"unherit": "^1.0.4",
-						"unist-util-remove-position": "^1.0.0",
-						"vfile-location": "^2.0.0",
-						"xtend": "^4.0.1"
+						"trim-trailing-lines": "1.1.2",
+						"unherit": "1.1.2",
+						"unist-util-remove-position": "1.1.3",
+						"vfile-location": "2.0.5",
+						"xtend": "4.0.2"
 					}
 				},
 				"remark-stringify": {
@@ -10675,20 +10670,20 @@
 					"integrity": "sha512-xLuyKTnuQer3ke9hkU38SUYLiTmS078QOnoFavztmbt/pAJtNSkNtFgR0U//uCcmG0qnyxao+PDuatQav46F1w==",
 					"dev": true,
 					"requires": {
-						"ccount": "^1.0.0",
-						"is-alphanumeric": "^1.0.0",
-						"is-decimal": "^1.0.0",
-						"is-whitespace-character": "^1.0.0",
-						"longest-streak": "^2.0.1",
-						"markdown-escapes": "^1.0.0",
-						"markdown-table": "^1.1.0",
-						"mdast-util-compact": "^1.0.0",
-						"parse-entities": "^1.0.2",
-						"repeat-string": "^1.5.4",
-						"state-toggle": "^1.0.0",
-						"stringify-entities": "^1.0.1",
-						"unherit": "^1.0.4",
-						"xtend": "^4.0.1"
+						"ccount": "1.0.4",
+						"is-alphanumeric": "1.0.0",
+						"is-decimal": "1.0.3",
+						"is-whitespace-character": "1.0.3",
+						"longest-streak": "2.0.3",
+						"markdown-escapes": "1.0.3",
+						"markdown-table": "1.1.3",
+						"mdast-util-compact": "1.0.3",
+						"parse-entities": "1.2.2",
+						"repeat-string": "1.6.1",
+						"state-toggle": "1.0.2",
+						"stringify-entities": "1.3.2",
+						"unherit": "1.1.2",
+						"xtend": "4.0.2"
 					}
 				}
 			}
@@ -10699,7 +10694,7 @@
 			"integrity": "sha512-QQIiIqgEjNnquc0d4b6HDOSFZxbFQoy4MPpli2lSLpKhMyBkKwwca2HFqu4xzxlKID/F2fxSOowwtKpgczhF7A==",
 			"dev": true,
 			"requires": {
-				"postcss": "^5.2.16"
+				"postcss": "5.2.18"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -10720,11 +10715,11 @@
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
 					},
 					"dependencies": {
 						"supports-color": {
@@ -10747,10 +10742,10 @@
 					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
 					"dev": true,
 					"requires": {
-						"chalk": "^1.1.3",
-						"js-base64": "^2.1.9",
-						"source-map": "^0.5.6",
-						"supports-color": "^3.2.3"
+						"chalk": "1.1.3",
+						"js-base64": "2.5.1",
+						"source-map": "0.5.7",
+						"supports-color": "3.2.3"
 					}
 				},
 				"source-map": {
@@ -10765,7 +10760,7 @@
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				},
 				"supports-color": {
@@ -10774,7 +10769,7 @@
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"dev": true,
 					"requires": {
-						"has-flag": "^1.0.0"
+						"has-flag": "1.0.0"
 					}
 				}
 			}
@@ -10791,7 +10786,7 @@
 			"integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
 			"dev": true,
 			"requires": {
-				"postcss": "^7.0.5"
+				"postcss": "7.0.17"
 			}
 		},
 		"postcss-modules-local-by-default": {
@@ -10800,10 +10795,10 @@
 			"integrity": "sha512-jM/V8eqM4oJ/22j0gx4jrp63GSvDH6v86OqyTHHUvk4/k1vceipZsaymiZ5PvocqZOl5SFHiFJqjs3la0wnfIQ==",
 			"dev": true,
 			"requires": {
-				"icss-utils": "^4.1.1",
-				"postcss": "^7.0.16",
-				"postcss-selector-parser": "^6.0.2",
-				"postcss-value-parser": "^4.0.0"
+				"icss-utils": "4.1.1",
+				"postcss": "7.0.17",
+				"postcss-selector-parser": "6.0.2",
+				"postcss-value-parser": "4.0.0"
 			}
 		},
 		"postcss-modules-scope": {
@@ -10812,8 +10807,8 @@
 			"integrity": "sha512-91Rjps0JnmtUB0cujlc8KIKCsJXWjzuxGeT/+Q2i2HXKZ7nBUeF9YQTZZTNvHVoNYj1AthsjnGLtqDUE0Op79A==",
 			"dev": true,
 			"requires": {
-				"postcss": "^7.0.6",
-				"postcss-selector-parser": "^6.0.0"
+				"postcss": "7.0.17",
+				"postcss-selector-parser": "6.0.2"
 			}
 		},
 		"postcss-modules-values": {
@@ -10822,8 +10817,8 @@
 			"integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
 			"dev": true,
 			"requires": {
-				"icss-utils": "^4.0.0",
-				"postcss": "^7.0.6"
+				"icss-utils": "4.1.1",
+				"postcss": "7.0.17"
 			}
 		},
 		"postcss-reporter": {
@@ -10832,10 +10827,10 @@
 			"integrity": "sha512-rBkDbaHAu5uywbCR2XE8a25tats3xSOsGNx6mppK6Q9kSFGKc/FyAzfci+fWM2l+K402p1D0pNcfDGxeje5IKg==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"lodash": "^4.17.4",
-				"log-symbols": "^2.0.0",
-				"postcss": "^6.0.8"
+				"chalk": "2.4.2",
+				"lodash": "4.17.14",
+				"log-symbols": "2.2.0",
+				"postcss": "6.0.23"
 			},
 			"dependencies": {
 				"postcss": {
@@ -10844,9 +10839,9 @@
 					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
 					"dev": true,
 					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
+						"chalk": "2.4.2",
+						"source-map": "0.6.1",
+						"supports-color": "5.5.0"
 					}
 				}
 			}
@@ -10863,7 +10858,7 @@
 			"integrity": "sha1-t1Pv9sfArqXoN1++TN6L+QY/8UI=",
 			"dev": true,
 			"requires": {
-				"postcss": "^6.0.6"
+				"postcss": "6.0.23"
 			},
 			"dependencies": {
 				"postcss": {
@@ -10872,9 +10867,9 @@
 					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
 					"dev": true,
 					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
+						"chalk": "2.4.2",
+						"source-map": "0.6.1",
+						"supports-color": "5.5.0"
 					}
 				}
 			}
@@ -10885,8 +10880,8 @@
 			"integrity": "sha512-cUmYzkP747fPCQE6d+CH2l1L4VSyIlAzZsok3HPjb5Gzsq3jE+VjpAdGlPsnQ310WKWI42sw+ar0UNN59/f3hg==",
 			"dev": true,
 			"requires": {
-				"gonzales-pe": "^4.0.3",
-				"postcss": "^6.0.6"
+				"gonzales-pe": "4.2.4",
+				"postcss": "6.0.23"
 			},
 			"dependencies": {
 				"postcss": {
@@ -10895,9 +10890,9 @@
 					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
 					"dev": true,
 					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
+						"chalk": "2.4.2",
+						"source-map": "0.6.1",
+						"supports-color": "5.5.0"
 					}
 				}
 			}
@@ -10908,7 +10903,7 @@
 			"integrity": "sha512-4EFYGHcEw+H3E06PT/pQQri06u/1VIIPjeJQaM8skB80vZuXMhp4cSNV5azmdNkontnOID/XYWEvEEELLFB1ww==",
 			"dev": true,
 			"requires": {
-				"postcss": "^6.0.23"
+				"postcss": "6.0.23"
 			},
 			"dependencies": {
 				"postcss": {
@@ -10917,9 +10912,9 @@
 					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
 					"dev": true,
 					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
+						"chalk": "2.4.2",
+						"source-map": "0.6.1",
+						"supports-color": "5.5.0"
 					}
 				}
 			}
@@ -10930,9 +10925,9 @@
 			"integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
 			"dev": true,
 			"requires": {
-				"cssesc": "^3.0.0",
-				"indexes-of": "^1.0.1",
-				"uniq": "^1.0.1"
+				"cssesc": "3.0.0",
+				"indexes-of": "1.0.1",
+				"uniq": "1.0.1"
 			}
 		},
 		"postcss-value-parser": {
@@ -10965,19 +10960,19 @@
 			"integrity": "sha512-0dael2aMpMAxAwClnLi2Coc30v3BubsTX6clqseZ8NFCJZnbZlwxZGHHESYBlqTyN9lvZDHHv+XdeHW0fKhxJQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/parser": "^1.10.2",
-				"common-tags": "^1.4.0",
-				"core-js": "^3.1.4",
-				"dlv": "^1.1.0",
-				"eslint": "^5.0.0",
-				"indent-string": "^4.0.0",
-				"lodash.merge": "^4.6.0",
-				"loglevel-colored-level-prefix": "^1.0.0",
-				"prettier": "^1.7.0",
-				"pretty-format": "^23.0.1",
-				"require-relative": "^0.8.7",
-				"typescript": "^3.2.1",
-				"vue-eslint-parser": "^2.0.2"
+				"@typescript-eslint/parser": "1.12.0",
+				"common-tags": "1.8.0",
+				"core-js": "3.1.4",
+				"dlv": "1.1.3",
+				"eslint": "5.16.0",
+				"indent-string": "4.0.0",
+				"lodash.merge": "4.6.2",
+				"loglevel-colored-level-prefix": "1.0.0",
+				"prettier": "1.18.2",
+				"pretty-format": "23.6.0",
+				"require-relative": "0.8.7",
+				"typescript": "3.5.3",
+				"vue-eslint-parser": "2.0.3"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -11004,8 +10999,8 @@
 					"integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0",
-						"ansi-styles": "^3.2.0"
+						"ansi-regex": "3.0.0",
+						"ansi-styles": "3.2.1"
 					}
 				},
 				"vue-eslint-parser": {
@@ -11014,12 +11009,12 @@
 					"integrity": "sha512-ZezcU71Owm84xVF6gfurBQUGg8WQ+WZGxgDEQu1IHFBZNx7BFZg3L1yHxrCBNNwbwFtE1GuvfJKMtb6Xuwc/Bw==",
 					"dev": true,
 					"requires": {
-						"debug": "^3.1.0",
-						"eslint-scope": "^3.7.1",
-						"eslint-visitor-keys": "^1.0.0",
-						"espree": "^3.5.2",
-						"esquery": "^1.0.0",
-						"lodash": "^4.17.4"
+						"debug": "3.1.0",
+						"eslint-scope": "3.7.1",
+						"eslint-visitor-keys": "1.0.0",
+						"espree": "3.5.4",
+						"esquery": "1.0.1",
+						"lodash": "4.17.14"
 					}
 				}
 			}
@@ -11030,9 +11025,9 @@
 			"integrity": "sha1-rbx5YLe7/iiaVX3F9zdhmiINBqU=",
 			"dev": true,
 			"requires": {
-				"condense-newlines": "^0.2.1",
-				"extend-shallow": "^2.0.1",
-				"js-beautify": "^1.6.12"
+				"condense-newlines": "0.2.1",
+				"extend-shallow": "2.0.1",
+				"js-beautify": "1.10.0"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -11041,7 +11036,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -11052,10 +11047,10 @@
 			"integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
-				"ansi-regex": "^4.0.0",
-				"ansi-styles": "^3.2.0",
-				"react-is": "^16.8.4"
+				"@jest/types": "24.8.0",
+				"ansi-regex": "4.1.0",
+				"ansi-styles": "3.2.1",
+				"react-is": "16.8.6"
 			}
 		},
 		"private": {
@@ -11094,8 +11089,8 @@
 			"integrity": "sha512-+x5TozgqYdOwWsQFZizE/Tra3fKvAoy037kOyU6cgz84n8f6zxngLOV4O32kTwt9FcLCxAqw0P/c8rOr9y+Gfg==",
 			"dev": true,
 			"requires": {
-				"kleur": "^3.0.2",
-				"sisteransi": "^1.0.0"
+				"kleur": "3.0.3",
+				"sisteransi": "1.0.2"
 			}
 		},
 		"prop-types": {
@@ -11139,12 +11134,12 @@
 			"integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.1.0",
-				"browserify-rsa": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"parse-asn1": "^5.0.0",
-				"randombytes": "^2.0.1",
-				"safe-buffer": "^5.1.2"
+				"bn.js": "4.11.8",
+				"browserify-rsa": "4.0.1",
+				"create-hash": "1.2.0",
+				"parse-asn1": "5.1.4",
+				"randombytes": "2.1.0",
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"pump": {
@@ -11152,8 +11147,8 @@
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
 			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
 			"requires": {
-				"end-of-stream": "^1.1.0",
-				"once": "^1.3.1"
+				"end-of-stream": "1.4.1",
+				"once": "1.4.0"
 			}
 		},
 		"pumpify": {
@@ -11162,9 +11157,9 @@
 			"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
 			"dev": true,
 			"requires": {
-				"duplexify": "^3.6.0",
-				"inherits": "^2.0.3",
-				"pump": "^2.0.0"
+				"duplexify": "3.7.1",
+				"inherits": "2.0.4",
+				"pump": "2.0.1"
 			},
 			"dependencies": {
 				"pump": {
@@ -11173,8 +11168,8 @@
 					"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
 					"dev": true,
 					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.1"
+						"end-of-stream": "1.4.1",
+						"once": "1.4.0"
 					}
 				}
 			}
@@ -11221,9 +11216,9 @@
 			"integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
 			"dev": true,
 			"requires": {
-				"is-number": "^4.0.0",
-				"kind-of": "^6.0.0",
-				"math-random": "^1.0.1"
+				"is-number": "4.0.0",
+				"kind-of": "6.0.2",
+				"math-random": "1.0.4"
 			},
 			"dependencies": {
 				"is-number": {
@@ -11240,7 +11235,7 @@
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "^5.1.0"
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"randomfill": {
@@ -11249,8 +11244,8 @@
 			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
 			"dev": true,
 			"requires": {
-				"randombytes": "^2.0.5",
-				"safe-buffer": "^5.1.0"
+				"randombytes": "2.1.0",
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"raw-loader": {
@@ -11259,8 +11254,8 @@
 			"integrity": "sha512-FsELYliOpX5HdPdxa7PzTmEc5OTchmLUs/r4f8oLDGCYE+xC2FjVbDXzdyLcBrdlDnvkx1x5wzphixcWpxJG5w==",
 			"dev": true,
 			"requires": {
-				"loader-utils": "^1.1.0",
-				"schema-utils": "^1.0.0"
+				"loader-utils": "1.2.3",
+				"schema-utils": "1.0.0"
 			}
 		},
 		"react": {
@@ -11298,9 +11293,9 @@
 			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "^4.0.0",
-				"normalize-package-data": "^2.3.2",
-				"path-type": "^3.0.0"
+				"load-json-file": "4.0.0",
+				"normalize-package-data": "2.5.0",
+				"path-type": "3.0.0"
 			}
 		},
 		"read-pkg-up": {
@@ -11309,8 +11304,8 @@
 			"integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
 			"dev": true,
 			"requires": {
-				"find-up": "^3.0.0",
-				"read-pkg": "^3.0.0"
+				"find-up": "3.0.0",
+				"read-pkg": "3.0.0"
 			}
 		},
 		"readable-stream": {
@@ -11318,9 +11313,9 @@
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
 			"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
 			"requires": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
+				"inherits": "2.0.4",
+				"string_decoder": "1.2.0",
+				"util-deprecate": "1.0.2"
 			}
 		},
 		"readdirp": {
@@ -11329,9 +11324,9 @@
 			"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.11",
-				"micromatch": "^3.1.10",
-				"readable-stream": "^2.0.2"
+				"graceful-fs": "4.2.0",
+				"micromatch": "3.1.10",
+				"readable-stream": "2.3.6"
 			},
 			"dependencies": {
 				"braces": {
@@ -11340,16 +11335,16 @@
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.3",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -11358,7 +11353,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -11369,10 +11364,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -11381,7 +11376,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -11398,7 +11393,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -11407,7 +11402,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -11418,19 +11413,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.13",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					}
 				},
 				"readable-stream": {
@@ -11439,13 +11434,13 @@
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.4",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.1",
+						"safe-buffer": "5.1.2",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"string_decoder": {
@@ -11454,7 +11449,7 @@
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "5.1.2"
 					}
 				},
 				"to-regex-range": {
@@ -11463,8 +11458,8 @@
 					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 					"dev": true,
 					"requires": {
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1"
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1"
 					}
 				}
 			}
@@ -11475,7 +11470,7 @@
 			"integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
 			"dev": true,
 			"requires": {
-				"util.promisify": "^1.0.0"
+				"util.promisify": "1.0.0"
 			}
 		},
 		"redent": {
@@ -11484,8 +11479,8 @@
 			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
 			"dev": true,
 			"requires": {
-				"indent-string": "^2.1.0",
-				"strip-indent": "^1.0.1"
+				"indent-string": "2.1.0",
+				"strip-indent": "1.0.1"
 			}
 		},
 		"reduce-extract": {
@@ -11493,7 +11488,7 @@
 			"resolved": "https://registry.npmjs.org/reduce-extract/-/reduce-extract-1.0.0.tgz",
 			"integrity": "sha1-Z/I4W+2mUGG19fQxJmLosIDKFSU=",
 			"requires": {
-				"test-value": "^1.0.1"
+				"test-value": "1.1.0"
 			},
 			"dependencies": {
 				"array-back": {
@@ -11501,7 +11496,7 @@
 					"resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
 					"integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
 					"requires": {
-						"typical": "^2.6.0"
+						"typical": "2.6.1"
 					}
 				},
 				"test-value": {
@@ -11509,8 +11504,8 @@
 					"resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
 					"integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
 					"requires": {
-						"array-back": "^1.0.2",
-						"typical": "^2.4.2"
+						"array-back": "1.0.4",
+						"typical": "2.6.1"
 					}
 				}
 			}
@@ -11530,7 +11525,7 @@
 			"resolved": "https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.1.tgz",
 			"integrity": "sha1-aK0OrRGFXJo31OglbBW7+Hly/Iw=",
 			"requires": {
-				"test-value": "^2.0.0"
+				"test-value": "2.1.0"
 			},
 			"dependencies": {
 				"array-back": {
@@ -11538,7 +11533,7 @@
 					"resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
 					"integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
 					"requires": {
-						"typical": "^2.6.0"
+						"typical": "2.6.1"
 					}
 				},
 				"test-value": {
@@ -11546,8 +11541,8 @@
 					"resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
 					"integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
 					"requires": {
-						"array-back": "^1.0.3",
-						"typical": "^2.6.0"
+						"array-back": "1.0.4",
+						"typical": "2.6.1"
 					}
 				}
 			}
@@ -11564,7 +11559,7 @@
 			"integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
 			"dev": true,
 			"requires": {
-				"regenerate": "^1.4.0"
+				"regenerate": "1.4.0"
 			}
 		},
 		"regenerator-runtime": {
@@ -11578,7 +11573,7 @@
 			"integrity": "sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==",
 			"dev": true,
 			"requires": {
-				"private": "^0.1.6"
+				"private": "0.1.8"
 			}
 		},
 		"regex-cache": {
@@ -11587,7 +11582,7 @@
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
 			"dev": true,
 			"requires": {
-				"is-equal-shallow": "^0.1.3"
+				"is-equal-shallow": "0.1.3"
 			}
 		},
 		"regex-not": {
@@ -11596,8 +11591,8 @@
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^3.0.2",
-				"safe-regex": "^1.1.0"
+				"extend-shallow": "3.0.2",
+				"safe-regex": "1.1.0"
 			}
 		},
 		"regexp-tree": {
@@ -11618,12 +11613,12 @@
 			"integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
 			"dev": true,
 			"requires": {
-				"regenerate": "^1.4.0",
-				"regenerate-unicode-properties": "^8.0.2",
-				"regjsgen": "^0.5.0",
-				"regjsparser": "^0.6.0",
-				"unicode-match-property-ecmascript": "^1.0.4",
-				"unicode-match-property-value-ecmascript": "^1.1.0"
+				"regenerate": "1.4.0",
+				"regenerate-unicode-properties": "8.1.0",
+				"regjsgen": "0.5.0",
+				"regjsparser": "0.6.0",
+				"unicode-match-property-ecmascript": "1.0.4",
+				"unicode-match-property-value-ecmascript": "1.1.0"
 			}
 		},
 		"regjsgen": {
@@ -11638,7 +11633,7 @@
 			"integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
 			"dev": true,
 			"requires": {
-				"jsesc": "~0.5.0"
+				"jsesc": "0.5.0"
 			},
 			"dependencies": {
 				"jsesc": {
@@ -11654,9 +11649,9 @@
 			"resolved": "https://registry.npmjs.org/remark/-/remark-7.0.1.tgz",
 			"integrity": "sha1-pd5NrPq/D2CkmCbvJMR5gH+QS/s=",
 			"requires": {
-				"remark-parse": "^3.0.0",
-				"remark-stringify": "^3.0.0",
-				"unified": "^6.0.0"
+				"remark-parse": "3.0.1",
+				"remark-stringify": "3.0.1",
+				"unified": "6.2.0"
 			}
 		},
 		"remark-parse": {
@@ -11664,22 +11659,22 @@
 			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-3.0.1.tgz",
 			"integrity": "sha1-G5+EGkTY9PvyJGhQJlRZpOs1TIA=",
 			"requires": {
-				"collapse-white-space": "^1.0.2",
-				"has": "^1.0.1",
-				"is-alphabetical": "^1.0.0",
-				"is-decimal": "^1.0.0",
-				"is-whitespace-character": "^1.0.0",
-				"is-word-character": "^1.0.0",
-				"markdown-escapes": "^1.0.0",
-				"parse-entities": "^1.0.2",
-				"repeat-string": "^1.5.4",
-				"state-toggle": "^1.0.0",
+				"collapse-white-space": "1.0.5",
+				"has": "1.0.3",
+				"is-alphabetical": "1.0.3",
+				"is-decimal": "1.0.3",
+				"is-whitespace-character": "1.0.3",
+				"is-word-character": "1.0.3",
+				"markdown-escapes": "1.0.3",
+				"parse-entities": "1.2.2",
+				"repeat-string": "1.6.1",
+				"state-toggle": "1.0.2",
 				"trim": "0.0.1",
-				"trim-trailing-lines": "^1.0.0",
-				"unherit": "^1.0.4",
-				"unist-util-remove-position": "^1.0.0",
-				"vfile-location": "^2.0.0",
-				"xtend": "^4.0.1"
+				"trim-trailing-lines": "1.1.2",
+				"unherit": "1.1.2",
+				"unist-util-remove-position": "1.1.3",
+				"vfile-location": "2.0.5",
+				"xtend": "4.0.2"
 			}
 		},
 		"remark-stringify": {
@@ -11687,20 +11682,20 @@
 			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-3.0.1.tgz",
 			"integrity": "sha1-eSQr6+CnUggbWAlRb6DAbt7Aac8=",
 			"requires": {
-				"ccount": "^1.0.0",
-				"is-alphanumeric": "^1.0.0",
-				"is-decimal": "^1.0.0",
-				"is-whitespace-character": "^1.0.0",
-				"longest-streak": "^2.0.1",
-				"markdown-escapes": "^1.0.0",
-				"markdown-table": "^1.1.0",
-				"mdast-util-compact": "^1.0.0",
-				"parse-entities": "^1.0.2",
-				"repeat-string": "^1.5.4",
-				"state-toggle": "^1.0.0",
-				"stringify-entities": "^1.0.1",
-				"unherit": "^1.0.4",
-				"xtend": "^4.0.1"
+				"ccount": "1.0.4",
+				"is-alphanumeric": "1.0.0",
+				"is-decimal": "1.0.3",
+				"is-whitespace-character": "1.0.3",
+				"longest-streak": "2.0.3",
+				"markdown-escapes": "1.0.3",
+				"markdown-table": "1.1.3",
+				"mdast-util-compact": "1.0.3",
+				"parse-entities": "1.2.2",
+				"repeat-string": "1.6.1",
+				"state-toggle": "1.0.2",
+				"stringify-entities": "1.3.2",
+				"unherit": "1.1.2",
+				"xtend": "4.0.2"
 			}
 		},
 		"remove-trailing-separator": {
@@ -11726,7 +11721,7 @@
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 			"dev": true,
 			"requires": {
-				"is-finite": "^1.0.0"
+				"is-finite": "1.0.2"
 			}
 		},
 		"replace-ext": {
@@ -11740,26 +11735,26 @@
 			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
 			"dev": true,
 			"requires": {
-				"aws-sign2": "~0.7.0",
-				"aws4": "^1.8.0",
-				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.6",
-				"extend": "~3.0.2",
-				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.2",
-				"har-validator": "~5.1.0",
-				"http-signature": "~1.2.0",
-				"is-typedarray": "~1.0.0",
-				"isstream": "~0.1.2",
-				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.19",
-				"oauth-sign": "~0.9.0",
-				"performance-now": "^2.1.0",
-				"qs": "~6.5.2",
-				"safe-buffer": "^5.1.2",
-				"tough-cookie": "~2.4.3",
-				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.3.2"
+				"aws-sign2": "0.7.0",
+				"aws4": "1.8.0",
+				"caseless": "0.12.0",
+				"combined-stream": "1.0.8",
+				"extend": "3.0.2",
+				"forever-agent": "0.6.1",
+				"form-data": "2.3.3",
+				"har-validator": "5.1.3",
+				"http-signature": "1.2.0",
+				"is-typedarray": "1.0.0",
+				"isstream": "0.1.2",
+				"json-stringify-safe": "5.0.1",
+				"mime-types": "2.1.24",
+				"oauth-sign": "0.9.0",
+				"performance-now": "2.1.0",
+				"qs": "6.5.2",
+				"safe-buffer": "5.1.2",
+				"tough-cookie": "2.4.3",
+				"tunnel-agent": "0.6.0",
+				"uuid": "3.3.2"
 			},
 			"dependencies": {
 				"punycode": {
@@ -11774,8 +11769,8 @@
 					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
 					"dev": true,
 					"requires": {
-						"psl": "^1.1.24",
-						"punycode": "^1.4.1"
+						"psl": "1.2.0",
+						"punycode": "1.4.1"
 					}
 				}
 			}
@@ -11786,7 +11781,7 @@
 			"integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.11"
+				"lodash": "4.17.14"
 			}
 		},
 		"request-promise-native": {
@@ -11796,8 +11791,8 @@
 			"dev": true,
 			"requires": {
 				"request-promise-core": "1.1.2",
-				"stealthy-require": "^1.1.1",
-				"tough-cookie": "^2.3.3"
+				"stealthy-require": "1.1.1",
+				"tough-cookie": "2.5.0"
 			}
 		},
 		"require-directory": {
@@ -11827,7 +11822,7 @@
 			"resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
 			"integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
 			"requires": {
-				"lodash": "^4.17.14"
+				"lodash": "4.17.14"
 			}
 		},
 		"resolve": {
@@ -11836,7 +11831,7 @@
 			"integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
 			"dev": true,
 			"requires": {
-				"path-parse": "^1.0.6"
+				"path-parse": "1.0.6"
 			}
 		},
 		"resolve-cwd": {
@@ -11845,7 +11840,7 @@
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
 			"dev": true,
 			"requires": {
-				"resolve-from": "^3.0.0"
+				"resolve-from": "3.0.0"
 			},
 			"dependencies": {
 				"resolve-from": {
@@ -11862,8 +11857,8 @@
 			"integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
 			"dev": true,
 			"requires": {
-				"expand-tilde": "^2.0.0",
-				"global-modules": "^1.0.0"
+				"expand-tilde": "2.0.2",
+				"global-modules": "1.0.0"
 			},
 			"dependencies": {
 				"global-modules": {
@@ -11872,9 +11867,9 @@
 					"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
 					"dev": true,
 					"requires": {
-						"global-prefix": "^1.0.1",
-						"is-windows": "^1.0.1",
-						"resolve-dir": "^1.0.0"
+						"global-prefix": "1.0.2",
+						"is-windows": "1.0.2",
+						"resolve-dir": "1.0.1"
 					}
 				}
 			}
@@ -11897,8 +11892,8 @@
 			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 			"dev": true,
 			"requires": {
-				"onetime": "^2.0.0",
-				"signal-exit": "^3.0.2"
+				"onetime": "2.0.1",
+				"signal-exit": "3.0.2"
 			}
 		},
 		"ret": {
@@ -11912,7 +11907,7 @@
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
 			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
 			"requires": {
-				"glob": "^7.1.3"
+				"glob": "7.1.4"
 			}
 		},
 		"ripemd160": {
@@ -11921,8 +11916,8 @@
 			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
 			"dev": true,
 			"requires": {
-				"hash-base": "^3.0.0",
-				"inherits": "^2.0.1"
+				"hash-base": "3.0.4",
+				"inherits": "2.0.4"
 			}
 		},
 		"rsvp": {
@@ -11937,7 +11932,7 @@
 			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
 			"dev": true,
 			"requires": {
-				"is-promise": "^2.1.0"
+				"is-promise": "2.1.0"
 			}
 		},
 		"run-queue": {
@@ -11946,7 +11941,7 @@
 			"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
 			"dev": true,
 			"requires": {
-				"aproba": "^1.1.1"
+				"aproba": "1.2.0"
 			}
 		},
 		"rxjs": {
@@ -11955,7 +11950,7 @@
 			"integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
 			"dev": true,
 			"requires": {
-				"tslib": "^1.9.0"
+				"tslib": "1.10.0"
 			}
 		},
 		"safe-buffer": {
@@ -11969,7 +11964,7 @@
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"dev": true,
 			"requires": {
-				"ret": "~0.1.10"
+				"ret": "0.1.15"
 			}
 		},
 		"safer-buffer": {
@@ -11984,15 +11979,15 @@
 			"integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
 			"dev": true,
 			"requires": {
-				"@cnakazawa/watch": "^1.0.3",
-				"anymatch": "^2.0.0",
-				"capture-exit": "^2.0.0",
-				"exec-sh": "^0.3.2",
-				"execa": "^1.0.0",
-				"fb-watchman": "^2.0.0",
-				"micromatch": "^3.1.4",
-				"minimist": "^1.1.1",
-				"walker": "~1.0.5"
+				"@cnakazawa/watch": "1.0.3",
+				"anymatch": "2.0.0",
+				"capture-exit": "2.0.0",
+				"exec-sh": "0.3.2",
+				"execa": "1.0.0",
+				"fb-watchman": "2.0.0",
+				"micromatch": "3.1.10",
+				"minimist": "1.2.0",
+				"walker": "1.0.7"
 			},
 			"dependencies": {
 				"braces": {
@@ -12001,16 +11996,16 @@
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.3",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -12019,7 +12014,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -12030,10 +12025,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -12042,7 +12037,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -12059,7 +12054,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -12068,7 +12063,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -12079,19 +12074,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.13",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					}
 				},
 				"minimist": {
@@ -12106,8 +12101,8 @@
 					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 					"dev": true,
 					"requires": {
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1"
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1"
 					}
 				}
 			}
@@ -12118,10 +12113,10 @@
 			"integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.0",
-				"lodash": "^4.0.0",
-				"scss-tokenizer": "^0.2.3",
-				"yargs": "^7.0.0"
+				"glob": "7.1.4",
+				"lodash": "4.17.14",
+				"scss-tokenizer": "0.2.3",
+				"yargs": "7.1.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -12142,9 +12137,9 @@
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 					"dev": true,
 					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wrap-ansi": "2.1.0"
 					}
 				},
 				"find-up": {
@@ -12153,8 +12148,8 @@
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"dev": true,
 					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"get-caller-file": {
@@ -12175,7 +12170,7 @@
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"number-is-nan": "1.0.1"
 					}
 				},
 				"lcid": {
@@ -12184,7 +12179,7 @@
 					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 					"dev": true,
 					"requires": {
-						"invert-kv": "^1.0.0"
+						"invert-kv": "1.0.0"
 					}
 				},
 				"load-json-file": {
@@ -12193,11 +12188,11 @@
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
+						"graceful-fs": "4.2.0",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"strip-bom": "2.0.0"
 					}
 				},
 				"os-locale": {
@@ -12206,7 +12201,7 @@
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 					"dev": true,
 					"requires": {
-						"lcid": "^1.0.0"
+						"lcid": "1.0.0"
 					}
 				},
 				"parse-json": {
@@ -12215,7 +12210,7 @@
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 					"dev": true,
 					"requires": {
-						"error-ex": "^1.2.0"
+						"error-ex": "1.3.2"
 					}
 				},
 				"path-exists": {
@@ -12224,7 +12219,7 @@
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "^2.0.0"
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"path-type": {
@@ -12233,9 +12228,9 @@
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"graceful-fs": "4.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"pify": {
@@ -12250,9 +12245,9 @@
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "^1.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
+						"load-json-file": "1.1.0",
+						"normalize-package-data": "2.5.0",
+						"path-type": "1.1.0"
 					}
 				},
 				"read-pkg-up": {
@@ -12261,8 +12256,8 @@
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 					"dev": true,
 					"requires": {
-						"find-up": "^1.0.0",
-						"read-pkg": "^1.0.0"
+						"find-up": "1.1.2",
+						"read-pkg": "1.1.0"
 					}
 				},
 				"require-main-filename": {
@@ -12277,9 +12272,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				},
 				"strip-ansi": {
@@ -12288,7 +12283,7 @@
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				},
 				"strip-bom": {
@@ -12297,7 +12292,7 @@
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"dev": true,
 					"requires": {
-						"is-utf8": "^0.2.0"
+						"is-utf8": "0.2.1"
 					}
 				},
 				"which-module": {
@@ -12312,8 +12307,8 @@
 					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 					"dev": true,
 					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1"
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1"
 					}
 				},
 				"y18n": {
@@ -12328,19 +12323,19 @@
 					"integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
 					"dev": true,
 					"requires": {
-						"camelcase": "^3.0.0",
-						"cliui": "^3.2.0",
-						"decamelize": "^1.1.1",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^1.4.0",
-						"read-pkg-up": "^1.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^1.0.2",
-						"which-module": "^1.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^5.0.0"
+						"camelcase": "3.0.0",
+						"cliui": "3.2.0",
+						"decamelize": "1.2.0",
+						"get-caller-file": "1.0.3",
+						"os-locale": "1.4.0",
+						"read-pkg-up": "1.0.1",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "1.0.2",
+						"which-module": "1.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "5.0.0"
 					}
 				},
 				"yargs-parser": {
@@ -12349,7 +12344,7 @@
 					"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
 					"dev": true,
 					"requires": {
-						"camelcase": "^3.0.0"
+						"camelcase": "3.0.0"
 					}
 				}
 			}
@@ -12360,12 +12355,12 @@
 			"integrity": "sha512-+G+BKGglmZM2GUSfT9TLuEp6tzehHPjAMoRRItOojWIqIGPloVCMhNIQuG639eJ+y033PaGTSjLaTHts8Kw79w==",
 			"dev": true,
 			"requires": {
-				"clone-deep": "^2.0.1",
-				"loader-utils": "^1.0.1",
-				"lodash.tail": "^4.1.1",
-				"neo-async": "^2.5.0",
-				"pify": "^3.0.0",
-				"semver": "^5.5.0"
+				"clone-deep": "2.0.2",
+				"loader-utils": "1.2.3",
+				"lodash.tail": "4.1.1",
+				"neo-async": "2.6.1",
+				"pify": "3.0.0",
+				"semver": "5.7.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -12398,9 +12393,9 @@
 			"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
 			"dev": true,
 			"requires": {
-				"ajv": "^6.1.0",
-				"ajv-errors": "^1.0.0",
-				"ajv-keywords": "^3.1.0"
+				"ajv": "6.10.2",
+				"ajv-errors": "1.0.1",
+				"ajv-keywords": "3.4.1"
 			}
 		},
 		"scss-tokenizer": {
@@ -12409,8 +12404,8 @@
 			"integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
 			"dev": true,
 			"requires": {
-				"js-base64": "^2.1.8",
-				"source-map": "^0.4.2"
+				"js-base64": "2.5.1",
+				"source-map": "0.4.4"
 			},
 			"dependencies": {
 				"source-map": {
@@ -12419,7 +12414,7 @@
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
 					"dev": true,
 					"requires": {
-						"amdefine": ">=0.0.4"
+						"amdefine": "1.0.1"
 					}
 				}
 			}
@@ -12446,10 +12441,10 @@
 			"integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^2.0.1",
-				"is-extendable": "^0.1.1",
-				"is-plain-object": "^2.0.3",
-				"split-string": "^3.0.1"
+				"extend-shallow": "2.0.1",
+				"is-extendable": "0.1.1",
+				"is-plain-object": "2.0.4",
+				"split-string": "3.1.0"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -12458,7 +12453,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -12475,8 +12470,8 @@
 			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
+				"inherits": "2.0.4",
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"shallow-clone": {
@@ -12485,9 +12480,9 @@
 			"integrity": "sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==",
 			"dev": true,
 			"requires": {
-				"is-extendable": "^0.1.1",
-				"kind-of": "^5.0.0",
-				"mixin-object": "^2.0.1"
+				"is-extendable": "0.1.1",
+				"kind-of": "5.1.0",
+				"mixin-object": "2.0.1"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -12503,7 +12498,7 @@
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"requires": {
-				"shebang-regex": "^1.0.0"
+				"shebang-regex": "1.0.0"
 			}
 		},
 		"shebang-regex": {
@@ -12546,9 +12541,9 @@
 			"integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "^3.2.0",
-				"astral-regex": "^1.0.0",
-				"is-fullwidth-code-point": "^2.0.0"
+				"ansi-styles": "3.2.1",
+				"astral-regex": "1.0.0",
+				"is-fullwidth-code-point": "2.0.0"
 			}
 		},
 		"snapdragon": {
@@ -12557,14 +12552,14 @@
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
 			"dev": true,
 			"requires": {
-				"base": "^0.11.1",
-				"debug": "^2.2.0",
-				"define-property": "^0.2.5",
-				"extend-shallow": "^2.0.1",
-				"map-cache": "^0.2.2",
-				"source-map": "^0.5.6",
-				"source-map-resolve": "^0.5.0",
-				"use": "^3.1.0"
+				"base": "0.11.2",
+				"debug": "2.6.9",
+				"define-property": "0.2.5",
+				"extend-shallow": "2.0.1",
+				"map-cache": "0.2.2",
+				"source-map": "0.5.7",
+				"source-map-resolve": "0.5.2",
+				"use": "3.1.1"
 			},
 			"dependencies": {
 				"debug": {
@@ -12582,7 +12577,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"extend-shallow": {
@@ -12591,7 +12586,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				},
 				"source-map": {
@@ -12608,9 +12603,9 @@
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
 			"dev": true,
 			"requires": {
-				"define-property": "^1.0.0",
-				"isobject": "^3.0.0",
-				"snapdragon-util": "^3.0.1"
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"snapdragon-util": "3.0.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -12619,7 +12614,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -12628,7 +12623,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -12637,7 +12632,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -12646,9 +12641,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				}
 			}
@@ -12659,7 +12654,7 @@
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.2.0"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"is-buffer": {
@@ -12674,7 +12669,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -12684,9 +12679,9 @@
 			"resolved": "https://registry.npmjs.org/sort-array/-/sort-array-2.0.0.tgz",
 			"integrity": "sha1-OKnG2if9fRR7QuYFVPKBGHtN9HI=",
 			"requires": {
-				"array-back": "^1.0.4",
-				"object-get": "^2.1.0",
-				"typical": "^2.6.0"
+				"array-back": "1.0.4",
+				"object-get": "2.1.0",
+				"typical": "2.6.1"
 			},
 			"dependencies": {
 				"array-back": {
@@ -12694,7 +12689,7 @@
 					"resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
 					"integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
 					"requires": {
-						"typical": "^2.6.0"
+						"typical": "2.6.1"
 					}
 				}
 			}
@@ -12716,11 +12711,11 @@
 			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
 			"dev": true,
 			"requires": {
-				"atob": "^2.1.1",
-				"decode-uri-component": "^0.2.0",
-				"resolve-url": "^0.2.1",
-				"source-map-url": "^0.4.0",
-				"urix": "^0.1.0"
+				"atob": "2.1.2",
+				"decode-uri-component": "0.2.0",
+				"resolve-url": "0.2.1",
+				"source-map-url": "0.4.0",
+				"urix": "0.1.0"
 			}
 		},
 		"source-map-support": {
@@ -12729,8 +12724,8 @@
 			"integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
 			"dev": true,
 			"requires": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
+				"buffer-from": "1.1.1",
+				"source-map": "0.6.1"
 			}
 		},
 		"source-map-url": {
@@ -12745,8 +12740,8 @@
 			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
 			"dev": true,
 			"requires": {
-				"spdx-expression-parse": "^3.0.0",
-				"spdx-license-ids": "^3.0.0"
+				"spdx-expression-parse": "3.0.0",
+				"spdx-license-ids": "3.0.5"
 			}
 		},
 		"spdx-exceptions": {
@@ -12761,8 +12756,8 @@
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 			"dev": true,
 			"requires": {
-				"spdx-exceptions": "^2.1.0",
-				"spdx-license-ids": "^3.0.0"
+				"spdx-exceptions": "2.2.0",
+				"spdx-license-ids": "3.0.5"
 			}
 		},
 		"spdx-license-ids": {
@@ -12783,7 +12778,7 @@
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^3.0.0"
+				"extend-shallow": "3.0.2"
 			}
 		},
 		"sprintf-js": {
@@ -12797,15 +12792,15 @@
 			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
 			"dev": true,
 			"requires": {
-				"asn1": "~0.2.3",
-				"assert-plus": "^1.0.0",
-				"bcrypt-pbkdf": "^1.0.0",
-				"dashdash": "^1.12.0",
-				"ecc-jsbn": "~0.1.1",
-				"getpass": "^0.1.1",
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.0.2",
-				"tweetnacl": "~0.14.0"
+				"asn1": "0.2.4",
+				"assert-plus": "1.0.0",
+				"bcrypt-pbkdf": "1.0.2",
+				"dashdash": "1.14.1",
+				"ecc-jsbn": "0.1.2",
+				"getpass": "0.1.7",
+				"jsbn": "0.1.1",
+				"safer-buffer": "2.1.2",
+				"tweetnacl": "0.14.5"
 			}
 		},
 		"ssri": {
@@ -12814,7 +12809,7 @@
 			"integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
 			"dev": true,
 			"requires": {
-				"figgy-pudding": "^3.5.1"
+				"figgy-pudding": "3.5.1"
 			}
 		},
 		"stack-utils": {
@@ -12834,8 +12829,8 @@
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
 			"dev": true,
 			"requires": {
-				"define-property": "^0.2.5",
-				"object-copy": "^0.1.0"
+				"define-property": "0.2.5",
+				"object-copy": "0.1.0"
 			},
 			"dependencies": {
 				"define-property": {
@@ -12844,7 +12839,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				}
 			}
@@ -12855,7 +12850,7 @@
 			"integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
 			"dev": true,
 			"requires": {
-				"readable-stream": "^2.0.1"
+				"readable-stream": "2.3.6"
 			},
 			"dependencies": {
 				"readable-stream": {
@@ -12864,13 +12859,13 @@
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.4",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.1",
+						"safe-buffer": "5.1.2",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"string_decoder": {
@@ -12879,7 +12874,7 @@
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "5.1.2"
 					}
 				}
 			}
@@ -12896,8 +12891,8 @@
 			"integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
 			"dev": true,
 			"requires": {
-				"inherits": "~2.0.1",
-				"readable-stream": "^2.0.2"
+				"inherits": "2.0.4",
+				"readable-stream": "2.3.6"
 			},
 			"dependencies": {
 				"readable-stream": {
@@ -12906,13 +12901,13 @@
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.4",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.1",
+						"safe-buffer": "5.1.2",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"string_decoder": {
@@ -12921,7 +12916,7 @@
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "5.1.2"
 					}
 				}
 			}
@@ -12931,7 +12926,7 @@
 			"resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
 			"integrity": "sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc=",
 			"requires": {
-				"array-back": "^1.0.2"
+				"array-back": "1.0.4"
 			},
 			"dependencies": {
 				"array-back": {
@@ -12939,7 +12934,7 @@
 					"resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
 					"integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
 					"requires": {
-						"typical": "^2.6.0"
+						"typical": "2.6.1"
 					}
 				}
 			}
@@ -12950,8 +12945,8 @@
 			"integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
 			"dev": true,
 			"requires": {
-				"end-of-stream": "^1.1.0",
-				"stream-shift": "^1.0.0"
+				"end-of-stream": "1.4.1",
+				"stream-shift": "1.0.0"
 			}
 		},
 		"stream-http": {
@@ -12960,11 +12955,11 @@
 			"integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
 			"dev": true,
 			"requires": {
-				"builtin-status-codes": "^3.0.0",
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.3.6",
-				"to-arraybuffer": "^1.0.0",
-				"xtend": "^4.0.0"
+				"builtin-status-codes": "3.0.0",
+				"inherits": "2.0.4",
+				"readable-stream": "2.3.6",
+				"to-arraybuffer": "1.0.1",
+				"xtend": "4.0.2"
 			},
 			"dependencies": {
 				"readable-stream": {
@@ -12973,13 +12968,13 @@
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.4",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.1",
+						"safe-buffer": "5.1.2",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"string_decoder": {
@@ -12988,7 +12983,7 @@
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "5.1.2"
 					}
 				}
 			}
@@ -13010,8 +13005,8 @@
 			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
 			"dev": true,
 			"requires": {
-				"astral-regex": "^1.0.0",
-				"strip-ansi": "^4.0.0"
+				"astral-regex": "1.0.0",
+				"strip-ansi": "4.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -13026,7 +13021,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				}
 			}
@@ -13036,9 +13031,9 @@
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
 			"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
 			"requires": {
-				"emoji-regex": "^7.0.1",
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^5.1.0"
+				"emoji-regex": "7.0.3",
+				"is-fullwidth-code-point": "2.0.0",
+				"strip-ansi": "5.2.0"
 			}
 		},
 		"string_decoder": {
@@ -13046,7 +13041,7 @@
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
 			"integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
 			"requires": {
-				"safe-buffer": "~5.1.0"
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"stringify-entities": {
@@ -13054,10 +13049,10 @@
 			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
 			"integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
 			"requires": {
-				"character-entities-html4": "^1.0.0",
-				"character-entities-legacy": "^1.0.0",
-				"is-alphanumerical": "^1.0.0",
-				"is-hexadecimal": "^1.0.0"
+				"character-entities-html4": "1.1.3",
+				"character-entities-legacy": "1.1.3",
+				"is-alphanumerical": "1.0.3",
+				"is-hexadecimal": "1.0.3"
 			}
 		},
 		"strip-ansi": {
@@ -13065,7 +13060,7 @@
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
 			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 			"requires": {
-				"ansi-regex": "^4.1.0"
+				"ansi-regex": "4.1.0"
 			}
 		},
 		"strip-bom": {
@@ -13085,7 +13080,7 @@
 			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
 			"dev": true,
 			"requires": {
-				"get-stdin": "^4.0.1"
+				"get-stdin": "4.0.1"
 			}
 		},
 		"strip-json-comments": {
@@ -13098,7 +13093,7 @@
 			"resolved": "https://registry.npmjs.org/structured-source/-/structured-source-3.0.2.tgz",
 			"integrity": "sha1-3YAkJeD1PcSm56yjdSkBoczaevU=",
 			"requires": {
-				"boundary": "^1.0.1"
+				"boundary": "1.0.1"
 			}
 		},
 		"style-search": {
@@ -13113,45 +13108,45 @@
 			"integrity": "sha512-56hPH5mTFnk8LzlEuTWq0epa34fHuS54UFYQidBOFt563RJBNi1nz1F2HK2MoT1X1waq47milvRsRahFCCJs/Q==",
 			"dev": true,
 			"requires": {
-				"autoprefixer": "^7.1.2",
-				"balanced-match": "^1.0.0",
-				"chalk": "^2.0.1",
-				"cosmiconfig": "^3.1.0",
-				"debug": "^3.0.0",
-				"execall": "^1.0.0",
-				"file-entry-cache": "^2.0.0",
-				"get-stdin": "^5.0.1",
-				"globby": "^7.0.0",
-				"globjoin": "^0.1.4",
-				"html-tags": "^2.0.0",
-				"ignore": "^3.3.3",
-				"imurmurhash": "^0.1.4",
-				"known-css-properties": "^0.5.0",
-				"lodash": "^4.17.4",
-				"log-symbols": "^2.0.0",
-				"mathml-tag-names": "^2.0.1",
-				"meow": "^4.0.0",
-				"micromatch": "^2.3.11",
-				"normalize-selector": "^0.2.0",
-				"pify": "^3.0.0",
-				"postcss": "^6.0.6",
-				"postcss-html": "^0.12.0",
-				"postcss-less": "^1.1.0",
-				"postcss-media-query-parser": "^0.2.3",
-				"postcss-reporter": "^5.0.0",
-				"postcss-resolve-nested-selector": "^0.1.1",
-				"postcss-safe-parser": "^3.0.1",
-				"postcss-sass": "^0.2.0",
-				"postcss-scss": "^1.0.2",
-				"postcss-selector-parser": "^3.1.0",
-				"postcss-value-parser": "^3.3.0",
-				"resolve-from": "^4.0.0",
-				"specificity": "^0.3.1",
-				"string-width": "^2.1.0",
-				"style-search": "^0.1.0",
-				"sugarss": "^1.0.0",
-				"svg-tags": "^1.0.0",
-				"table": "^4.0.1"
+				"autoprefixer": "7.2.6",
+				"balanced-match": "1.0.0",
+				"chalk": "2.4.2",
+				"cosmiconfig": "3.1.0",
+				"debug": "3.1.0",
+				"execall": "1.0.0",
+				"file-entry-cache": "2.0.0",
+				"get-stdin": "5.0.1",
+				"globby": "7.1.1",
+				"globjoin": "0.1.4",
+				"html-tags": "2.0.0",
+				"ignore": "3.3.10",
+				"imurmurhash": "0.1.4",
+				"known-css-properties": "0.5.0",
+				"lodash": "4.17.14",
+				"log-symbols": "2.2.0",
+				"mathml-tag-names": "2.1.1",
+				"meow": "4.0.1",
+				"micromatch": "2.3.11",
+				"normalize-selector": "0.2.0",
+				"pify": "3.0.0",
+				"postcss": "6.0.23",
+				"postcss-html": "0.12.0",
+				"postcss-less": "1.1.5",
+				"postcss-media-query-parser": "0.2.3",
+				"postcss-reporter": "5.0.0",
+				"postcss-resolve-nested-selector": "0.1.1",
+				"postcss-safe-parser": "3.0.1",
+				"postcss-sass": "0.2.0",
+				"postcss-scss": "1.0.6",
+				"postcss-selector-parser": "3.1.1",
+				"postcss-value-parser": "3.3.1",
+				"resolve-from": "4.0.0",
+				"specificity": "0.3.2",
+				"string-width": "2.1.1",
+				"style-search": "0.1.0",
+				"sugarss": "1.0.1",
+				"svg-tags": "1.0.0",
+				"table": "4.0.3"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -13166,7 +13161,7 @@
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.0.1"
+						"arr-flatten": "1.1.0"
 					}
 				},
 				"array-unique": {
@@ -13181,9 +13176,9 @@
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 					"dev": true,
 					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
+						"expand-range": "1.8.2",
+						"preserve": "0.2.0",
+						"repeat-element": "1.1.3"
 					}
 				},
 				"camelcase": {
@@ -13198,9 +13193,9 @@
 					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
 					"dev": true,
 					"requires": {
-						"camelcase": "^4.1.0",
-						"map-obj": "^2.0.0",
-						"quick-lru": "^1.0.0"
+						"camelcase": "4.1.0",
+						"map-obj": "2.0.0",
+						"quick-lru": "1.1.0"
 					}
 				},
 				"expand-brackets": {
@@ -13209,7 +13204,7 @@
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 					"dev": true,
 					"requires": {
-						"is-posix-bracket": "^0.1.0"
+						"is-posix-bracket": "0.1.1"
 					}
 				},
 				"extglob": {
@@ -13218,7 +13213,7 @@
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				},
 				"file-entry-cache": {
@@ -13227,8 +13222,8 @@
 					"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
 					"dev": true,
 					"requires": {
-						"flat-cache": "^1.2.1",
-						"object-assign": "^4.0.1"
+						"flat-cache": "1.3.4",
+						"object-assign": "4.1.1"
 					}
 				},
 				"find-up": {
@@ -13237,7 +13232,7 @@
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"locate-path": "^2.0.0"
+						"locate-path": "2.0.0"
 					}
 				},
 				"flat-cache": {
@@ -13246,10 +13241,10 @@
 					"integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
 					"dev": true,
 					"requires": {
-						"circular-json": "^0.3.1",
-						"graceful-fs": "^4.1.2",
-						"rimraf": "~2.6.2",
-						"write": "^0.2.1"
+						"circular-json": "0.3.3",
+						"graceful-fs": "4.2.0",
+						"rimraf": "2.6.3",
+						"write": "0.2.1"
 					}
 				},
 				"get-stdin": {
@@ -13264,12 +13259,12 @@
 					"integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
 					"dev": true,
 					"requires": {
-						"array-union": "^1.0.1",
-						"dir-glob": "^2.0.0",
-						"glob": "^7.1.2",
-						"ignore": "^3.3.5",
-						"pify": "^3.0.0",
-						"slash": "^1.0.0"
+						"array-union": "1.0.2",
+						"dir-glob": "2.2.2",
+						"glob": "7.1.4",
+						"ignore": "3.3.10",
+						"pify": "3.0.0",
+						"slash": "1.0.0"
 					}
 				},
 				"ignore": {
@@ -13296,7 +13291,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				},
 				"locate-path": {
@@ -13305,8 +13300,8 @@
 					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 					"dev": true,
 					"requires": {
-						"p-locate": "^2.0.0",
-						"path-exists": "^3.0.0"
+						"p-locate": "2.0.0",
+						"path-exists": "3.0.0"
 					}
 				},
 				"map-obj": {
@@ -13321,15 +13316,15 @@
 					"integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
 					"dev": true,
 					"requires": {
-						"camelcase-keys": "^4.0.0",
-						"decamelize-keys": "^1.0.0",
-						"loud-rejection": "^1.0.0",
-						"minimist": "^1.1.3",
-						"minimist-options": "^3.0.1",
-						"normalize-package-data": "^2.3.4",
-						"read-pkg-up": "^3.0.0",
-						"redent": "^2.0.0",
-						"trim-newlines": "^2.0.0"
+						"camelcase-keys": "4.2.0",
+						"decamelize-keys": "1.1.0",
+						"loud-rejection": "1.6.0",
+						"minimist": "1.2.0",
+						"minimist-options": "3.0.2",
+						"normalize-package-data": "2.5.0",
+						"read-pkg-up": "3.0.0",
+						"redent": "2.0.0",
+						"trim-newlines": "2.0.0"
 					}
 				},
 				"micromatch": {
@@ -13338,19 +13333,19 @@
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^2.0.0",
-						"array-unique": "^0.2.1",
-						"braces": "^1.8.2",
-						"expand-brackets": "^0.1.4",
-						"extglob": "^0.3.1",
-						"filename-regex": "^2.0.0",
-						"is-extglob": "^1.0.0",
-						"is-glob": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"normalize-path": "^2.0.1",
-						"object.omit": "^2.0.0",
-						"parse-glob": "^3.0.4",
-						"regex-cache": "^0.4.2"
+						"arr-diff": "2.0.0",
+						"array-unique": "0.2.1",
+						"braces": "1.8.5",
+						"expand-brackets": "0.1.5",
+						"extglob": "0.3.2",
+						"filename-regex": "2.0.1",
+						"is-extglob": "1.0.0",
+						"is-glob": "2.0.1",
+						"kind-of": "3.2.2",
+						"normalize-path": "2.1.1",
+						"object.omit": "2.0.1",
+						"parse-glob": "3.0.4",
+						"regex-cache": "0.4.4"
 					}
 				},
 				"minimist": {
@@ -13365,7 +13360,7 @@
 					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
 					"dev": true,
 					"requires": {
-						"p-try": "^1.0.0"
+						"p-try": "1.0.0"
 					}
 				},
 				"p-locate": {
@@ -13374,7 +13369,7 @@
 					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 					"dev": true,
 					"requires": {
-						"p-limit": "^1.1.0"
+						"p-limit": "1.3.0"
 					}
 				},
 				"p-try": {
@@ -13395,9 +13390,9 @@
 					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
 					"dev": true,
 					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
+						"chalk": "2.4.2",
+						"source-map": "0.6.1",
+						"supports-color": "5.5.0"
 					}
 				},
 				"postcss-selector-parser": {
@@ -13406,9 +13401,9 @@
 					"integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
 					"dev": true,
 					"requires": {
-						"dot-prop": "^4.1.1",
-						"indexes-of": "^1.0.1",
-						"uniq": "^1.0.1"
+						"dot-prop": "4.2.0",
+						"indexes-of": "1.0.1",
+						"uniq": "1.0.1"
 					}
 				},
 				"postcss-value-parser": {
@@ -13423,8 +13418,8 @@
 					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
 					"dev": true,
 					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^3.0.0"
+						"find-up": "2.1.0",
+						"read-pkg": "3.0.0"
 					}
 				},
 				"redent": {
@@ -13433,8 +13428,8 @@
 					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
 					"dev": true,
 					"requires": {
-						"indent-string": "^3.0.0",
-						"strip-indent": "^2.0.0"
+						"indent-string": "3.2.0",
+						"strip-indent": "2.0.0"
 					}
 				},
 				"slash": {
@@ -13449,7 +13444,7 @@
 					"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "^2.0.0"
+						"is-fullwidth-code-point": "2.0.0"
 					}
 				},
 				"string-width": {
@@ -13458,8 +13453,8 @@
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -13468,7 +13463,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				},
 				"strip-indent": {
@@ -13483,12 +13478,12 @@
 					"integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
 					"dev": true,
 					"requires": {
-						"ajv": "^6.0.1",
-						"ajv-keywords": "^3.0.0",
-						"chalk": "^2.1.0",
-						"lodash": "^4.17.4",
+						"ajv": "6.10.2",
+						"ajv-keywords": "3.4.1",
+						"chalk": "2.4.2",
+						"lodash": "4.17.14",
 						"slice-ansi": "1.0.0",
-						"string-width": "^2.1.1"
+						"string-width": "2.1.1"
 					}
 				},
 				"trim-newlines": {
@@ -13503,7 +13498,7 @@
 					"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
 					"dev": true,
 					"requires": {
-						"mkdirp": "^0.5.1"
+						"mkdirp": "0.5.1"
 					}
 				}
 			}
@@ -13520,7 +13515,7 @@
 			"integrity": "sha512-BvuuLYwoet8JutOP7K1a8YaiENN+0HQn390eDi0SWe1h7Uhx6O3GUQ6Ubgie9b/AmHX4Btmp+ZzVGbzriFTBcA==",
 			"dev": true,
 			"requires": {
-				"stylelint-config-recommended": "^2.2.0"
+				"stylelint-config-recommended": "2.2.0"
 			}
 		},
 		"stylelint-webpack-plugin": {
@@ -13529,10 +13524,10 @@
 			"integrity": "sha512-jtYx3aJ2qDMvBMswe5NRPTO7kJgAKafc6GilAkWDp/ewoAmnoxA6TsYMnIPtLECRLwXevaCPvlh2JEUMGZCoUQ==",
 			"dev": true,
 			"requires": {
-				"arrify": "^1.0.1",
-				"micromatch": "^3.1.8",
-				"object-assign": "^4.1.0",
-				"ramda": "^0.25.0"
+				"arrify": "1.0.1",
+				"micromatch": "3.1.10",
+				"object-assign": "4.1.1",
+				"ramda": "0.25.0"
 			},
 			"dependencies": {
 				"braces": {
@@ -13541,16 +13536,16 @@
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.3",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -13559,7 +13554,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -13570,10 +13565,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -13582,7 +13577,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -13599,7 +13594,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -13608,7 +13603,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -13619,19 +13614,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.13",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					}
 				},
 				"to-regex-range": {
@@ -13640,8 +13635,8 @@
 					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 					"dev": true,
 					"requires": {
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1"
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1"
 					}
 				}
 			}
@@ -13652,7 +13647,7 @@
 			"integrity": "sha512-3qgLZytikQQEVn1/FrhY7B68gPUUGY3R1Q1vTiD5xT+Ti1DP/8iZuwFet9ONs5+bmL8pZoDQ6JrQHVgrNlK6mA==",
 			"dev": true,
 			"requires": {
-				"postcss": "^6.0.14"
+				"postcss": "6.0.23"
 			},
 			"dependencies": {
 				"postcss": {
@@ -13661,9 +13656,9 @@
 					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
 					"dev": true,
 					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
+						"chalk": "2.4.2",
+						"source-map": "0.6.1",
+						"supports-color": "5.5.0"
 					}
 				}
 			}
@@ -13673,7 +13668,7 @@
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 			"requires": {
-				"has-flag": "^3.0.0"
+				"has-flag": "3.0.0"
 			}
 		},
 		"svg-tags": {
@@ -13694,10 +13689,10 @@
 			"integrity": "sha512-E6CK1/pZe2N75rGZQotFOdmzWQ1AILtgYbMAbAjvms0S1l5IDB47zG3nCnFGB/w+7nB3vKofbLXCH7HPBo864w==",
 			"dev": true,
 			"requires": {
-				"ajv": "^6.9.1",
-				"lodash": "^4.17.11",
-				"slice-ansi": "^2.1.0",
-				"string-width": "^3.0.0"
+				"ajv": "6.10.2",
+				"lodash": "4.17.14",
+				"slice-ansi": "2.1.0",
+				"string-width": "3.1.0"
 			}
 		},
 		"table-layout": {
@@ -13705,11 +13700,11 @@
 			"resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.5.tgz",
 			"integrity": "sha512-zTvf0mcggrGeTe/2jJ6ECkJHAQPIYEwDoqsiqBjI24mvRmQbInK5jq33fyypaCBxX08hMkfmdOqj6haT33EqWw==",
 			"requires": {
-				"array-back": "^2.0.0",
-				"deep-extend": "~0.6.0",
-				"lodash.padend": "^4.6.1",
-				"typical": "^2.6.1",
-				"wordwrapjs": "^3.0.0"
+				"array-back": "2.0.0",
+				"deep-extend": "0.6.0",
+				"lodash.padend": "4.6.1",
+				"typical": "2.6.1",
+				"wordwrapjs": "3.0.0"
 			},
 			"dependencies": {
 				"array-back": {
@@ -13717,7 +13712,7 @@
 					"resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
 					"integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
 					"requires": {
-						"typical": "^2.6.1"
+						"typical": "2.6.1"
 					}
 				}
 			}
@@ -13739,9 +13734,9 @@
 			"integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
 			"dev": true,
 			"requires": {
-				"block-stream": "*",
-				"fstream": "^1.0.12",
-				"inherits": "2"
+				"block-stream": "0.0.9",
+				"fstream": "1.0.12",
+				"inherits": "2.0.4"
 			}
 		},
 		"temp-path": {
@@ -13755,9 +13750,9 @@
 			"integrity": "sha512-jvNoEQSPXJdssFwqPSgWjsOrb+ELoE+ILpHPKXC83tIxOlh2U75F1KuB2luLD/3a6/7K3Vw5pDn+hvu0C4AzSw==",
 			"dev": true,
 			"requires": {
-				"commander": "^2.20.0",
-				"source-map": "~0.6.1",
-				"source-map-support": "~0.5.12"
+				"commander": "2.20.0",
+				"source-map": "0.6.1",
+				"source-map-support": "0.5.12"
 			}
 		},
 		"terser-webpack-plugin": {
@@ -13766,16 +13761,16 @@
 			"integrity": "sha512-W2YWmxPjjkUcOWa4pBEv4OP4er1aeQJlSo2UhtCFQCuRXEHjOFscO8VyWHj9JLlA0RzQb8Y2/Ta78XZvT54uGg==",
 			"dev": true,
 			"requires": {
-				"cacache": "^11.3.2",
-				"find-cache-dir": "^2.0.0",
-				"is-wsl": "^1.1.0",
-				"loader-utils": "^1.2.3",
-				"schema-utils": "^1.0.0",
-				"serialize-javascript": "^1.7.0",
-				"source-map": "^0.6.1",
-				"terser": "^4.0.0",
-				"webpack-sources": "^1.3.0",
-				"worker-farm": "^1.7.0"
+				"cacache": "11.3.3",
+				"find-cache-dir": "2.1.0",
+				"is-wsl": "1.1.0",
+				"loader-utils": "1.2.3",
+				"schema-utils": "1.0.0",
+				"serialize-javascript": "1.7.0",
+				"source-map": "0.6.1",
+				"terser": "4.1.2",
+				"webpack-sources": "1.3.0",
+				"worker-farm": "1.7.0"
 			}
 		},
 		"test-exclude": {
@@ -13784,10 +13779,10 @@
 			"integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
 			"dev": true,
 			"requires": {
-				"glob": "^7.1.3",
-				"minimatch": "^3.0.4",
-				"read-pkg-up": "^4.0.0",
-				"require-main-filename": "^2.0.0"
+				"glob": "7.1.4",
+				"minimatch": "3.0.4",
+				"read-pkg-up": "4.0.0",
+				"require-main-filename": "2.0.0"
 			}
 		},
 		"test-value": {
@@ -13795,8 +13790,8 @@
 			"resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
 			"integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
 			"requires": {
-				"array-back": "^2.0.0",
-				"typical": "^2.6.1"
+				"array-back": "2.0.0",
+				"typical": "2.6.1"
 			},
 			"dependencies": {
 				"array-back": {
@@ -13804,7 +13799,7 @@
 					"resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
 					"integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
 					"requires": {
-						"typical": "^2.6.1"
+						"typical": "2.6.1"
 					}
 				}
 			}
@@ -13833,8 +13828,8 @@
 			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
 			"dev": true,
 			"requires": {
-				"readable-stream": "~2.3.6",
-				"xtend": "~4.0.1"
+				"readable-stream": "2.3.6",
+				"xtend": "4.0.2"
 			},
 			"dependencies": {
 				"readable-stream": {
@@ -13843,13 +13838,13 @@
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.4",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.1",
+						"safe-buffer": "5.1.2",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"string_decoder": {
@@ -13858,7 +13853,7 @@
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "5.1.2"
 					}
 				}
 			}
@@ -13869,7 +13864,7 @@
 			"integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
 			"dev": true,
 			"requires": {
-				"setimmediate": "^1.0.4"
+				"setimmediate": "1.0.5"
 			}
 		},
 		"tmp": {
@@ -13878,7 +13873,7 @@
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
 			"dev": true,
 			"requires": {
-				"os-tmpdir": "~1.0.2"
+				"os-tmpdir": "1.0.2"
 			}
 		},
 		"tmpl": {
@@ -13905,7 +13900,7 @@
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"is-buffer": {
@@ -13920,7 +13915,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -13931,10 +13926,10 @@
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
 			"dev": true,
 			"requires": {
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"regex-not": "^1.0.2",
-				"safe-regex": "^1.1.0"
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"regex-not": "1.0.2",
+				"safe-regex": "1.1.0"
 			}
 		},
 		"to-regex-range": {
@@ -13942,7 +13937,7 @@
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
 			"requires": {
-				"is-number": "^7.0.0"
+				"is-number": "7.0.0"
 			}
 		},
 		"tough-cookie": {
@@ -13951,8 +13946,8 @@
 			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
 			"dev": true,
 			"requires": {
-				"psl": "^1.1.28",
-				"punycode": "^2.1.1"
+				"psl": "1.2.0",
+				"punycode": "2.1.1"
 			}
 		},
 		"tr46": {
@@ -13961,7 +13956,7 @@
 			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
 			"dev": true,
 			"requires": {
-				"punycode": "^2.1.0"
+				"punycode": "2.1.1"
 			}
 		},
 		"traverse": {
@@ -14007,7 +14002,7 @@
 			"integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
 			"dev": true,
 			"requires": {
-				"glob": "^7.1.2"
+				"glob": "7.1.4"
 			}
 		},
 		"tsconfig": {
@@ -14016,10 +14011,10 @@
 			"integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
 			"dev": true,
 			"requires": {
-				"@types/strip-bom": "^3.0.0",
+				"@types/strip-bom": "3.0.0",
 				"@types/strip-json-comments": "0.0.30",
-				"strip-bom": "^3.0.0",
-				"strip-json-comments": "^2.0.0"
+				"strip-bom": "3.0.0",
+				"strip-json-comments": "2.0.1"
 			},
 			"dependencies": {
 				"strip-json-comments": {
@@ -14048,7 +14043,7 @@
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "^5.0.1"
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"tweetnacl": {
@@ -14078,7 +14073,7 @@
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "~1.1.2"
+				"prelude-ls": "1.1.2"
 			}
 		},
 		"typedarray": {
@@ -14123,8 +14118,8 @@
 			"resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.2.tgz",
 			"integrity": "sha512-W3tMnpaMG7ZY6xe/moK04U9fBhi6wEiCYHUW5Mop/wQHf12+79EQGwxYejNdhEz2mkqkBlGwm7pxmgBKMVUj0w==",
 			"requires": {
-				"inherits": "^2.0.1",
-				"xtend": "^4.0.1"
+				"inherits": "2.0.4",
+				"xtend": "4.0.2"
 			}
 		},
 		"unicode-canonical-property-names-ecmascript": {
@@ -14139,8 +14134,8 @@
 			"integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
 			"dev": true,
 			"requires": {
-				"unicode-canonical-property-names-ecmascript": "^1.0.4",
-				"unicode-property-aliases-ecmascript": "^1.0.4"
+				"unicode-canonical-property-names-ecmascript": "1.0.4",
+				"unicode-property-aliases-ecmascript": "1.0.5"
 			}
 		},
 		"unicode-match-property-value-ecmascript": {
@@ -14160,12 +14155,12 @@
 			"resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
 			"integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
 			"requires": {
-				"bail": "^1.0.0",
-				"extend": "^3.0.0",
-				"is-plain-obj": "^1.1.0",
-				"trough": "^1.0.0",
-				"vfile": "^2.0.0",
-				"x-is-string": "^0.1.0"
+				"bail": "1.0.4",
+				"extend": "3.0.2",
+				"is-plain-obj": "1.1.0",
+				"trough": "1.0.4",
+				"vfile": "2.3.0",
+				"x-is-string": "0.1.0"
 			}
 		},
 		"union-value": {
@@ -14174,10 +14169,10 @@
 			"integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
 			"dev": true,
 			"requires": {
-				"arr-union": "^3.1.0",
-				"get-value": "^2.0.6",
-				"is-extendable": "^0.1.1",
-				"set-value": "^2.0.1"
+				"arr-union": "3.1.0",
+				"get-value": "2.0.6",
+				"is-extendable": "0.1.1",
+				"set-value": "2.0.1"
 			}
 		},
 		"uniq": {
@@ -14192,7 +14187,7 @@
 			"integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
 			"dev": true,
 			"requires": {
-				"unique-slug": "^2.0.0"
+				"unique-slug": "2.0.2"
 			}
 		},
 		"unique-slug": {
@@ -14201,7 +14196,7 @@
 			"integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
 			"dev": true,
 			"requires": {
-				"imurmurhash": "^0.1.4"
+				"imurmurhash": "0.1.4"
 			}
 		},
 		"unist-util-find-all-after": {
@@ -14210,7 +14205,7 @@
 			"integrity": "sha512-CaxvMjTd+yF93BKLJvZnEfqdM7fgEACsIpQqz8vIj9CJnUb9VpyymFS3tg6TCtgrF7vfCJBF5jbT2Ox9CBRYRQ==",
 			"dev": true,
 			"requires": {
-				"unist-util-is": "^3.0.0"
+				"unist-util-is": "3.0.0"
 			}
 		},
 		"unist-util-is": {
@@ -14223,7 +14218,7 @@
 			"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.3.tgz",
 			"integrity": "sha512-CtszTlOjP2sBGYc2zcKA/CvNdTdEs3ozbiJ63IPBxh8iZg42SCCb8m04f8z2+V1aSk5a7BxbZKEdoDjadmBkWA==",
 			"requires": {
-				"unist-util-visit": "^1.1.0"
+				"unist-util-visit": "1.4.1"
 			}
 		},
 		"unist-util-stringify-position": {
@@ -14236,7 +14231,7 @@
 			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
 			"integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
 			"requires": {
-				"unist-util-visit-parents": "^2.0.0"
+				"unist-util-visit-parents": "2.1.2"
 			}
 		},
 		"unist-util-visit-parents": {
@@ -14244,7 +14239,7 @@
 			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
 			"integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
 			"requires": {
-				"unist-util-is": "^3.0.0"
+				"unist-util-is": "3.0.0"
 			}
 		},
 		"unset-value": {
@@ -14253,8 +14248,8 @@
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
 			"dev": true,
 			"requires": {
-				"has-value": "^0.3.1",
-				"isobject": "^3.0.0"
+				"has-value": "0.3.1",
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"has-value": {
@@ -14263,9 +14258,9 @@
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
 					"dev": true,
 					"requires": {
-						"get-value": "^2.0.3",
-						"has-values": "^0.1.4",
-						"isobject": "^2.0.0"
+						"get-value": "2.0.6",
+						"has-values": "0.1.4",
+						"isobject": "2.1.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -14299,7 +14294,7 @@
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
 			"dev": true,
 			"requires": {
-				"punycode": "^2.1.0"
+				"punycode": "2.1.1"
 			}
 		},
 		"urix": {
@@ -14360,8 +14355,8 @@
 			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"object.getownpropertydescriptors": "^2.0.3"
+				"define-properties": "1.1.3",
+				"object.getownpropertydescriptors": "2.0.3"
 			}
 		},
 		"uuid": {
@@ -14374,8 +14369,8 @@
 			"resolved": "https://registry.npmjs.org/v-tooltip/-/v-tooltip-3.0.0-alpha.11.tgz",
 			"integrity": "sha512-n95vxc1fBZrCkmkJTuH/O0if+8r7r+dFfZpOYCysYT+bIJiK4gxMiEo8olTMoIM1uxikiOGN+CMURcW764m6Xw==",
 			"requires": {
-				"popper.js": "^1.15.0",
-				"vue-resize": "^0.4.5"
+				"popper.js": "1.15.0",
+				"vue-resize": "0.4.5"
 			}
 		},
 		"v8-compile-cache": {
@@ -14390,8 +14385,8 @@
 			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
 			"dev": true,
 			"requires": {
-				"spdx-correct": "^3.0.0",
-				"spdx-expression-parse": "^3.0.0"
+				"spdx-correct": "3.1.0",
+				"spdx-expression-parse": "3.0.0"
 			}
 		},
 		"verror": {
@@ -14400,9 +14395,9 @@
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0",
+				"assert-plus": "1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "^1.2.0"
+				"extsprintf": "1.3.0"
 			}
 		},
 		"vfile": {
@@ -14410,10 +14405,10 @@
 			"resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
 			"integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
 			"requires": {
-				"is-buffer": "^1.1.4",
+				"is-buffer": "1.1.6",
 				"replace-ext": "1.0.0",
-				"unist-util-stringify-position": "^1.0.0",
-				"vfile-message": "^1.0.0"
+				"unist-util-stringify-position": "1.1.2",
+				"vfile-message": "1.1.1"
 			},
 			"dependencies": {
 				"is-buffer": {
@@ -14433,7 +14428,7 @@
 			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
 			"integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
 			"requires": {
-				"unist-util-stringify-position": "^1.1.1"
+				"unist-util-stringify-position": "1.1.2"
 			}
 		},
 		"vm-browserify": {
@@ -14468,12 +14463,12 @@
 			"integrity": "sha512-JlHVZwBBTNVvzmifwjpZYn0oPWH2SgWv5dojlZBsrhablDu95VFD+hriB1rQGwbD+bms6g+rAFhQHk6+NyiS6g==",
 			"dev": true,
 			"requires": {
-				"debug": "^4.1.0",
-				"eslint-scope": "^4.0.0",
-				"eslint-visitor-keys": "^1.0.0",
-				"espree": "^4.1.0",
-				"esquery": "^1.0.1",
-				"lodash": "^4.17.11"
+				"debug": "4.1.1",
+				"eslint-scope": "4.0.3",
+				"eslint-visitor-keys": "1.0.0",
+				"espree": "4.1.0",
+				"esquery": "1.0.1",
+				"lodash": "4.17.14"
 			},
 			"dependencies": {
 				"acorn-jsx": {
@@ -14488,7 +14483,7 @@
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"eslint-scope": {
@@ -14497,8 +14492,8 @@
 					"integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
 					"dev": true,
 					"requires": {
-						"esrecurse": "^4.1.0",
-						"estraverse": "^4.1.1"
+						"esrecurse": "4.2.1",
+						"estraverse": "4.2.0"
 					}
 				},
 				"espree": {
@@ -14507,9 +14502,9 @@
 					"integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
 					"dev": true,
 					"requires": {
-						"acorn": "^6.0.2",
-						"acorn-jsx": "^5.0.0",
-						"eslint-visitor-keys": "^1.0.0"
+						"acorn": "6.2.0",
+						"acorn-jsx": "5.0.1",
+						"eslint-visitor-keys": "1.0.0"
 					}
 				},
 				"ms": {
@@ -14537,16 +14532,16 @@
 			"integrity": "sha512-PY9Rwt4OyaVlA+KDJJ0614CbEvNOkffDI9g9moLQC/2DDoo0YrqZm7dHi13Q10uoK5Nt5WCYFdeAheOExPah0w==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
-				"chalk": "^2.1.0",
-				"extract-from-css": "^0.4.4",
-				"find-babel-config": "^1.1.0",
-				"js-beautify": "^1.6.14",
-				"node-cache": "^4.1.1",
-				"object-assign": "^4.1.1",
-				"source-map": "^0.5.6",
-				"tsconfig": "^7.0.0",
-				"vue-template-es2015-compiler": "^1.6.0"
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+				"chalk": "2.4.2",
+				"extract-from-css": "0.4.4",
+				"find-babel-config": "1.2.0",
+				"js-beautify": "1.10.0",
+				"node-cache": "4.2.0",
+				"object-assign": "4.1.1",
+				"source-map": "0.5.7",
+				"tsconfig": "7.0.0",
+				"vue-template-es2015-compiler": "1.9.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -14563,11 +14558,11 @@
 			"integrity": "sha512-fwIKtA23Pl/rqfYP5TSGK7gkEuLhoTvRYW+TU7ER3q9GpNLt/PjG5NLv3XHRDiTg7OPM1JcckBgds+VnAc+HbA==",
 			"dev": true,
 			"requires": {
-				"@vue/component-compiler-utils": "^3.0.0",
-				"hash-sum": "^1.0.2",
-				"loader-utils": "^1.1.0",
-				"vue-hot-reload-api": "^2.3.0",
-				"vue-style-loader": "^4.1.0"
+				"@vue/component-compiler-utils": "3.0.0",
+				"hash-sum": "1.0.2",
+				"loader-utils": "1.2.3",
+				"vue-hot-reload-api": "2.3.3",
+				"vue-style-loader": "4.1.2"
 			}
 		},
 		"vue-masonry-css": {
@@ -14596,8 +14591,8 @@
 			"integrity": "sha512-0ip8ge6Gzz/Bk0iHovU9XAUQaFt/G2B61bnWa2tCcqqdgfHs1lF9xXorFbE55Gmy92okFT+8bfmySuUOu13vxQ==",
 			"dev": true,
 			"requires": {
-				"hash-sum": "^1.0.2",
-				"loader-utils": "^1.0.2"
+				"hash-sum": "1.0.2",
+				"loader-utils": "1.2.3"
 			}
 		},
 		"vue-template-compiler": {
@@ -14606,8 +14601,8 @@
 			"integrity": "sha512-jVZkw4/I/HT5ZMvRnhv78okGusqe0+qH2A0Em0Cp8aq78+NK9TII263CDVz2QXZsIT+yyV/gZc/j/vlwa+Epyg==",
 			"dev": true,
 			"requires": {
-				"de-indent": "^1.0.2",
-				"he": "^1.1.0"
+				"de-indent": "1.0.2",
+				"he": "1.2.0"
 			}
 		},
 		"vue-template-es2015-compiler": {
@@ -14636,7 +14631,7 @@
 			"resolved": "https://registry.npmjs.org/vue2-datepicker/-/vue2-datepicker-2.12.0.tgz",
 			"integrity": "sha512-09PRIFm5hWrpfSBxWKJqm78yC0MTUZlq9MItLsWDe1OPgRqwWpex4fGkL7/nJG+d39v60wckQoVdk9RpLx8C9w==",
 			"requires": {
-				"fecha": "^2.3.3"
+				"fecha": "2.3.3"
 			}
 		},
 		"vuepress-jsdoc": {
@@ -14644,18 +14639,18 @@
 			"resolved": "https://registry.npmjs.org/vuepress-jsdoc/-/vuepress-jsdoc-1.7.3.tgz",
 			"integrity": "sha512-TFuWSdW3No5KF6n+bfPhDHJE7ngKHJBMJtKcEL3uNR1FbiKPvhMkE4vf72QPrO79VB/wwK9H6I0O23MZXsASPA==",
 			"requires": {
-				"@vuedoc/md": "^1.6.0",
-				"bluebird": "^3.5.5",
-				"chalk": "^2.4.2",
-				"cross-env": "^5.2.0",
-				"del": "^4.1.1",
-				"front-matter": "^3.0.2",
-				"fs.promised": "^3.0.0",
-				"jsdoc-to-markdown": "^5.0.0",
-				"micromatch": "^4.0.2",
-				"mkdirp": "^0.5.1",
-				"rimraf": "^2.6.3",
-				"yargs": "^13.2.4"
+				"@vuedoc/md": "1.6.0",
+				"bluebird": "3.5.5",
+				"chalk": "2.4.2",
+				"cross-env": "5.2.0",
+				"del": "4.1.1",
+				"front-matter": "3.0.2",
+				"fs.promised": "3.0.0",
+				"jsdoc-to-markdown": "5.0.0",
+				"micromatch": "4.0.2",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.3",
+				"yargs": "13.2.4"
 			}
 		},
 		"vuetrend": {
@@ -14679,7 +14674,7 @@
 			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
 			"dev": true,
 			"requires": {
-				"browser-process-hrtime": "^0.1.2"
+				"browser-process-hrtime": "0.1.3"
 			}
 		},
 		"walk-back": {
@@ -14693,7 +14688,7 @@
 			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
 			"dev": true,
 			"requires": {
-				"makeerror": "1.0.x"
+				"makeerror": "1.0.11"
 			}
 		},
 		"watchpack": {
@@ -14702,9 +14697,9 @@
 			"integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
 			"dev": true,
 			"requires": {
-				"chokidar": "^2.0.2",
-				"graceful-fs": "^4.1.2",
-				"neo-async": "^2.5.0"
+				"chokidar": "2.1.6",
+				"graceful-fs": "4.2.0",
+				"neo-async": "2.6.1"
 			}
 		},
 		"webidl-conversions": {
@@ -14723,25 +14718,25 @@
 				"@webassemblyjs/helper-module-context": "1.8.5",
 				"@webassemblyjs/wasm-edit": "1.8.5",
 				"@webassemblyjs/wasm-parser": "1.8.5",
-				"acorn": "^6.2.0",
-				"ajv": "^6.1.0",
-				"ajv-keywords": "^3.1.0",
-				"chrome-trace-event": "^1.0.0",
-				"enhanced-resolve": "^4.1.0",
-				"eslint-scope": "^4.0.0",
-				"json-parse-better-errors": "^1.0.2",
-				"loader-runner": "^2.3.0",
-				"loader-utils": "^1.1.0",
-				"memory-fs": "~0.4.1",
-				"micromatch": "^3.1.8",
-				"mkdirp": "~0.5.0",
-				"neo-async": "^2.5.0",
-				"node-libs-browser": "^2.0.0",
-				"schema-utils": "^1.0.0",
-				"tapable": "^1.1.0",
-				"terser-webpack-plugin": "^1.1.0",
-				"watchpack": "^1.5.0",
-				"webpack-sources": "^1.3.0"
+				"acorn": "6.2.0",
+				"ajv": "6.10.2",
+				"ajv-keywords": "3.4.1",
+				"chrome-trace-event": "1.0.2",
+				"enhanced-resolve": "4.1.0",
+				"eslint-scope": "4.0.3",
+				"json-parse-better-errors": "1.0.2",
+				"loader-runner": "2.4.0",
+				"loader-utils": "1.2.3",
+				"memory-fs": "0.4.1",
+				"micromatch": "3.1.10",
+				"mkdirp": "0.5.1",
+				"neo-async": "2.6.1",
+				"node-libs-browser": "2.2.1",
+				"schema-utils": "1.0.0",
+				"tapable": "1.1.3",
+				"terser-webpack-plugin": "1.3.0",
+				"watchpack": "1.6.0",
+				"webpack-sources": "1.3.0"
 			},
 			"dependencies": {
 				"braces": {
@@ -14750,16 +14745,16 @@
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.3",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -14768,7 +14763,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -14779,8 +14774,8 @@
 					"integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
 					"dev": true,
 					"requires": {
-						"esrecurse": "^4.1.0",
-						"estraverse": "^4.1.1"
+						"esrecurse": "4.2.1",
+						"estraverse": "4.2.0"
 					}
 				},
 				"fill-range": {
@@ -14789,10 +14784,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -14801,7 +14796,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -14818,7 +14813,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -14827,7 +14822,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -14838,19 +14833,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.13",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					}
 				},
 				"to-regex-range": {
@@ -14859,8 +14854,8 @@
 					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 					"dev": true,
 					"requires": {
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1"
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1"
 					}
 				}
 			}
@@ -14890,7 +14885,7 @@
 					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -14901,7 +14896,7 @@
 			"integrity": "sha512-4p8WQyS98bUJcCvFMbdGZyZmsKuWjWVnVHnAS3FFg0HDaRVrPbkivx2RYCre8UiemD67RsiFFLfn4JhLAin8Vw==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.5"
+				"lodash": "4.17.14"
 			}
 		},
 		"webpack-sources": {
@@ -14910,8 +14905,8 @@
 			"integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
 			"dev": true,
 			"requires": {
-				"source-list-map": "^2.0.0",
-				"source-map": "~0.6.1"
+				"source-list-map": "2.0.1",
+				"source-map": "0.6.1"
 			}
 		},
 		"whatwg-encoding": {
@@ -14935,9 +14930,9 @@
 			"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
 			"dev": true,
 			"requires": {
-				"lodash.sortby": "^4.7.0",
-				"tr46": "^1.0.1",
-				"webidl-conversions": "^4.0.2"
+				"lodash.sortby": "4.7.0",
+				"tr46": "1.0.1",
+				"webidl-conversions": "4.0.2"
 			}
 		},
 		"which": {
@@ -14945,7 +14940,7 @@
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 			"requires": {
-				"isexe": "^2.0.0"
+				"isexe": "2.0.0"
 			}
 		},
 		"which-module": {
@@ -14959,7 +14954,7 @@
 			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 			"dev": true,
 			"requires": {
-				"string-width": "^1.0.2 || 2"
+				"string-width": "2.1.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -14974,8 +14969,8 @@
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -14984,7 +14979,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				}
 			}
@@ -14999,8 +14994,8 @@
 			"resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
 			"integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
 			"requires": {
-				"reduce-flatten": "^1.0.1",
-				"typical": "^2.6.1"
+				"reduce-flatten": "1.0.1",
+				"typical": "2.6.1"
 			}
 		},
 		"worker-farm": {
@@ -15009,7 +15004,7 @@
 			"integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
 			"dev": true,
 			"requires": {
-				"errno": "~0.1.7"
+				"errno": "0.1.7"
 			}
 		},
 		"wrap-ansi": {
@@ -15017,9 +15012,9 @@
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
 			"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
 			"requires": {
-				"ansi-styles": "^3.2.0",
-				"string-width": "^3.0.0",
-				"strip-ansi": "^5.0.0"
+				"ansi-styles": "3.2.1",
+				"string-width": "3.1.0",
+				"strip-ansi": "5.2.0"
 			}
 		},
 		"wrappy": {
@@ -15033,7 +15028,7 @@
 			"integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
 			"dev": true,
 			"requires": {
-				"mkdirp": "^0.5.1"
+				"mkdirp": "0.5.1"
 			}
 		},
 		"write-file-atomic": {
@@ -15042,9 +15037,9 @@
 			"integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.11",
-				"imurmurhash": "^0.1.4",
-				"signal-exit": "^3.0.2"
+				"graceful-fs": "4.2.0",
+				"imurmurhash": "0.1.4",
+				"signal-exit": "3.0.2"
 			}
 		},
 		"ws": {
@@ -15053,7 +15048,7 @@
 			"integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
 			"dev": true,
 			"requires": {
-				"async-limiter": "~1.0.0"
+				"async-limiter": "1.0.0"
 			}
 		},
 		"x-is-string": {
@@ -15093,17 +15088,17 @@
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
 			"integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
 			"requires": {
-				"cliui": "^5.0.0",
-				"find-up": "^3.0.0",
-				"get-caller-file": "^2.0.1",
-				"os-locale": "^3.1.0",
-				"require-directory": "^2.1.1",
-				"require-main-filename": "^2.0.0",
-				"set-blocking": "^2.0.0",
-				"string-width": "^3.0.0",
-				"which-module": "^2.0.0",
-				"y18n": "^4.0.0",
-				"yargs-parser": "^13.1.0"
+				"cliui": "5.0.0",
+				"find-up": "3.0.0",
+				"get-caller-file": "2.0.5",
+				"os-locale": "3.1.0",
+				"require-directory": "2.1.1",
+				"require-main-filename": "2.0.0",
+				"set-blocking": "2.0.0",
+				"string-width": "3.1.0",
+				"which-module": "2.0.0",
+				"y18n": "4.0.0",
+				"yargs-parser": "13.1.1"
 			}
 		},
 		"yargs-parser": {
@@ -15111,8 +15106,8 @@
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
 			"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
 			"requires": {
-				"camelcase": "^5.0.0",
-				"decamelize": "^1.2.0"
+				"camelcase": "5.3.1",
+				"decamelize": "1.2.0"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
 	},
 	"dependencies": {
 		"vue-masonry-css": "^1.0.3",
-		"hashtag-regex": "^2.0.0",
 		"linkifyjs": "^2.1.8",
 		"nextcloud-axios": "^0.2.0",
 		"nextcloud-vue": "^0.11.4",

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -419,8 +419,15 @@ export default {
 							return item.original.value
 						},
 						selectTemplate: function(item) {
+							let tag = '';
+							// item is undefined if selectTemplate is called from a noMatchTemplate menu
+							if (typeof item === 'undefined') {
+								tag = this.currentMentionTextSnapshot
+							} else {
+								tag = item.original.value
+							}
 							return '<span class="hashtag" contenteditable="false">'
-								+ '<a href="' + OC.generateUrl('/timeline/tags/' + item.original.value) + '" target="_blank">#' + item.original.value + '</a></span>'
+								+ '<a href="' + OC.generateUrl('/timeline/tags/' + tag) + '" target="_blank">#' + tag + '</a></span>'
 						},
 						values: (text, cb) => {
 							let tags = []
@@ -449,7 +456,7 @@ export default {
 				],
 				noMatchTemplate() {
 					if (this.current.collection.trigger === "#")
-						return "<span><strong>#" + this.current.mentionText + "</strong>: Tag not found." + "</span><br/><button>add tag</button>";
+						return '<li data-index="0">#' + this.current.mentionText + '</li>';
 				}
 			},
 			menuOpened: false

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -386,7 +386,7 @@ export default {
 						},
 						values: (text, cb) => {
 							let users = []
-		
+
 							if (text.length < 1) {
 								cb(users)
 							}
@@ -419,7 +419,7 @@ export default {
 							return item.original.value
 						},
 						selectTemplate: function(item) {
-							let tag = '';
+							let tag = ''
 							// item is undefined if selectTemplate is called from a noMatchTemplate menu
 							if (typeof item === 'undefined') {
 								tag = this.currentMentionTextSnapshot
@@ -431,7 +431,7 @@ export default {
 						},
 						values: (text, cb) => {
 							let tags = []
-		
+
 							if (text.length < 1) {
 								cb(tags)
 							}
@@ -439,14 +439,14 @@ export default {
 								if (result.data.result.exact) {
 									tags.push({
 										key: result.data.result.exact,
-										value: result.data.result.exact,
+										value: result.data.result.exact
 									})
 								}
 								for (var i in result.data.result.tags) {
 									let tag = result.data.result.tags[i]
 									tags.push({
 										key: tag.hashtag,
-										value: tag.hashtag,
+										value: tag.hashtag
 									})
 								}
 								cb(tags)
@@ -455,12 +455,13 @@ export default {
 					}
 				],
 				noMatchTemplate() {
-					if (this.current.collection.trigger === "#")
+					if (this.current.collection.trigger === '#') {
 						if (this.current.mentionText === '') {
 							return undefined
 						} else {
-							return '<li data-index="0">#' + this.current.mentionText + '</li>';
+							return '<li data-index="0">#' + this.current.mentionText + '</li>'
 						}
+					}
 				}
 			},
 			menuOpened: false

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -328,6 +328,9 @@
 		width: 16px;
 		vertical-align: text-bottom;
 	}
+	.hashtag {
+		text-decoration: underline;
+	}
 </style>
 <script>
 
@@ -365,47 +368,66 @@ export default {
 			search: '',
 			replyTo: null,
 			tributeOptions: {
-				lookup: function(item) {
-					return item.key + item.value
-				},
-				menuItemTemplate: function(item) {
-					return '<img src="' + item.original.avatar + '" /><div>'
-						+ '<span class="displayName">' + item.original.key + '</span>'
-						+ '<span class="account">' + item.original.value + '</span>'
-						+ '</div>'
-				},
-				selectTemplate: function(item) {
-					return '<span class="mention" contenteditable="false">'
-						+ '<a href="' + item.original.url + '" target="_blank"><img src="' + item.original.avatar + '" />@' + item.original.value + '</a></span>'
-				},
-				values: (text, cb) => {
-					let users = []
-
-					if (text.length < 1) {
-						cb(users)
+				collection: [
+					{
+						trigger: '@',
+						lookup: function(item) {
+							return item.key + item.value
+						},
+						menuItemTemplate: function(item) {
+							return '<img src="' + item.original.avatar + '" /><div>'
+								+ '<span class="displayName">' + item.original.key + '</span>'
+								+ '<span class="account">' + item.original.value + '</span>'
+								+ '</div>'
+						},
+						selectTemplate: function(item) {
+							return '<span class="mention" contenteditable="false">'
+								+ '<a href="' + item.original.url + '" target="_blank"><img src="' + item.original.avatar + '" />@' + item.original.value + '</a></span>'
+						},
+						values: (text, cb) => {
+							let users = []
+		
+							if (text.length < 1) {
+								cb(users)
+							}
+							this.remoteSearch(text).then((result) => {
+								if (result.data.result.exact) {
+									let user = result.data.result.exact
+									users.push({
+										key: user.preferredUsername,
+										value: user.account,
+										url: user.url,
+										avatar: user.local ? OC.generateUrl(`/avatar/${user.preferredUsername}/32`) : ''// TODO: use real avatar from server
+									})
+								}
+								for (var i in result.data.result.accounts) {
+									let user = result.data.result.accounts[i]
+									users.push({
+										key: user.preferredUsername,
+										value: user.account,
+										url: user.url,
+										avatar: user.local ? OC.generateUrl(`/avatar/${user.preferredUsername}/32`) : OC.generateUrl(`apps/social/api/v1/global/actor/avatar?id=${user.id}`)
+									})
+								}
+								cb(users)
+							})
+						}
+					},
+					{
+						trigger: '#',
+						menuItemTemplate: function(item) {
+							return item.original.value
+						},
+						selectTemplate: function(item) {
+							return '<span class="hashtag" contenteditable="false">@' + item.original.value + '</span>'
+						},
+						values: [
+					              { key: "foo", value: "foo" },
+					              { key: "bar", value: "bar" },
+					              { key: "baz", value: "baz" }
+						]	
 					}
-					this.remoteSearch(text).then((result) => {
-						if (result.data.result.exact) {
-							let user = result.data.result.exact
-							users.push({
-								key: user.preferredUsername,
-								value: user.account,
-								url: user.url,
-								avatar: user.local ? OC.generateUrl(`/avatar/${user.preferredUsername}/32`) : ''// TODO: use real avatar from server
-							})
-						}
-						for (var i in result.data.result.accounts) {
-							let user = result.data.result.accounts[i]
-							users.push({
-								key: user.preferredUsername,
-								value: user.account,
-								url: user.url,
-								avatar: user.local ? OC.generateUrl(`/avatar/${user.preferredUsername}/32`) : OC.generateUrl(`apps/social/api/v1/global/actor/avatar?id=${user.id}`)
-							})
-						}
-						cb(users)
-					})
-				}
+				]
 			},
 			menuOpened: false
 

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -46,7 +46,7 @@
 			</div>
 		</div>
 		<form class="new-post-form" @submit.prevent="createPost">
-			<vue-tribute ref="composerTribute" :options="tributeOptions">
+			<vue-tribute :options="tributeOptions">
 				<!-- eslint-disable-next-line vue/valid-v-model -->
 				<div ref="composerInput" v-contenteditable:post.dangerousHTML="canType && !loading" class="message"
 					placeholder="What would you like to share?" :class="{'icon-loading': loading}" @keyup.enter="keyup" />

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -456,7 +456,11 @@ export default {
 				],
 				noMatchTemplate() {
 					if (this.current.collection.trigger === "#")
-						return '<li data-index="0">#' + this.current.mentionText + '</li>';
+						if (this.current.mentionText === '') {
+							return ''
+						} else {
+							return '<li data-index="0">#' + this.current.mentionText + '</li>';
+						}
 				}
 			},
 			menuOpened: false

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -457,7 +457,7 @@ export default {
 				noMatchTemplate() {
 					if (this.current.collection.trigger === "#")
 						if (this.current.mentionText === '') {
-							return ''
+							return undefined
 						} else {
 							return '<li data-index="0">#' + this.current.mentionText + '</li>';
 						}

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -584,29 +584,29 @@ export default {
 				var em = document.createTextNode(emoji.getAttribute('alt'))
 				emoji.replaceWith(em)
 			})
-			let content = element.innerText.trim()
+			let contentHtml = element.innerHTML
 			let to = []
 			let hashtags = []
 			const mentionRegex = /@(([\w-_.]+)(@[\w-.]+)?)/g
 			let match = null
 			do {
-				match = mentionRegex.exec(content)
+				match = mentionRegex.exec(contentHtml)
 				if (match) {
 					to.push(match[1])
 				}
 			} while (match)
 
-			const hashtagRegex = /#([\w-_.]+)/g
+			const hashtagRegex = />#([^<]+)</g
 			match = null
 			do {
-				match = hashtagRegex.exec(content)
+				match = hashtagRegex.exec(contentHtml)
 				if (match) {
 					hashtags.push(match[1])
 				}
 			} while (match)
 
 			let data = {
-				content: content,
+				content: element.innerText.trim(),
 				to: to,
 				hashtags: hashtags,
 				type: this.type

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -390,7 +390,7 @@ export default {
 							if (text.length < 1) {
 								cb(users)
 							}
-							this.remoteSearch(text).then((result) => {
+							this.remoteSearchAccounts(text).then((result) => {
 								if (result.data.result.exact) {
 									let user = result.data.result.exact
 									users.push({
@@ -422,14 +422,32 @@ export default {
 							return '<span class="hashtag" contenteditable="false">'
 								+ '<a href="' + OC.generateUrl('/timeline/tags/' + item.original.value) + '" target="_blank">#' + item.original.value + '</a></span>'
 						},
-						values: [
-					              { key: "nextcloud", value: "nextcloud" },
-					              { key: "social", value: "social" },
-						]	
+						values: (text, cb) => {
+							let tags = []
+		
+							if (text.length < 1) {
+								cb(tags)
+							}
+							this.remoteSearchHashtags(text).then((result) => {
+								if (result.data.result.exact) {
+									tags.push({
+										key: result.data.result.exact,
+										value: result.data.result.exact,
+									})
+								}
+								for (var i in result.data.result.tags) {
+									let tag = result.data.result.tags[i]
+									tags.push({
+										key: tag.hashtag,
+										value: tag.hashtag,
+									})
+								}
+								cb(tags)
+							})
+						}
 					}
 				],
 				noMatchTemplate() {
-					console.log(this.current)
 					if (this.current.collection.trigger === "#")
 						return "<span><strong>#" + this.current.mentionText + "</strong>: Tag not found." + "</span><br/><button>add tag</button>";
 				}
@@ -602,8 +620,11 @@ export default {
 				this.$store.dispatch('refreshTimeline')
 			})
 		},
-		remoteSearch(text) {
+		remoteSearchAccounts(text) {
 			return axios.get(OC.generateUrl('apps/social/api/v1/global/accounts/search?search=' + text))
+		},
+		remoteSearchHashtags(text) {
+			return axios.get(OC.generateUrl('apps/social/api/v1/global/tags/search?search=' + text))
 		}
 	}
 }

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -46,7 +46,7 @@
 			</div>
 		</div>
 		<form class="new-post-form" @submit.prevent="createPost">
-			<vue-tribute :options="tributeOptions">
+			<vue-tribute ref="composerTribute" :options="tributeOptions">
 				<!-- eslint-disable-next-line vue/valid-v-model -->
 				<div ref="composerInput" v-contenteditable:post.dangerousHTML="canType && !loading" class="message"
 					placeholder="What would you like to share?" :class="{'icon-loading': loading}" @keyup.enter="keyup" />
@@ -419,15 +419,20 @@ export default {
 							return item.original.value
 						},
 						selectTemplate: function(item) {
-							return '<span class="hashtag" contenteditable="false">@' + item.original.value + '</span>'
+							return '<span class="hashtag" contenteditable="false">'
+								+ '<a href="' + OC.generateUrl('/timeline/tags/' + item.original.value) + '" target="_blank">#' + item.original.value + '</a></span>'
 						},
 						values: [
-					              { key: "foo", value: "foo" },
-					              { key: "bar", value: "bar" },
-					              { key: "baz", value: "baz" }
+					              { key: "nextcloud", value: "nextcloud" },
+					              { key: "social", value: "social" },
 						]	
 					}
-				]
+				],
+				noMatchTemplate() {
+					console.log(this.current)
+					if (this.current.collection.trigger === "#")
+						return "<span><strong>#" + this.current.mentionText + "</strong>: Tag not found." + "</span><br/><button>add tag</button>";
+				}
 			},
 			menuOpened: false
 

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -388,8 +388,9 @@ export default {
 							let users = []
 
 							if (text.length < 1) {
-								cb(users)
+								return
 							}
+
 							this.remoteSearchAccounts(text).then((result) => {
 								if (result.data.result.exact) {
 									let user = result.data.result.exact
@@ -409,7 +410,9 @@ export default {
 										avatar: user.local ? OC.generateUrl(`/avatar/${user.preferredUsername}/32`) : OC.generateUrl(`apps/social/api/v1/global/actor/avatar?id=${user.id}`)
 									})
 								}
-								cb(users)
+								if (users.length > 0) {
+									cb(users)
+								}
 							})
 						}
 					},
@@ -433,7 +436,7 @@ export default {
 							let tags = []
 
 							if (text.length < 1) {
-								cb(tags)
+								return
 							}
 							this.remoteSearchHashtags(text).then((result) => {
 								if (result.data.result.exact) {
@@ -449,20 +452,13 @@ export default {
 										value: tag.hashtag
 									})
 								}
-								cb(tags)
+								if (tags.length > 0) {
+									cb(tags)
+								}
 							})
 						}
 					}
-				],
-				noMatchTemplate() {
-					if (this.current.collection.trigger === '#') {
-						if (this.current.mentionText === '') {
-							return undefined
-						} else {
-							return '<li data-index="0">#' + this.current.mentionText + '</li>'
-						}
-					}
-				}
+				]
 			},
 			menuOpened: false
 

--- a/src/components/TimelinePost.vue
+++ b/src/components/TimelinePost.vue
@@ -60,8 +60,6 @@ import PostAttachment from './PostAttachment'
 
 pluginMention(linkify)
 
-const hashtagRegex = require('hashtag-regex')
-
 export default {
 	name: 'TimelinePost',
 	components: {
@@ -102,7 +100,7 @@ export default {
 			return Date.parse(this.item.published)
 		},
 		formatedMessage() {
-			var message = this.item.content
+			let message = this.item.content
 			if (typeof message === 'undefined') {
 				return ''
 			}
@@ -114,7 +112,9 @@ export default {
 					}
 				}
 			})
-			message = this.mangleHashtags(message)
+			if (this.item.hashtags !== undefined) {
+				message = this.mangleHashtags(message)
+			}
 			message = this.$twemoji.parse(message)
 			return message
 		},
@@ -140,10 +140,12 @@ export default {
 	methods: {
 		mangleHashtags(msg) {
 			// Replace hashtag's href parameter with local ones
-			const regex = hashtagRegex()
-			msg = msg.replace(regex, function(matched) {
-				var a = '<a href="' + OC.generateUrl('/apps/social/timeline/tags/' + matched.substring(1)) + '">' + matched + '</a>'
-				return a
+			this.item.hashtags.forEach(tag => {
+				let patt = new RegExp("#" + tag, "gi")
+				msg = msg.replace( patt, function(matched) {
+					var a = '<a href="' + OC.generateUrl('/apps/social/timeline/tags/' + matched.substring(1)) + '">' + matched + '</a>'
+					return a
+				})
 			})
 			return msg
 		},

--- a/src/components/TimelinePost.vue
+++ b/src/components/TimelinePost.vue
@@ -141,8 +141,8 @@ export default {
 		mangleHashtags(msg) {
 			// Replace hashtag's href parameter with local ones
 			this.item.hashtags.forEach(tag => {
-				let patt = new RegExp("#" + tag, "gi")
-				msg = msg.replace( patt, function(matched) {
+				let patt = new RegExp('#' + tag, 'gi')
+				msg = msg.replace(patt, function(matched) {
 					var a = '<a href="' + OC.generateUrl('/apps/social/timeline/tags/' + matched.substring(1)) + '">' + matched + '</a>'
 					return a
 				})


### PR DESCRIPTION
* Resolves: 
* Target version: master 

### Summary

Originaly, hashtags were identified in the front-end using linkifyjs. But, this method, amongst other limitations, doesn't support hashtags with non-latin characters.

I then changed to hashtag-regex which brought some improvements. 

Unfortunately, this method still has the problem that if a hashtag is directly followed by some text, social's front-end will wrongly identify the hashtag as in the following toot: "Hello #fediverseHow are you?" (social identifies a "#fediverseHow" hashtag whereas the intended hashtag is "#fediverse" only).
 
The thing is: the list of hashtags in a toot is sent together with the toot (in its 'tag' attribute) and is stored in the DB (field 'hashtags' in the ac_social_a2_stream table).

This PR makes use of this 'hashtags' field to identify hastags.

### Remaining issues

This PR doesn't work better than hastag-regex atm because the 'hashtags' field in the DB doesn't support non-latin characters.

Here's a sample output:

![image](https://user-images.githubusercontent.com/8179031/62055915-d68e7700-b21c-11e9-9056-79babe33ce74.png)

We can see that the hashtag isn't fully identified.

And, here's what the DB says about this toot:

```sql
MariaDB [nextcloud]> select * from oc_social_a2_stream where hashtags='["gTest"]'\G;
*************************** 1. row ***************************
           id_prim: 4b02b8ab1458ee096d7f8449eb5febb9a7053983faac84e5671e3a73ba5e226dfaffe99e37356da1943421ab48d5bf359838236be861853f2378c8531923c092
                id: https://nextcloud.bollu.be/index.php/apps/social/@cyrille/15644098951701989652
              type: Note
                to: https://nextcloud.bollu.be/index.php/apps/social/@cyrille/followers
          to_array: []
                cc: ["https://www.w3.org/ns/activitystreams#Public"]
               bcc: []
           content: this is just a test of a toot with a hashtag containing non-latin characters. #gTest&eacute;CeTruc
           summary:
         published: 2019-07-29T14:18:15+00:00
    published_time: 2019-07-29 14:18:15
     attributed_to: https://nextcloud.bollu.be/index.php/apps/social/@cyrille
       in_reply_to:
       activity_id:
         object_id:
          hashtags: ["gTest"]
            source:
         instances: [{"uri":"https://nextcloud.bollu.be/index.php/apps/social/@cyrille/followers","type":3,"priority":1}]
       attachments: []
             cache: []
          creation: 2019-07-29 14:18:16
             local: 1
hidden_on_timeline: 0
           details: []
           subtype:
1 row in set (0.001 sec)

ERROR: No query specified

MariaDB [nextcloud]>

```