### PR TITLE
Fixes Composer's weird behavior when hashtag or mention is last element in post

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -49,7 +49,8 @@
 			<vue-tribute :options="tributeOptions">
 				<!-- eslint-disable-next-line vue/valid-v-model -->
 				<div ref="composerInput" v-contenteditable:post.dangerousHTML="canType && !loading" class="message"
-					placeholder="What would you like to share?" :class="{'icon-loading': loading}" @keyup.enter="keyup" @tribute-replaced="updatePostFromTribute" />
+					placeholder="What would you like to share?" :class="{'icon-loading': loading}" @keyup.enter="keyup"
+					@tribute-replaced="updatePostFromTribute" />
 			</vue-tribute>
 			<emoji-picker ref="emojiPicker" :search="search" class="emoji-picker-wrapper"
 				@emoji="insert">

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -49,7 +49,7 @@
 			<vue-tribute :options="tributeOptions">
 				<!-- eslint-disable-next-line vue/valid-v-model -->
 				<div ref="composerInput" v-contenteditable:post.dangerousHTML="canType && !loading" class="message"
-					placeholder="What would you like to share?" :class="{'icon-loading': loading}" @keyup.enter="keyup" />
+					placeholder="What would you like to share?" :class="{'icon-loading': loading}" @keyup.enter="keyup" @tribute-replaced="updatePostFromTribute" />
 			</vue-tribute>
 			<emoji-picker ref="emojiPicker" :search="search" class="emoji-picker-wrapper"
 				@emoji="insert">
@@ -776,6 +776,10 @@ export default {
 			if (event.shiftKey) {
 				this.createPost(event)
 			}
+		},
+		updatePostFromTribute(event) {
+			// Trick to let vue-contenteditable know that tribute replaced a mention or hashtag
+			this.$refs.composerInput.oninput(event)
 		},
 		createPost(event) {
 			this.loading = true


### PR DESCRIPTION

* Resolves: #708
* Target version: master 

### Summary

vue-contenteditable updates its content when receiving the `oninput` event. 

Unfortunately, vue-tribute doesn't fire this event when it replaces a mention or hashtag. 

So, when we place a mention or hashtag using vue-tribute and directly click outside the Composer, the oninput event isn't fired and the post's content is reverted to what was typed before replacing the 
mention or hashtag.

This PR fixes this by firing the vue-contenteditable's oninput event upon reception of vue-tribute's `tribute-replaced`` event.