### PR TITLE
Notification timeline improvements

### DIFF
--- a/lib/Interfaces/Object/FollowInterface.php
+++ b/lib/Interfaces/Object/FollowInterface.php
@@ -302,7 +302,7 @@ class FollowInterface implements IActivityPubInterface {
 					 ->setId($follow->getId() . '/notification')
 					 ->setSubType(Follow::TYPE)
 					 ->setActorId($follower->getId())
-					 ->setSummary('{account} is following you')
+					 ->setSummary('{account} followed you')
 					 ->setTo($follow->getObjectId())
 					 ->setLocal(true);
 
@@ -310,4 +310,3 @@ class FollowInterface implements IActivityPubInterface {
 	}
 
 }
-

--- a/src/components/FollowButton.vue
+++ b/src/components/FollowButton.vue
@@ -110,6 +110,7 @@ export default {
 
 	button {
 		min-width: 110px;
+		margin: 3px 0 3px 0;
 	}
 
 	button * {

--- a/src/components/TimelineEntry.vue
+++ b/src/components/TimelineEntry.vue
@@ -19,8 +19,9 @@
 			</a>
 			{{ boosted }}
 		</div>
+		<user-entry v-if="item.type === 'SocialAppNotification' && item.details.actor" :key="item.details.actor.id" :item="item.details.actor" />
 		<timeline-post
-			v-if="item.type === 'SocialAppNotification' && item.details.post"
+			v-else-if="item.type === 'SocialAppNotification' && item.details.post"
 			:item="item.details.post" />
 		<timeline-post
 			v-else

--- a/src/components/TimelineEntry.vue
+++ b/src/components/TimelineEntry.vue
@@ -1,11 +1,14 @@
 <template>
-	<div class="timeline-entry">
-		<div v-if="item.type === 'SocialAppNotification'">
-			{{ actionSummary }}
+	<div class="timeline-entry" @click="getSinglePostTimeline">
+		<div v-if="item.type === 'SocialAppNotification'" class="notification-header">
+			<div class="notification-icon" :class="notificationIcon" />
+			<span class="notification-action">
+				{{ actionSummary }}
+			</span>
 		</div>
 		<div v-if="item.type === 'Announce'" class="boost">
 			<div class="container-icon-boost">
-				<span class="icon-boost" />
+				<span class="icon-boost icon-boosting" />
 			</div>
 			<router-link v-if="item.actor_info" :to="{ name: 'profile', params: { account: item.local ? item.actor_info.preferredUsername : item.actor_info.account }}">
 				<span v-tooltip.bottom="item.actor_info.account" class="post-author">
@@ -32,11 +35,13 @@
 
 <script>
 import TimelinePost from './TimelinePost.vue'
+import UserEntry from './UserEntry.vue'
 
 export default {
 	name: 'TimelineEntry',
 	components: {
-		TimelinePost
+		TimelinePost,
+		UserEntry
 	},
 	props: {
 		item: { type: Object, default: () => {} }
@@ -92,6 +97,18 @@ export default {
 			}
 
 			return summary
+		},
+		notificationIcon() {
+			switch (this.item.subtype) {
+			case 'Like':
+				return 'icon-favorite'
+			case 'Announce':
+				return 'icon-boost'
+			case 'Follow':
+				return 'icon-user'
+			default:
+				return ''
+			}
 		}
 	},
 	methods: {
@@ -110,18 +127,52 @@ export default {
 		}
 	}
 
+	.notification-header {
+		display: flex;
+		align-items: bottom;
+	}
+
+	.notification-action {
+		flex-grow: 1;
+		display: inline-block;
+		align-self: flex-end;
+	}
+
+	.notification-icon {
+		margin: 5px 10px 0 5px;
+		opacity: .5;
+		background-position: center;
+		background-size: contain;
+		overflow: hidden;
+		height: 20px;
+		min-width: 32px;
+		flex-shrink: 0;
+	}
+
+	.icon-boost {
+		display: inline-block;
+		vertical-align: middle;
+	}
+
+	.icon-favorite {
+		display: inline-block;
+		vertical-align: middle;
+	}
+
+	.icon-user {
+		display: inline-block;
+		vertical-align: middle;
+	}
+
 	.container-icon-boost {
 		display: inline-block;
 		padding-right: 6px;
 	}
 
-	.icon-boost {
-		display: inline-block;
+	.icon-boosting {
 		width: 38px;
 		height: 17px;
-		opacity: .5;
 		background-position: right center;
-		vertical-align: middle;
 	}
 
 	.boost {

--- a/src/components/TimelineList.vue
+++ b/src/components/TimelineList.vue
@@ -96,7 +96,7 @@ export default {
 				notifications: {
 					image: 'img/undraw/notifications.svg',
 					title: t('social', 'No notifications found'),
-					description: t('social', 'You haven\'t receive any notifications yet')
+					description: t('social', 'You haven\'t received any notifications yet')
 				},
 				federated: {
 					image: 'img/undraw/global.svg',

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -21,7 +21,7 @@
 				</div>
 			</div>
 		</transition>
-		<composer v-if="type !== 'notifications' && type !== 'single-post'" />
+		<composer v-if="type !== 'notifications' && type !== 'single-post' && type !== 'liked'" />
 		<h2 v-if="type === 'tags'">
 			#{{ this.$route.params.tag }}
 		</h2>


### PR DESCRIPTION
* Target version: master 

### Summary
polishing the notification timeline

- [x] use user component for "{account} followed you}"
- [x] add icons in front of to the action summary
- [ ] only show display name/username in action summary (and not complete handle)
- [ ] add more spacing between action summary and post or user component

