### PR TITLE
FIX: lock button on empty message

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -90,7 +90,7 @@
 			</masonry>
 
 			<div class="options">
-				<input :value="currentVisibilityPostLabel" :disabled="post.length < 1 || post==='br'" class="submit primary"
+				<input :value="currentVisibilityPostLabel" :disabled="post.length < 1 || post==='<br>'" class="submit primary"
 					type="submit" title="" data-original-title="Post">
 				<div v-click-outside="hidePopoverMenu">
 					<button :class="currentVisibilityIconClass" @click.prevent="togglePopoverMenu" />


### PR DESCRIPTION
Corrects the remaining value of the composer's post that may still be there while considering the composer empty.

Signed-off-by: Cyrille Bollu <cyrpub@bollu.be>

* Resolves: #739 
* Target version: master 

