### PR TITLE
FIX: Removes heading '#' from the search terms as search won't work

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -225,6 +225,7 @@ export default {
 			})
 		},
 		search(term) {
+			term = encodeURIComponent(term)
 			this.searchTerm = term
 		},
 		resetSearch() {

--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -32,7 +32,7 @@
 			</p>
 		</div>
 		<div v-else>
-			<h3>{{ t('social', 'Searching for') }} {{ term }}</h3>
+			<h3>{{ t('social', 'Searching for') }} {{ decodeURIComponent(term) }}</h3>
 			<user-entry v-for="result in allResults" :key="result.id" :item="result" />
 			<div v-if="hashtags.length > 0">
 				<li v-for="tag in hashtags" :key="tag.hashtag" class="tag">

--- a/src/components/Search.vue
+++ b/src/components/Search.vue
@@ -28,7 +28,7 @@
 				{{ t('social', 'No results found') }}
 			</h2>
 			<p v-if="!loading">
-				{{ t('social', 'There were no results for your search:') }} {{ term }}
+				{{ t('social', 'There were no results for your search:') }} {{ decodeURIComponent(term) }}
 			</p>
 		</div>
 		<div v-else>


### PR DESCRIPTION
FIX: Removes heading '#' from the search terms as search won't work when search term starts with such character (probably due to 'generateUrl')

Signed-off-by: Cyrille Bollu <cyrpub@bollu.be>

* Resolves: #773
* Target version: master 


