### PR TITLE
FIX: Change the empty content's text on profile pages

### DIFF
--- a/src/components/TimelineList.vue
+++ b/src/components/TimelineList.vue
@@ -123,8 +123,14 @@ export default {
 				return this.emptyContent[this.$route.params.type]
 			}
 			if (typeof this.emptyContent[this.$route.name] !== 'undefined') {
-				return this.$route.name === 'timeline' ? this.emptyContent['default'] : this.emptyContent[this.$route.name]
+				let content = this.emptyContent[this.$route.name]
+				// Change text on profile page when accessed by a public (non-authenticated) user
+				if (this.$route.name === 'profile' && this.serverData.public) {
+					content.title = this.$route.params.account + ' ' + t('social', 'hasn\'t tooted yet') 
+				}
+				return this.$route.name === 'timeline' ? this.emptyContent['default'] : content
 			}
+			// Fallback
 			return this.emptyContent.default
 		},
 		timeline: function() {

--- a/src/components/TimelineList.vue
+++ b/src/components/TimelineList.vue
@@ -124,8 +124,8 @@ export default {
 			}
 			if (typeof this.emptyContent[this.$route.name] !== 'undefined') {
 				let content = this.emptyContent[this.$route.name]
-				// Change text on profile page when accessed by a public (non-authenticated) user
-				if (this.$route.name === 'profile' && this.serverData.public) {
+				// Change text on profile page when accessed by another user or a public (non-authenticated) user
+				if (this.$route.name === 'profile' && (this.serverData.public || this.$route.params.account !== this.currentUser.uid)) {
 					content.title = this.$route.params.account + ' ' + t('social', 'hasn\'t tooted yet') 
 				}
 				return this.$route.name === 'timeline' ? this.emptyContent['default'] : content

--- a/src/components/TimelineList.vue
+++ b/src/components/TimelineList.vue
@@ -126,7 +126,7 @@ export default {
 				let content = this.emptyContent[this.$route.name]
 				// Change text on profile page when accessed by another user or a public (non-authenticated) user
 				if (this.$route.name === 'profile' && (this.serverData.public || this.$route.params.account !== this.currentUser.uid)) {
-					content.title = this.$route.params.account + ' ' + t('social', 'hasn\'t tooted yet') 
+					content.title = this.$route.params.account + ' ' + t('social', 'hasn\'t tooted yet')
 				}
 				return this.$route.name === 'timeline' ? this.emptyContent['default'] : content
 			}


### PR DESCRIPTION
FIX: Change the empty content's text on profile pages when they are accessed by a public (non-authenticated) user.

Signed-off-by: Cyrille Bollu <cyrpub@bollu.be>

* Resolves: #770 
* Target version: master 




