### PR TITLE
Allows long URL's in post messages to be wrapped so as to not overflow their parent element.

### DIFF
--- a/src/components/TimelinePost.vue
+++ b/src/components/TimelinePost.vue
@@ -264,5 +264,6 @@ export default {
 <style>
 	.post-message a {
 		text-decoration: underline;
+		overflow-wrap: anywhere;
 	}
 </style>


### PR DESCRIPTION
* Resolves: #813 
* Target version: master 

### Summary

Before:

![image](https://user-images.githubusercontent.com/8179031/68480737-cdf30700-0235-11ea-83c8-ccb5da95224d.png)

After:

![image](https://user-images.githubusercontent.com/8179031/68480753-d8ad9c00-0235-11ea-8f54-190f0a792464.png)


