### PR TITLE
Fix Primary index name on "oc_social_a2_cache_documts" is too long

### DIFF
--- a/lib/Db/CoreRequestBuilder.php
+++ b/lib/Db/CoreRequestBuilder.php
@@ -60,21 +60,21 @@ use OCP\ILogger;
 class CoreRequestBuilder {
 
 
-	const TABLE_REQUEST_QUEUE = 'social_a2_request_queue';
+	const TABLE_REQUEST_QUEUE = 'social_a2_req_queue';
 
 	const TABLE_ACTORS = 'social_a2_actors';
 	const TABLE_STREAM = 'social_a2_stream';
 	const TABLE_STREAM_DEST = 'social_a2_stream_dest';
 	const TABLE_STREAM_TAGS = 'social_a2_stream_tags';
 	const TABLE_STREAM_QUEUE = 'social_a2_stream_queue';
-	const TABLE_STREAM_ACTIONS = 'social_a2_stream_action';
+	const TABLE_STREAM_ACTIONS = 'social_a2_stream_act';
 
 	const TABLE_HASHTAGS = 'social_a2_hashtags';
 	const TABLE_FOLLOWS = 'social_a2_follows';
 	const TABLE_ACTIONS = 'social_a2_actions';
 
 	const TABLE_CACHE_ACTORS = 'social_a2_cache_actors';
-	const TABLE_CACHE_DOCUMENTS = 'social_a2_cache_documts';
+	const TABLE_CACHE_DOCUMENTS = 'social_a2_cache_docum';
 
 	/** @var array */
 	private $tables = [

--- a/lib/Migration/Version0002Date20190506000001.php
+++ b/lib/Migration/Version0002Date20190506000001.php
@@ -619,11 +619,11 @@ class Version0002Date20190506000001 extends SimpleMigrationStep {
 	 * @param ISchemaWrapper $schema
 	 */
 	private function createCacheDocuments(ISchemaWrapper $schema) {
-		if ($schema->hasTable('social_a2_cache_documts')) {
+		if ($schema->hasTable('social_a2_cache_docum')) {
 			return;
 		}
 
-		$table = $schema->createTable('social_a2_cache_documts');
+		$table = $schema->createTable('social_a2_cache_docum');
 		$table->addColumn(
 			'id', 'string',
 			[
@@ -716,11 +716,11 @@ class Version0002Date20190506000001 extends SimpleMigrationStep {
 	 * @param ISchemaWrapper $schema
 	 */
 	private function createRequestQueue(ISchemaWrapper $schema) {
-		if ($schema->hasTable('social_a2_request_queue')) {
+		if ($schema->hasTable('social_a2_req_queue')) {
 			return;
 		}
 
-		$table = $schema->createTable('social_a2_request_queue');
+		$table = $schema->createTable('social_a2_req_queue');
 		$table->addColumn(
 			'id', 'bigint',
 			[
@@ -796,11 +796,11 @@ class Version0002Date20190506000001 extends SimpleMigrationStep {
 	 * @param ISchemaWrapper $schema
 	 */
 	private function createStreamActions(ISchemaWrapper $schema) {
-		if ($schema->hasTable('social_a2_stream_action')) {
+		if ($schema->hasTable('social_a2_stream_act')) {
 			return;
 		}
 
-		$table = $schema->createTable('social_a2_stream_action');
+		$table = $schema->createTable('social_a2_stream_act');
 
 		$table->addColumn(
 			'id', Type::INTEGER,
@@ -1064,7 +1064,7 @@ class Version0002Date20190506000001 extends SimpleMigrationStep {
 	 */
 	private function fillCacheDocuments(ISchemaWrapper $schema) {
 		$this->duplicateTable(
-			$schema, 'social_cache_documents', 'social_a2_cache_documts',
+			$schema, 'social_cache_documents', 'social_a2_cache_docum',
 			[
 				'id',
 				'id_prim',
@@ -1091,7 +1091,7 @@ class Version0002Date20190506000001 extends SimpleMigrationStep {
 	 */
 	private function fillRequestQueue(ISchemaWrapper $schema) {
 		$this->duplicateTable(
-			$schema, 'social_request_queue', 'social_a2_request_queue',
+			$schema, 'social_request_queue', 'social_a2_req_queue',
 			[
 				'id',
 				'token',
@@ -1114,7 +1114,7 @@ class Version0002Date20190506000001 extends SimpleMigrationStep {
 	 */
 	private function fillStreamActions(ISchemaWrapper $schema) {
 		$this->duplicateTable(
-			$schema, 'social_stream_actions', 'social_a2_stream_action',
+			$schema, 'social_stream_actions', 'social_a2_stream_act',
 			[
 				'id',
 				'actor_id',

--- a/lib/Migration/Version0002Date20190622000001.php
+++ b/lib/Migration/Version0002Date20190622000001.php
@@ -120,7 +120,7 @@ class Version0002Date20190622000001 extends SimpleMigrationStep {
 			$schema, 'id', 'social_cache_actors', 'social_a2_cache_actors', 'local', 'boolean'
 		);
 		$this->check(
-			$schema, 'id', 'social_cache_documents', 'social_a2_cache_documts', 'public',
+			$schema, 'id', 'social_cache_documents', 'social_a2_cache_docum', 'public',
 			'boolean'
 		);
 
@@ -139,16 +139,16 @@ class Version0002Date20190622000001 extends SimpleMigrationStep {
 			'datetime'
 		);
 		$this->check(
-			$schema, 'id', 'social_cache_documents', 'social_a2_cache_documts', 'creation',
+			$schema, 'id', 'social_cache_documents', 'social_a2_cache_docum', 'creation',
 			'datetime'
 		);
 
 		$this->check(
-			$schema, 'id', 'social_cache_documents', 'social_a2_cache_documts', 'caching',
+			$schema, 'id', 'social_cache_documents', 'social_a2_cache_docum', 'caching',
 			'datetime'
 		);
 
-//		$this->check($schema, 'id', 'social_request_queue', 'social_a2_request_queue','last', 'datetime');
+//		$this->check($schema, 'id', 'social_request_queue', 'social_a2_req_queue','last', 'datetime');
 //		$this->check($schema, 'id', 'social_queue_stream', 'social_a2_stream_queue', 'last', 'datetime');
 
 		$this->check(

--- a/lib/Migration/Version0002Date20190717000001.php
+++ b/lib/Migration/Version0002Date20190717000001.php
@@ -73,11 +73,11 @@ class Version0002Date20190717000001 extends SimpleMigrationStep {
 	): ISchemaWrapper {
 		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
-		if (!$schema->hasTable('social_a2_cache_documts')) {
+		if (!$schema->hasTable('social_a2_cache_docum')) {
 			return $schema;
 		}
 
-		$table = $schema->getTable('social_a2_cache_documts');
+		$table = $schema->getTable('social_a2_cache_docum');
 		if (!$table->hasColumn('resized_copy')) {
 			$table->addColumn(
 				'resized_copy', Type::TEXT,

--- a/lib/Migration/Version0002Date20190925000001.php
+++ b/lib/Migration/Version0002Date20190925000001.php
@@ -74,7 +74,7 @@ class Version0002Date20190925000001 extends SimpleMigrationStep {
 		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
 
-		$table = $schema->getTable('social_a2_stream_action');
+		$table = $schema->getTable('social_a2_stream_act');
 		if (!$table->hasColumn('liked')) {
 			$table->addColumn('liked', 'boolean');
 		}
@@ -113,7 +113,7 @@ class Version0002Date20190925000001 extends SimpleMigrationStep {
 		while (true) {
 			$qb = $this->connection->getQueryBuilder();
 			$qb->select('id', 'actor_id', 'stream_id', 'values')
-			   ->from('social_a2_stream_action')
+			   ->from('social_a2_stream_act')
 			   ->setMaxResults(1000)
 			   ->setFirstResult($start);
 
@@ -139,7 +139,7 @@ class Version0002Date20190925000001 extends SimpleMigrationStep {
 	 */
 	private function updateStreamActions(array $data) {
 		$update = $this->connection->getQueryBuilder();
-		$update->update('social_a2_stream_action');
+		$update->update('social_a2_stream_act');
 
 		$id = $data['id'];
 		$actorId = $data['actor_id'];

--- a/lib/Migration/Version0002Date20191010000001.php
+++ b/lib/Migration/Version0002Date20191010000001.php
@@ -176,7 +176,7 @@ class Version0002Date20191010000001 extends SimpleMigrationStep {
 		}
 
 
-		$table = $schema->getTable('social_a2_stream_action');
+		$table = $schema->getTable('social_a2_stream_act');
 		if (!$table->hasColumn('actor_id_prim')) {
 			$table->addColumn(
 				'actor_id_prim', 'string',
@@ -263,13 +263,13 @@ class Version0002Date20191010000001 extends SimpleMigrationStep {
 	 * @param ISchemaWrapper $schema
 	 */
 	private function updateTableStreamActions(ISchemaWrapper $schema) {
-		if (!$schema->hasTable('social_a2_stream_action')) {
+		if (!$schema->hasTable('social_a2_stream_act')) {
 			return;
 		}
 
 		$qb = $this->connection->getQueryBuilder();
 		$qb->select('*')
-		   ->from('social_a2_stream_action');
+		   ->from('social_a2_stream_act');
 
 		$cursor = $qb->execute();
 		while ($data = $cursor->fetch()) {
@@ -288,7 +288,7 @@ class Version0002Date20191010000001 extends SimpleMigrationStep {
 		}
 
 		$update = $this->connection->getQueryBuilder();
-		$update->update('social_a2_stream_action');
+		$update->update('social_a2_stream_act');
 		$update->set('stream_id_prim', $update->createNamedParameter(hash('sha512', $data['stream_id'])));
 		$update->set('actor_id_prim', $update->createNamedParameter(hash('sha512', $data['actor_id'])));
 


### PR DESCRIPTION
also fixes social_a2_request_queue and social_a2_stream_action name length
new names: social_a2_cache_docum, social_a2_req_queue and social_a2_stream_act

closes #850

Signed-off-by: Ruben Barkow <github@r.z11.de>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


