### PR TITLE
Dark timeline entries for the dark Nextcloud theme

### DIFF
--- a/src/components/TimelineEntry.vue
+++ b/src/components/TimelineEntry.vue
@@ -138,6 +138,9 @@ export default {
 	.timeline-entry:hover {
 		background-color: #F5F5F5;
 	}
+	body.dark .timeline-entry:hover {
+		background-color: #202020;
+	}
 
 	.container-icon-boost {
 		display: inline-block;

--- a/src/components/TimelineEntry.vue
+++ b/src/components/TimelineEntry.vue
@@ -134,12 +134,9 @@ export default {
 	.timeline-entry {
 		padding: 10px;
 		margin-bottom: 10px;
-	}
-	.timeline-entry:hover {
-		background-color: #F5F5F5;
-	}
-	body.dark .timeline-entry:hover {
-		background-color: #202020;
+		&:hover {
+			background-color: var(--color-background-hover);
+		}
 	}
 
 	.container-icon-boost {


### PR DESCRIPTION
* Resolves: Issue not reported, just fixed
* Target version: master 

### Summary
The hover colour of timeline posts is always white at present, even with the dark theme enabled. This is very jarring for dark theme users. This PR contains an incredibly simple change to introduce a lighter dark hover highlight for dark theme users.
