### PR TITLE
query instead of create Application in background jobs

### DIFF
--- a/lib/Cron/Cache.php
+++ b/lib/Cron/Cache.php
@@ -76,7 +76,7 @@ class Cache extends TimedJob {
 	 * @throws QueryException
 	 */
 	protected function run($argument) {
-		$app = new Application();
+		$app = \OC::$server->query(Application::class);
 		$c = $app->getContainer();
 
 		$this->accountService = $c->query(AccountService::class);

--- a/lib/Cron/Chunk.php
+++ b/lib/Cron/Chunk.php
@@ -66,7 +66,7 @@ class Chunk extends TimedJob {
 	 * @throws QueryException
 	 */
 	protected function run($argument) {
-		$app = new Application();
+		$app = \OC::$server->query(Application::class);
 		$c = $app->getContainer();
 
 		$this->configService = $c->query(ConfigService::class);

--- a/lib/Cron/Queue.php
+++ b/lib/Cron/Queue.php
@@ -76,7 +76,7 @@ class Queue extends TimedJob {
 	 * @throws QueryException
 	 */
 	protected function run($argument) {
-		$app = new Application();
+		$app = \OC::$server->query(Application::class);
 		$c = $app->getContainer();
 
 		$this->requestQueueService = $c->query(RequestQueueService::class);


### PR DESCRIPTION
Prevents some log spam

