### PR TITLE
render profile page for ostatus follow url

### DIFF
--- a/lib/Controller/OStatusController.php
+++ b/lib/Controller/OStatusController.php
@@ -72,12 +72,15 @@ class OStatusController extends Controller {
 
 	/** @var IUserManager */
 	private $userSession;
+	/** @var IInitialStateService */
+	private $initialStateService;
 
 
 	/**
 	 * OStatusController constructor.
 	 *
 	 * @param IRequest $request
+	 * @param IInitialStateService $initialStateService
 	 * @param CacheActorService $cacheActorService
 	 * @param AccountService $accountService
 	 * @param CurlService $curlService
@@ -122,14 +125,14 @@ class OStatusController extends Controller {
 			}
 
 			$this->initialStateService->provideInitialState('social', 'serverData', [
-				'account'     => $actor->getAccount(),
+				'account' => $actor->getAccount(),
 				'currentUser' => [
-					'uid'         => $user->getUID(),
+					'uid' => $user->getUID(),
 					'displayName' => $user->getDisplayName(),
-				]
+				],
 			]);
 			return new TemplateResponse(
-				'social', 'main', 'guest'
+				'social', 'main', []
 			);
 		} catch (Exception $e) {
 			return $this->fail($e);
@@ -151,11 +154,11 @@ class OStatusController extends Controller {
 			$following = $this->accountService->getActor($local);
 
 			$this->initialStateService->provideInitialState('social', 'serverData', [
-				'local'   => $local,
-				'account' => $following->getAccount()
+				'local' => $local,
+				'account' => $following->getAccount(),
 			]);
 			return new TemplateResponse(
-				'social', 'main', 'guest'
+				'social', 'main', [], 'guest'
 			);
 		} catch (Exception $e) {
 			return $this->fail($e);

--- a/src/router.js
+++ b/src/router.js
@@ -97,6 +97,14 @@ export default new Router({
 					}
 				}
 			]
+		},
+		{
+			path: '/:index(index.php/)?apps/social/ostatus/follow',
+			components: {
+				default: Profile,
+				details: ProfileTimeline
+			},
+			props: true,
 		}
 	]
 })

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -81,7 +81,7 @@ export default {
 	beforeMount() {
 
 		let fetchMethod = ''
-		this.uid = this.$route.params.account
+		this.uid = this.$route.params.account || this.serverData.account
 
 		// Are we authenticated?
 		if (this.serverData.public) {


### PR DESCRIPTION
when initiating a follow from a remote mastadon instance, the user gets directed to `apps/social/ostatus/follow/?uri=` which is currently broken.

this changes it to render the regular profile page for that link, allowing the user to follow the profile.

I'm not sure what the previous behaviour was before things got broken

