### PR TITLE
preserve some of the whitespace from html tags

### DIFF
--- a/lib/Model/ActivityPub/ACore.php
+++ b/lib/Model/ActivityPub/ACore.php
@@ -557,10 +557,14 @@ class ACore extends Item implements JsonSerializable {
 				return $value;
 
 			case self::AS_STRING:
+				// try to preserve some whitespace from the html tags
+				$value = preg_replace("/\<br *\/?\>/", "\n", $value);
+				$value = preg_replace("/\<\/?p>/", "\n", $value);
+
 				$value = strip_tags($value);
 				$value = html_entity_decode($value, ENT_QUOTES | ENT_HTML5);
 
-				return $value;
+				return trim($value);
 
 			case self::AS_USERNAME:
 				$value = strip_tags($value);


### PR DESCRIPTION
without the "html whitespace" a hashtag posted after a url will be seen as part of the link by linkify, and then mangled by the hashtagmangler and break the url.

additionally this keeps the appearance of the post closer to the original

Before:
![image](https://user-images.githubusercontent.com/1283854/93097920-b8404080-f695-11ea-977c-5878d098ddf0.png)


After: 
![image](https://user-images.githubusercontent.com/1283854/93097892-b0809c00-f695-11ea-99de-8da012dfda41.png)

Original:
![image](https://user-images.githubusercontent.com/1283854/93097954-c42c0280-f695-11ea-887d-b4cf69dde3f6.png)

