### PR TITLE
fix migration by allowing null values for 'nid'

### DIFF
--- a/lib/Migration/Version0003Date20200823023911.php
+++ b/lib/Migration/Version0003Date20200823023911.php
@@ -139,6 +139,7 @@ class Version0003Date20200823023911 extends SimpleMigrationStep {
 			[
 				'length'   => 11,
 				'unsigned' => true,
+				'notnull' => false,
 			]
 		);
 	}


### PR DESCRIPTION
since existing rows will not have any value set, the column needs to allow null.

