### PR TITLE
use prefered username as fallback if no account name is provided

### DIFF
--- a/src/components/ProfileInfo.vue
+++ b/src/components/ProfileInfo.vue
@@ -137,6 +137,9 @@ export default {
 			if (typeof this.accountInfo.name !== 'undefined' && this.accountInfo.name !== '') {
 				return this.accountInfo.name
 			}
+			if (typeof this.accountInfo.preferredUsername !== 'undefined' && this.accountInfo.preferredUsername !== '') {
+				return this.accountInfo.preferredUsername
+			}
 			return this.account
 		},
 		accountInfo: function() {


### PR DESCRIPTION
instead of falling back directly to the full account id (userid@example.com) use the preferred username if available

This stops it just showing the account id twice if no name is provided

