### PR TITLE
Repair "followRemote" page

### DIFF
--- a/lib/Controller/OStatusController.php
+++ b/lib/Controller/OStatusController.php
@@ -158,7 +158,7 @@ class OStatusController extends Controller {
 				'account' => $following->getAccount(),
 			]);
 			return new TemplateResponse(
-				'social', 'main', [], 'guest'
+				'social', 'ostatus', [], 'guest'
 			);
 		} catch (Exception $e) {
 			return $this->fail($e);

--- a/src/components/ProfileInfo.vue
+++ b/src/components/ProfileInfo.vue
@@ -151,7 +151,7 @@ export default {
 	},
 	methods: {
 		followRemote() {
-			window.open(generateUrl('/apps/social/api/v1/ostatus/followRemote/' + encodeURI(this.localUid)), 'followRemote', 'width=433,height=600toolbar=no,menubar=no,scrollbars=yes,resizable=yes')
+			window.open(generateUrl('/apps/social/api/v1/ostatus/followRemote/' + encodeURI(this.localUid)), 'followRemote', 'width=433,height=600,toolbar=no,menubar=no,scrollbars=yes,resizable=yes')
 		}
 	}
 }

--- a/templates/ostatus.php
+++ b/templates/ostatus.php
@@ -22,6 +22,8 @@
  *
  */
 
-script('social', 'social');
+script('social', 'ostatus');
 style('social', 'style');
 ?>
+
+<div id="content"></div>


### PR DESCRIPTION
* templates/main.php: Close previously opened php tag
* lib/Controller/OStatusController.php: Use "ostatus" template to get OStatus.vue instead of App.vue
* templates/ostatus.php: Return back ostatus template. Add 'content' block because 'guest' layout have no such block
* src/components/ProfileInfo.vue: Fix typo in followRemote page opening style

Signed-off-by: Nikolai Merinov <nikolai.merinov@member.fsf.org>


* Resolves: 
* Target version: master 

### Summary

This PR resolves issue added by ff9224e4adbfc1aee8503a2104276173a6b77d94 commit:
1. followRemote generated on base of "guest" layout that have no own "content" block, so we change to 
`src/ostatus.js` finished up with vue error about missed `#content` block
2. I failed to found a way how `script('social', 'social');` from `templates/main.php` should load `OStatus.vue`, so I simply makes `templates/ostatus.php` based pn `main.php`

Suggested change fixes page https://cloud.mndet.net/apps/social/api/v1/ostatus/followRemote/mnd that loaded when you press "Follow" button at https://cloud.mndet.net/apps/social/@mnd/
