### PR TITLE
Support unquoted fields in Signature header

### DIFF
--- a/lib/Service/SignatureService.php
+++ b/lib/Service/SignatureService.php
@@ -468,8 +468,9 @@ class SignatureService {
 
 			list($k, $v) = explode('=', $entry, 2);
 			preg_match('/"([^"]+)"/', $v, $varr);
-			$v = trim($varr[0], '"');
-
+			if ($varr[0] !== null) {
+				$v = trim($varr[0], '"');
+			}
 			$sign[$k] = $v;
 		}
 


### PR DESCRIPTION
Signed-off-by: Nikolai Merinov <nikolai.merinov@member.fsf.org>


* Resolves: 
* Target version: master 

### Summary
When I try to subscribe to users from https://juick.com/ (e.g. @schors@juick.com) the server sends PUSH Accept message with the following Signature header:
```
keyId="https://juick.com/u/schors#main-key",created=1606061559,algorithm="rsa-sha256",headers="(request-target) host date digest",signature="<signature-data>"
``` 
where `created=1606061559` key-value pair has no quote around value part. Suggested change allows to part such signatures