### PR TITLE
Fix Followers page content

### DIFF
--- a/src/store/account.js
+++ b/src/store/account.js
@@ -46,10 +46,13 @@ const mutations = {
 		let users = []
 		for (var index in data) {
 			const actor = data[index].actor_info
-			addAccount(state, {
-				actorId: actor.id,
-				data: actor
-			})
+			if (typeof actor !== 'undefined' && account !== actor.account) {
+				users.push(actor.id)
+				addAccount(state, {
+					actorId: actor.id,
+					data: actor
+				})
+			}
 		}
 		Vue.set(state.accounts[_getActorIdForAccount(account)], 'followersList', users)
 	},


### PR DESCRIPTION
This change reverts changes from 3421661ee95d1357b8ad0cc5183aa88e62aed04e commit
that makes 'followersList' always empty

Signed-off-by: Nikolai Merinov <nikolai.merinov@member.fsf.org>


* Resolves:
* Target version: master 

### Summary
Commit 3421661ee95d1357b8ad0cc5183aa88e62aed04e removed code that filled `users` list and effectively make `followersList` always empty.