### PR TITLE
Do not lose first newline in message

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -766,7 +766,7 @@ export default {
 			} while (match)
 
 			// Remove all html tags but </div> (wich we turn in newlines) and decode the remaining html entities
-			let content = contentHtml.replace(/<(?!\/div)[^>]+>/gi, '').replace(/<\/div>/gi, '\n').trim()
+			let content = contentHtml.replace(/<div/, '\n<div').replace(/<(?!\/div)[^>]+>/gi, '').replace(/<\/div>/gi, '\n').trim()
 			content = he.decode(content)
 
 			let data = {


### PR DESCRIPTION
When you create multiline notes like the following in Chromium 86.0.4240.198:
> 1
> 2
> 3

You got the following HTML: `1<div>2</div><div>3</div>` without `<div>`
block around first line. Add newline before first `<div>`.

This code also valid for IceCat 68.11.0esr where you got
`<div>1</div><div>2</div><div>3</div>` in same case because final
`trim()` call will remove leading newlines.

Signed-off-by: Nikolai Merinov <nikolai.merinov@member.fsf.org>


* Resolves: 
* Target version: master 

### Summary
For messages created from Chromium browser I loose first newline in the message. Add a hack to bring it back.
**NOTE** I'ld prefer a better solution, but I barely familiar with web development and can't understand why chromium behave differently in this place