### PR TITLE
Store newlines as <br /> tag in new posted Notes

### DIFF
--- a/lib/Model/ActivityPub/ACore.php
+++ b/lib/Model/ActivityPub/ACore.php
@@ -566,7 +566,7 @@ class ACore extends Item implements JsonSerializable {
 				return $value;
 
 			case self::AS_CONTENT:
-				$value = strip_tags($value, ['a', 'p', 'span', 'br']);
+				$value = strip_tags($value, '<a><p><span><br>');
 				$value = html_entity_decode($value, ENT_QUOTES | ENT_HTML5);
 
 				return $value;

--- a/lib/Service/PostService.php
+++ b/lib/Service/PostService.php
@@ -126,7 +126,7 @@ class PostService {
 		$this->streamService->assignItem($note, $actor, $post->getType());
 
 		$note->setAttributedTo($actor->getId());
-		$note->setContent(htmlentities($post->getContent(), ENT_QUOTES));
+		$note->setContent(str_replace(array("\r\n", "\r", "\n"), "<br />", htmlentities($post->getContent(), ENT_QUOTES)));
 
 		$this->generateDocumentsFromAttachments($note, $post);
 


### PR DESCRIPTION
ActivityStream assumes that content is HTML message: https://www.w3.org/TR/2017/REC-activitystreams-vocabulary-20170523/#dfn-content
To fullfill this assumption save newlines as `<br />` during post creation

Signed-off-by: Nikolai Merinov <nikolai.merinov@member.fsf.org>

* Resolves: #1139  
* Target version: master 

### Summary
Suggested change should allow to store post in manner that allows to display it correctly on the web. Looks like other fediverse instances behave in similar manner. My only doubt is what better: use `nl2br` php function to have both newlines and `<br \>` tag, or use `replace()` call to have only `<br \>` tag
