### PR TITLE
Allow to follow to PeerTube 3.0.0 users

### DIFF
--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -444,7 +444,7 @@ class ConfigService {
 
 		if ($request->getType() === Request::TYPE_GET) {
 			$request->addHeader(
-				'Accept', 'application/json; profile="https://www.w3.org/ns/activitystreams"'
+				'Accept', 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
 			);
 		}
 

--- a/lib/Service/CurlService.php
+++ b/lib/Service/CurlService.php
@@ -173,6 +173,9 @@ class CurlService {
 		}
 
 		$url = $this->get('Link.@attributes.template', $result, '');
+		if ($url === '') {
+			throw new HostMetaException('Failed to get URL');
+		}
 		$host = parse_url($url, PHP_URL_HOST);
 		$protocols = [parse_url($url, PHP_URL_SCHEME)];
 

--- a/lib/Service/SignatureService.php
+++ b/lib/Service/SignatureService.php
@@ -154,7 +154,7 @@ class SignatureService {
 
 		$localActor = $this->actorsRequest->getFromId($queue->getAuthor());
 
-		$headersElements = ['content-length', 'date', 'host', 'digest'];
+		$headersElements = ['(request-target)', 'content-length', 'date', 'host', 'digest'];
 		$allElements = [
 			'(request-target)' => 'post ' . $path->getPath(),
 			'date'             => $date,


### PR DESCRIPTION
Solved three issues:
* lib/Service/ConfigService.php: With "Accept: application/json" PeerTube
  returns user page in HTML format. Replace header with
  "Accept: application/ld+json".
* lib/Service/CurlService.php: Do not broke "$host" variable if host-meta
  resultion failed.
* lib/Service/SignatureService.php: POST to https://framatube.org/accounts/fsf/inbox
  ends with error "(request-target) was not a signed header". Added
  (request-target) to signature.

Signed-off-by: Nikolai Merinov <nikolai.merinov@member.fsf.org>


* Resolves: #1133 
* Target version: master 

### Summary
I tried to communicate with updated PeerTube instance that contains bugfix mentioned in #1133 and observed additional issues. After suggested changes I was able to follow PeerTube account

