### PR TITLE
Display Boosted messages in user's timelime

### DIFF
--- a/lib/Db/SocialCrossQueryBuilder.php
+++ b/lib/Db/SocialCrossQueryBuilder.php
@@ -255,8 +255,8 @@ class SocialCrossQueryBuilder extends SocialCoreQueryBuilder {
 	/**
 	 * @param string $alias
 	 */
-	public function leftJoinStreamAction(string $alias = 'sa'): void {
-		if ($this->getType() !== QueryBuilder::SELECT || !$this->hasViewer()) {
+	public function leftJoinStreamAction(string $alias = 'sa', string $actor_id = ''): void {
+		if ($this->getType() !== QueryBuilder::SELECT || ($actor_id === '' && !$this->hasViewer())) {
 			return;
 		}
 
@@ -274,8 +274,12 @@ class SocialCrossQueryBuilder extends SocialCoreQueryBuilder {
 
 		$on = $expr->andX();
 //		$this->inChunk('sa', $on);
-		$viewer = $this->getViewer();
-		$idPrim = $this->prim($viewer->getId());
+		if ($actor_id === '') {
+			$viewer = $this->getViewer();
+			$idPrim = $this->prim($viewer->getId());
+		} else {
+			$idPrim = $this->prim($actor_id);
+		}
 
 		$on->add($expr->eq($alias . '.actor_id_prim', $this->createNamedParameter($idPrim)));
 		$on->add($orX);

--- a/lib/Db/StreamRequest.php
+++ b/lib/Db/StreamRequest.php
@@ -481,7 +481,7 @@ class StreamRequest extends StreamRequestBuilder {
 		$qb = $this->getStreamSelectSql();
 		$qb->limitPaginate($since, $limit);
 
-		$qb->limitToAttributedTo($actorId);
+		// $qb->limitToAttributedTo($actorId);
 
 		$qb->selectDestFollowing('sd', '');
 		$qb->innerJoinSteamDest('recipient', 'id_prim', 'sd', 's');
@@ -489,7 +489,14 @@ class StreamRequest extends StreamRequestBuilder {
 		$qb->limitToDest($accountIsViewer ? '' : ACore::CONTEXT_PUBLIC, 'recipient', '', 'sd');
 
 		$qb->linkToCacheActors('ca', 's.attributed_to_prim');
-		$qb->leftJoinStreamAction();
+		$qb->leftJoinStreamAction('sa', $actorId);
+
+		$expr = $qb->expr();
+		$qb->andWhere($expr->orX(
+				$expr->eq('s.attributed_to',  $qb->createNamedParameter($actorId)),
+				$expr->andX(
+					$expr->eq('sa.boosted', $qb->createNamedParameter(1)),
+					$expr->eq('s.type', $qb->createNamedParameter('Announce')))));
 
 		return $this->getStreamsFromRequest($qb);
 	}


### PR DESCRIPTION
Signed-off-by: Nikolai Merinov <nikolai.merinov@member.fsf.org>


* Resolves: #697
* Target version: master 

### Summary
This is non-ideal solution for the issue, but this solution solves the issue. Drawbacks of the solution:
1. Looks like it should generic replacement function for limitToAttributedTo instead of suggested `andWhere` clause
2. Probably Boost's should be counted in the `countNotesFromActorId` function as well.
3. Probably `'Announce'` string should be replaced with `Announce::TYPE` constant 
