### PR TITLE
fix #1129 empty only existing tables in emptyAll()

### DIFF
--- a/lib/Db/CoreRequestBuilder.php
+++ b/lib/Db/CoreRequestBuilder.php
@@ -1201,10 +1201,11 @@ class CoreRequestBuilder {
 	 */
 	public function emptyAll() {
 		foreach ($this->tables as $table) {
-			$qb = $this->dbConnection->getQueryBuilder();
-			$qb->delete($table);
-
-			$qb->execute();
+			if ($schema->hasTable($table)) {
+				$qb = $this->dbConnection->getQueryBuilder();
+				$qb->delete($table);
+				$qb->execute();
+			}
 		}
 	}
 


### PR DESCRIPTION
* Resolves: #1129
* Target version: master 

### Summary

this fix for #1129 emptyAll tables which have already been created.
