### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/cypress/utils/index.js
+++ b/cypress/utils/index.js
@@ -30,6 +30,6 @@ const getSearchParams = url => {
 		}, {})
 }
 
-const randHash = () => Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 10)
+const randHash = () => Math.random().toString(36).replace(/[^a-z]+/g, '').slice(0, 10)
 
 export default { getSearchParams, randHash }

--- a/src/components/MessageContent.js
+++ b/src/components/MessageContent.js
@@ -67,7 +67,7 @@ function transformText(createElement, text) {
 						props: {
 							to: {
 								name: 'profile',
-								params: { account: match[2].substr(1) }
+								params: { account: match[2].slice(1) }
 							}
 						}
 					},
@@ -85,7 +85,7 @@ function transformText(createElement, text) {
 						props: {
 							to: {
 								name: 'tags',
-								params: { tag: match[2].substr(1) }
+								params: { tag: match[2].slice(1) }
 							}
 						}
 					},
@@ -139,7 +139,7 @@ function cleanLink(createElement, node, context) {
 				props: {
 					to: {
 						name: 'tags',
-						params: { tag: node.textContent.substr(1) }
+						params: { tag: node.textContent.slice(1) }
 					}
 				}
 			},

--- a/src/components/ProfileInfo.vue
+++ b/src/components/ProfileInfo.vue
@@ -128,7 +128,7 @@ export default {
 	computed: {
 		localUid() {
 			// Returns only the local part of a username
-			return (this.uid.indexOf('@') === -1) ? this.uid : this.uid.substr(0, this.uid.indexOf('@'))
+			return (this.uid.indexOf('@') === -1) ? this.uid : this.uid.slice(0, this.uid.indexOf('@'))
 		},
 		displayName() {
 			if (typeof this.accountInfo.name !== 'undefined' && this.accountInfo.name !== '') {

--- a/src/views/TimelineSinglePost.vue
+++ b/src/views/TimelineSinglePost.vue
@@ -62,7 +62,7 @@ export default {
 		 * @returns {String}
 		 */
 		account() {
-			return window.location.href.split('/')[window.location.href.split('/').length - 2].substr(1)
+			return window.location.href.split('/')[window.location.href.split('/').length - 2].slice(1)
 		},
 		/**
 		 * @description Returns the timeline currently loaded in the store


### PR DESCRIPTION
### Summary

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.