### PR TITLE
Update dependabot reviewer list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
     timezone: Europe/Paris
   open-pull-requests-limit: 10
   reviewers:
-  - juliushaertl
   - violoncelloCH
   ignore:
   - dependency-name: twemoji


### PR DESCRIPTION
I lack time to properly help with those reviews and they add quite some additional notifications to my list, so opting out of those for now.