### PR TITLE
nodeinfo rootUrl

### DIFF
--- a/lib/Controller/OAuthController.php
+++ b/lib/Controller/OAuthController.php
@@ -115,6 +115,7 @@ class OAuthController extends Controller {
 			"protocols" => [
 				"activitypub"
 			],
+			"rootUrl" => rtrim($this->urlGenerator->linkToRouteAbsolute('social.Navigation.navigate'), '/'),
 			"usage" => $usage,
 			"openRegistrations" => $openReg
 		];


### PR DESCRIPTION
```
$ curl https://cloud.example.net/.well-known/nodeinfo | jq
{
  "links": [
    {
      "rel": "http://nodeinfo.diaspora.software/ns/schema/2.0",
      "href": "https://cloud.example.net/index.php/apps/social/.well-known/nodeinfo/2.0"
    }
  ]
}
```


```
$ curl https://cloud.example.net/index.php/apps/social/.well-known/nodeinfo/2.0 | jq
{
  "version": "2.0",
  "software": {
    "name": "Nextcloud Social",
    "version": "0.5.0-beta"
  },
  "protocols": [
    "activitypub"
  ],
  "rootUrl": "https://cloud.example.net/index.php/apps/social",
  "usage": [],
  "openRegistrations": false
}
```

this is out of RFC, but mastodon clients (ie. tokodon ? ;p) can get the definitive root url of the app using `/.well-known/nodeinfo`. 
Meaning, during account creation, users just need to set the host `cloud.example.net` instead of `cloud.example.net/apps/social` and the client would be able to get the root url for every future request...
