### PR TITLE
confirmation popup

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -70,6 +70,7 @@ return [
 		['name' => 'OAuth#nodeinfo2', 'url' => '/.well-known/nodeinfo/2.0', 'verb' => 'GET'],
 		['name' => 'OAuth#apps', 'url' => '/api/v1/apps', 'verb' => 'POST'],
 		['name' => 'OAuth#authorize', 'url' => '/oauth/authorize', 'verb' => 'GET'],
+		['name' => 'OAuth#authorizing', 'url' => '/oauth/authorize', 'verb' => 'POST'],
 		['name' => 'OAuth#token', 'url' => '/oauth/token', 'verb' => 'POST'],
 
 		// Api for 3rd party

--- a/src/oauth.js
+++ b/src/oauth.js
@@ -1,10 +1,5 @@
-<?php
 /**
- * @copyright Copyright (c) 2019 Julius Härtl <jus@bitgrid.net>
- *
- * @author Jonas Sulzer <jonas@violoncello.ch>
- * @author Julius Härtl <jus@bitgrid.net>
- *
+ * @copyright 2022 Carl Schwan <carl@carlschwan.eu>
  * @license GNU AGPL version 3 or any later version
  *
  * This program is free software: you can redistribute it and/or modify
@@ -19,10 +14,25 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
- *
  */
 
-\OCP\Util::addScript('social', 'social-oauth');
-?>
+import Vue from 'vue'
+import OAuth2Authorize from './views/OAuth2Authorize.vue'
 
-<div id="social-oauth2"></div>
+// CSP config for webpack dynamic chunk loading
+// eslint-disable-next-line
+__webpack_nonce__ = btoa(OC.requestToken)
+
+// Correct the root of the app for chunk loading
+// OC.linkTo matches the apps folders
+// eslint-disable-next-line
+__webpack_public_path__ = OC.linkTo('social', 'js/')
+
+Vue.prototype.t = t
+Vue.prototype.n = n
+Vue.prototype.OC = OC
+Vue.prototype.OCA = OCA
+
+new Vue({
+	render: h => h(OAuth2Authorize),
+}).$mount('#social-oauth2')

--- a/src/views/OAuth2Authorize.vue
+++ b/src/views/OAuth2Authorize.vue
@@ -24,6 +24,9 @@
 				{{ t('social', '{appDisplayName} would like permission to access your account. It is a third party application.', {appDisplayName: appName}) }}
 				<b>{{ t('social', 'If you do not trust it, then you should not authorize it.') }}</b>
 			</p>
+			<input type="hidden"
+				name="requesttoken"
+				:value="OC.requestToken">
 			<div class="button-row">
 				<NcButton type="primary" nativeType="submit">
 					{{ t('social', 'Authorize') }}
@@ -53,7 +56,7 @@ export default {
 	},
 	computed: {
 		homeUrl() {
-			generateUrl('/apps/social/')
+			return generateUrl('/apps/social/')
 		},
 	},
 }

--- a/src/views/OAuth2Authorize.vue
+++ b/src/views/OAuth2Authorize.vue
@@ -1,0 +1,95 @@
+<!--
+ - @copyright 2022 Carl Schwan <carl@carlschwan.eu>
+ - @license GNU AGPL version 3 or any later version
+ -
+ - This program is free software: you can redistribute it and/or modify
+ - it under the terms of the GNU Affero General Public License as
+ - published by the Free Software Foundation, either version 3 of the
+ - License, or (at your option) any later version.
+ -
+ - This program is distributed in the hope that it will be useful,
+ - but WITHOUT ANY WARRANTY; without even the implied warranty of
+ - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ - GNU Affero General Public License for more details.
+ -
+ - You should have received a copy of the GNU Affero General Public License
+ - along with this program. If not, see <http://www.gnu.org/licenses/>.
+ -->
+
+<template>
+	<div class="wrapper">
+		<form class="guest-box" method="post">
+			<h1>{{ t('social', 'Authorization required') }}</h1>
+			<p>
+				{{ t('social', '{appDisplayName} would like permission to access your account. It is a third party application.', {appDisplayName: appName}) }}
+				<b>{{ t('social', 'If you do not trust it, then you should not authorize it.') }}</b>
+			</p>
+			<div class="button-row">
+				<NcButton type="primary" nativeType="submit">
+					{{ t('social', 'Authorize') }}
+				</NcButton>
+				<NcButton type="error" :href="homeUrl">
+					{{ t('social', 'Deny') }}
+				</NcButton>
+			</div>
+		</form>
+	</div>
+</template>
+
+<script>
+import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import { loadState } from '@nextcloud/initial-state'
+import { generateUrl } from '@nextcloud/router'
+
+export default {
+	name: 'OAuth2Authorize',
+	components: {
+		NcButton,
+	},
+	data() {
+		return {
+			appName: loadState('social', 'appName'),
+		}
+	},
+	computed: {
+		homeUrl() {
+			generateUrl('/apps/social/')
+		},
+	},
+}
+</script>
+
+<style lang="scss" scopped>
+.wrapper {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	width: 100%;
+}
+.guest-box {
+	color: var(--color-main-text);
+	background-color: var(--color-main-background);
+	padding: 1rem;
+	border-radius: var(--border-radius-large);
+	box-shadow: 0 0 10px var(--color-box-shadow);
+	display: inline-block;
+	max-width: 600px;
+
+	h1 {
+		font-weight: bold;
+		text-align: center;
+		font-size: 20px;
+		margin-bottom: 12px;
+		line-height: 140%;
+	}
+
+	.button-row {
+		display: flex;
+		gap: 1rem;
+		flex-direction: row;
+		margin-top: 1rem;
+		justify-content: end;
+	}
+}
+</style>

--- a/templates/oauth2.php
+++ b/templates/oauth2.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @copyright Copyright (c) 2019 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Jonas Sulzer <jonas@violoncello.ch>
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+\OCP\Util::addScript('social', 'social-oauth2');

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -8,7 +8,8 @@ webpackConfig.entry = {
 	social: path.join(__dirname, 'src', 'main.js'),
 	ostatus: path.join(__dirname, 'src', 'ostatus.js'),
 	profilePage: path.join(__dirname, 'src', 'profile.js'),
-    dashboard: path.join(__dirname, 'src', 'dashboard.js'),
+	dashboard: path.join(__dirname, 'src', 'dashboard.js'),
+	oauth: path.join(__dirname, 'src', 'oauth.js'),
 }
 
 module.exports = webpackConfig


### PR DESCRIPTION
We should add a popup that to let the user authorize/deny an oauth2 request

as an example, this is what displayed on mastodon:
![Selection_048](https://user-images.githubusercontent.com/1038617/200555252-d2891ecc-4159-485e-9701-f2ffe62be7f4.png)

'Authorize' should run a POST request passing the parameters attached to the template