### PR TITLE
Fix detection of webfinger endpoint with no 'resource' param

### DIFF
--- a/lib/WellKnown/WebfingerHandler.php
+++ b/lib/WellKnown/WebfingerHandler.php
@@ -101,7 +101,7 @@ class WebfingerHandler implements IHandler {
 	 * @return IResponse|null
 	 */
 	public function handleWebfinger(IRequestContext $context): ?IResponse {
-		$subject = $context->getHttpRequest()->getParam('resource');
+		$subject = $context->getHttpRequest()->getParam('resource') ?? '';
 		if (strpos($subject, 'acct:') === 0) {
 			$subject = substr($subject, 5);
 		}


### PR DESCRIPTION
This is necessary to make the "Overview" check pass.
`$subject` was `null` so `strpos` was throwing an exception, probably since php8.

