### PR TITLE
Check webfinger after having created the user

### DIFF
--- a/lib/Controller/NavigationController.php
+++ b/lib/Controller/NavigationController.php
@@ -153,11 +153,6 @@ class NavigationController extends Controller {
 			$this->configService->setSocialUrl();
 		}
 
-		if ($serverData['isAdmin']) {
-			$checks = $this->checkService->checkDefault();
-			$serverData['checks'] = $checks;
-		}
-
 		/*
 		 * Create social user account if it doesn't exist yet
 		 */
@@ -170,6 +165,11 @@ class NavigationController extends Controller {
 			// well, should not happens
 		} catch (SocialAppConfigException $e) {
 			// neither.
+		}
+
+		if ($serverData['isAdmin']) {
+			$checks = $this->checkService->checkDefault();
+			$serverData['checks'] = $checks;
 		}
 
 		$this->initialStateService->provideInitialState(Application::APP_NAME, 'serverData', $serverData);


### PR DESCRIPTION
On first run, the user does not exist, so the webfinger check fails.
This makes sure that the user exists before doing the webfinger check
