### PR TITLE
Update Profile.vue to read this.id instead of this.accountInfo.id

### DIFF
--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -97,7 +97,7 @@ export default {
 		/** @type {[import('../types/Mastodon').Account]} */
 		const response = await this.$store.dispatch(fetchMethod, this.profileAccount)
 		this.uid = response.acct
-		await this.$store.dispatch('fetchAccountRelationshipInfo', [this.accountInfo.id])
+		await this.$store.dispatch('fetchAccountRelationshipInfo', [this.id])
 	},
 }
 </script>


### PR DESCRIPTION
* Resolves: #1701 
* Target version: master 

### Summary
As explained in the mentioned issue, on opening the Profile, Profile.vue is trying to access this.accountInfo.id which is not found in the response returned by the request. The response JSON has id which technically should be accessible directly via this.id. Hence the change from this.accountInfo.id to this.id.