### PR TITLE
Retrieving id from response instead of this.accountInfo

### DIFF
--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -97,7 +97,7 @@ export default {
 		/** @type {[import('../types/Mastodon').Account]} */
 		const response = await this.$store.dispatch(fetchMethod, this.profileAccount)
 		this.uid = response.acct
-		await this.$store.dispatch('fetchAccountRelationshipInfo', [this.accountInfo.id])
+		await this.$store.dispatch('fetchAccountRelationshipInfo', [response.id])
 	},
 }
 </script>


### PR DESCRIPTION
As this.accountInfo is coming up as undefined, but the response does contain the id of the account, it should work fine in passing the id from response instead of this.accountInfo. this.accountInfo is undefined for localaccount because it is trying to find username@nextcloud.domain user from state which has username@localhost user.


* Resolves: #1701 
* Target version: master 

