### PR TITLE
update details only

### DIFF
--- a/lib/Service/AccountService.php
+++ b/lib/Service/AccountService.php
@@ -318,7 +318,7 @@ class AccountService {
 		}
 
 		$this->addLocalActorDetailCount($actor);
-		$this->actorService->cacheLocalActor($actor);
+		$this->actorService->cacheLocalActorDetails($actor);
 	}
 
 
@@ -348,7 +348,7 @@ class AccountService {
 	 *
 	 * @throws NoUserException
 	 */
-	private function updateCacheLocalActorName(Person &$actor) {
+	private function updateCacheLocalActorName(Person $actor) {
 		$user = $this->userManager->get($actor->getUserId());
 		if ($user === null) {
 			throw new NoUserException();

--- a/lib/Service/ActorService.php
+++ b/lib/Service/ActorService.php
@@ -106,6 +106,16 @@ class ActorService {
 	 *
 	 * @throws ItemAlreadyExistsException
 	 */
+	public function cacheLocalActorDetails(Person $actor) {
+		$this->cacheActorsRequest->updateDetails($actor);
+	}
+
+
+	/**
+	 * @param Person $actor
+	 *
+	 * @throws ItemAlreadyExistsException
+	 */
 	public function save(Person $actor) {
 		$this->cacheDocumentIfNeeded($actor);
 		$this->cacheActorsRequest->save($actor);


### PR DESCRIPTION
Doing an action like post, boost, like or follow update the entry in cache_actor with wrong data.
This PR only update details/count during this action...

The result will fix the fact that display name get ignored (ie. updated in the cache with username) 'randomly'.