### PR TITLE
useless cc on announce

### DIFF
--- a/lib/Service/BoostService.php
+++ b/lib/Service/BoostService.php
@@ -101,7 +101,7 @@ class BoostService {
 
 		$announce->setTo(ACore::CONTEXT_PUBLIC);
 		$announce->addCc($actor->getFollowers());
-		$announce->addcc($note->getAttributedTo());
+		//	$announce->addcc($note->getAttributedTo());
 
 		$announce->setObjectId($note->getId());
 		$announce->setRequestToken($this->uuid());


### PR DESCRIPTION
Remove the author of the original status from the `cc` list of a generated Announce

This will remove the display of `unknownUser boosted/liked/replied your own post`+post in the `Home` timeline. 
Don't know why it was required before; DM and Notifications makes it useless.

---
Current behavior:
![image](https://github.com/nextcloud/social/assets/1038617/2a74e9fd-83eb-4ed3-a520-7b7f8d3da534)
