### PR TITLE
Fix Markdown format in app description

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,8 +5,7 @@
 	<name>Social</name>
 	<summary>🎉 Nextcloud becomes part of the federated social networks!</summary>
 	<description><![CDATA[
-
-	** Disclaimer: this is a BETA version **
+**Disclaimer: this is a BETA version**
 
 **🎉 Nextcloud becomes part of the federated social networks!**
 


### PR DESCRIPTION
* Resolves: # -
* Target version: master 

### Summary

The format for the app description is not a valid Markdown format. As a result, instead of getting bold notice for beta release, we get `** Disclaimer: this is a BETA version **`.
