### PR TITLE
[PHP 8.4] Fix: Curl `CURLOPT_BINARYTRANSFER` deprecated

### DIFF
--- a/lib/Service/CurlService.php
+++ b/lib/Service/CurlService.php
@@ -377,7 +377,6 @@ class CurlService {
 		curl_setopt($curl, CURLOPT_TIMEOUT, $request->getTimeout());
 
 		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($curl, CURLOPT_BINARYTRANSFER, $request->isBinary());
 
 		curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, $request->isVerifyPeer());
 		curl_setopt($curl, CURLOPT_FOLLOWLOCATION, $request->isFollowLocation());

--- a/lib/Tools/Traits/TRequest.php
+++ b/lib/Tools/Traits/TRequest.php
@@ -114,7 +114,6 @@ trait TRequest {
 		curl_setopt($curl, CURLOPT_TIMEOUT, $request->getTimeout());
 
 		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($curl, CURLOPT_BINARYTRANSFER, $request->isBinary());
 
 		curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, $request->isVerifyPeer());
 		curl_setopt($curl, CURLOPT_FOLLOWLOCATION, $request->isFollowLocation());


### PR DESCRIPTION
The `CURLOPT_BINARYTRANSFER` PHP constant from the Curl extension was no-op since PHP 5.1, and is deprecated in PHP 8.4. This removes the constant usage to avoid the deprecation notice in PHP 8.4 and later.

Because this constant was no-op since PHP 5.1 (circa 2005), this change has no impact.

See:

 - [PHP.Watch - PHP 8.4 - Curl: CURLOPT_BINARYTRANSFER deprecated](https://php.watch/versions/8.4/CURLOPT_BINARYTRANSFER-deprecated)
 - [commit](https://github.com/php/php-src/commit/fc16285538e96ecb35d017231051f83dcbd8b55b)


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


