### PR TITLE
[master] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3242,23 +3242,6 @@
         "npm": "^10.0.0"
       }
     },
-    "node_modules/@nextcloud/axios/node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/@nextcloud/axios/node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
-    },
     "node_modules/@nextcloud/babel-config": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@nextcloud/babel-config/-/babel-config-1.0.0.tgz",
@@ -3331,18 +3314,6 @@
         "cypress": "^13.9.0"
       }
     },
-    "node_modules/@nextcloud/cypress/node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/@nextcloud/cypress/node_modules/debug": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
@@ -3396,13 +3367,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@nextcloud/cypress/node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true,
       "license": "MIT"
     },
@@ -5735,14 +5699,21 @@
       "peer": true
     },
     "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dev": true,
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/babel-jest": {
       "version": "29.5.0",
@@ -20179,16 +20150,17 @@
       }
     },
     "node_modules/wait-on": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.0.1.tgz",
-      "integrity": "sha512-9AnJE9qTjRQOlTZIldAaf/da2eW0eSRSgcqq85mXQja/DW3MriHxkpODDSUEg+Gri/rKEcXUZHe+cevvYItaog==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
+      "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "axios": "^0.27.2",
-        "joi": "^17.7.0",
+        "axios": "^1.6.1",
+        "joi": "^17.11.0",
         "lodash": "^4.17.21",
-        "minimist": "^1.2.7",
-        "rxjs": "^7.8.0"
+        "minimist": "^1.2.8",
+        "rxjs": "^7.8.1"
       },
       "bin": {
         "wait-on": "bin/wait-on"
@@ -23283,21 +23255,6 @@
           "requires": {
             "@nextcloud/typings": "^1.7.0"
           }
-        },
-        "axios": {
-          "version": "1.7.7",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-          "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
-          "requires": {
-            "follow-redirects": "^1.15.6",
-            "form-data": "^4.0.0",
-            "proxy-from-env": "^1.1.0"
-          }
-        },
-        "proxy-from-env": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-          "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         }
       }
     },
@@ -23352,17 +23309,6 @@
         "wait-on": "^8.0.0"
       },
       "dependencies": {
-        "axios": {
-          "version": "1.7.7",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-          "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
-          "dev": true,
-          "requires": {
-            "follow-redirects": "^1.15.6",
-            "form-data": "^4.0.0",
-            "proxy-from-env": "^1.1.0"
-          }
-        },
         "debug": {
           "version": "4.3.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
@@ -23399,12 +23345,6 @@
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-          "dev": true
-        },
-        "proxy-from-env": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-          "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
           "dev": true
         },
         "wait-on": {
@@ -25139,13 +25079,20 @@
       "peer": true
     },
     "axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dev": true,
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
       "requires": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "proxy-from-env": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+          "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+        }
       }
     },
     "babel-jest": {
@@ -35844,16 +35791,16 @@
       "requires": {}
     },
     "wait-on": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.0.1.tgz",
-      "integrity": "sha512-9AnJE9qTjRQOlTZIldAaf/da2eW0eSRSgcqq85mXQja/DW3MriHxkpODDSUEg+Gri/rKEcXUZHe+cevvYItaog==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
+      "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
       "dev": true,
       "requires": {
-        "axios": "^0.27.2",
-        "joi": "^17.7.0",
+        "axios": "^1.6.1",
+        "joi": "^17.11.0",
         "lodash": "^4.17.21",
-        "minimist": "^1.2.7",
-        "rxjs": "^7.8.0"
+        "minimist": "^1.2.8",
+        "rxjs": "^7.8.1"
       }
     },
     "walker": {


### PR DESCRIPTION
# Audit report

This audit fix resolves 11 of the total 13 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/dialogs](#user-content-\@nextcloud\/dialogs)
* [@nextcloud/files](#user-content-\@nextcloud\/files)
* [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* [@nextcloud/moment](#user-content-\@nextcloud\/moment)
* [@nextcloud/vue](#user-content-\@nextcloud\/vue)
* [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* [axios](#user-content-axios)
* [node-gettext](#user-content-node-gettext)
* [postcss](#user-content-postcss)
* [vue-loader](#user-content-vue-loader)
* [wait-on](#user-content-wait-on)
## Fixed vulnerabilities

### @nextcloud/dialogs <a href="#user-content-\@nextcloud\/dialogs" id="\@nextcloud\/dialogs">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/files](#user-content-\@nextcloud\/files)
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
  * [@nextcloud/vue](#user-content-\@nextcloud\/vue)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/@nextcloud/dialogs`

### @nextcloud/files <a href="#user-content-\@nextcloud\/files" id="\@nextcloud\/files">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* Affected versions: >=1.1.0
* Package usage:
  * `node_modules/@nextcloud/files`

### @nextcloud/l10n <a href="#user-content-\@nextcloud\/l10n" id="\@nextcloud\/l10n">#</a>
* Caused by vulnerable dependency:
  * [node-gettext](#user-content-node-gettext)
* Affected versions: >=1.1.0
* Package usage:
  * `node_modules/@nextcloud/l10n`
  * `node_modules/@nextcloud/moment/node_modules/@nextcloud/l10n`

### @nextcloud/moment <a href="#user-content-\@nextcloud\/moment" id="\@nextcloud\/moment">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
  * [node-gettext](#user-content-node-gettext)
* Affected versions: >=1.1.1
* Package usage:
  * `node_modules/@nextcloud/moment`

### @nextcloud/vue <a href="#user-content-\@nextcloud\/vue" id="\@nextcloud\/vue">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/dialogs](#user-content-\@nextcloud\/dialogs)
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* Affected versions: >=1.4.0
* Package usage:
  * `node_modules/@nextcloud/vue`

### @vue/component-compiler-utils <a href="#user-content-\@vue\/component-compiler-utils" id="\@vue\/component-compiler-utils">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: *
* Package usage:
  * `node_modules/@vue/component-compiler-utils`

### axios <a href="#user-content-axios" id="axios">#</a>
* Axios Cross-Site Request Forgery Vulnerability
* Severity: **moderate** (CVSS 6.5)
* Reference: [https://github.com/advisories/GHSA-wf5p-g6vw-rhxx](https://github.com/advisories/GHSA-wf5p-g6vw-rhxx)
* Affected versions: 0.8.1 - 0.27.2
* Package usage:
  * `node_modules/axios`

### node-gettext <a href="#user-content-node-gettext" id="node-gettext">#</a>
* node-gettext vulnerable to Prototype Pollution
* Severity: **moderate** (CVSS 5.9)
* Reference: [https://github.com/advisories/GHSA-g974-hxvm-x689](https://github.com/advisories/GHSA-g974-hxvm-x689)
* Affected versions: *
* Package usage:
  * `node_modules/node-gettext`

### postcss <a href="#user-content-postcss" id="postcss">#</a>
* PostCSS line return parsing error
* Severity: **moderate** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j)
* Affected versions: <8.4.31
* Package usage:
  * `node_modules/@vue/component-compiler-utils/node_modules/postcss`

### vue-loader <a href="#user-content-vue-loader" id="vue-loader">#</a>
* Caused by vulnerable dependency:
  * [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* Affected versions: 15.0.0-beta.1 - 15.11.1
* Package usage:
  * `node_modules/vue-loader`

### wait-on <a href="#user-content-wait-on" id="wait-on">#</a>
* Caused by vulnerable dependency:
  * [axios](#user-content-axios)
* Affected versions: 5.0.0-rc.0 - 7.1.0
* Package usage:
  * `node_modules/wait-on`