### PR TITLE
fix: Handle when required `resource` parameter is missing or empty

### DIFF
--- a/lib/WellKnown/WebfingerHandler.php
+++ b/lib/WellKnown/WebfingerHandler.php
@@ -224,7 +224,7 @@ class WebfingerHandler implements IHandler {
 		// on some setup (i.e. tests) the data are not available from IRequest
 		$requestUri = $request->getRequestUri();
 		if ($requestUri !== null) {
-			parse_str(parse_url($requestUri, PHP_URL_QUERY), $query);
+			parse_str(parse_url($requestUri, PHP_URL_QUERY) ?? '', $query);
 		}
 		
 		return $query['resource'] ?? '';

--- a/lib/WellKnown/WebfingerHandler.php
+++ b/lib/WellKnown/WebfingerHandler.php
@@ -223,7 +223,7 @@ class WebfingerHandler implements IHandler {
 		// work around to extract resource:
 		// on some setup (i.e. tests) the data are not available from IRequest
 		$requestUri = $request->getRequestUri();
-		if ($requestUri !== '') {
+		if ($requestUri !== null) {
 			parse_str(parse_url($requestUri, PHP_URL_QUERY), $query);
 		}
 		

--- a/lib/WellKnown/WebfingerHandler.php
+++ b/lib/WellKnown/WebfingerHandler.php
@@ -223,7 +223,7 @@ class WebfingerHandler implements IHandler {
 		// work around to extract resource:
 		// on some setup (i.e. tests) the data are not available from IRequest
 		$requestUri = $request->getRequestUri();
-		if ($requestUri !== null) {
+		if ($requestUri !== '') {
 			parse_str(parse_url($requestUri, PHP_URL_QUERY) ?? '', $query);
 		}
 		

--- a/lib/WellKnown/WebfingerHandler.php
+++ b/lib/WellKnown/WebfingerHandler.php
@@ -97,6 +97,12 @@ class WebfingerHandler implements IHandler {
 	 */
 	public function handleWebfinger(IRequestContext $context, ?IResponse $previousResponse): ?IResponse {
 		$subject = $this->getSubjectFromRequest($context->getHttpRequest());
+		
+		// the `resource` parameter is required
+		if ($subject === null || $subject === '') {
+			return new JrdResponse('', Http::STATUS_BAD_REQUEST);
+		}
+		
 		if (str_starts_with($subject, 'acct:')) {
 			$subject = substr($subject, 5);
 		}
@@ -216,8 +222,11 @@ class WebfingerHandler implements IHandler {
 
 		// work around to extract resource:
 		// on some setup (i.e. tests) the data are not available from IRequest
-		parse_str(parse_url($request->getRequestUri(), PHP_URL_QUERY), $query);
-
+		$requestUri = $request->getRequestUri();
+		if ($requestUri !== '') {
+			parse_str(parse_url($requestUri, PHP_URL_QUERY), $query);
+		}
+		
 		return $query['resource'] ?? '';
 	}
 }

--- a/lib/WellKnown/WebfingerHandler.php
+++ b/lib/WellKnown/WebfingerHandler.php
@@ -99,7 +99,7 @@ class WebfingerHandler implements IHandler {
 		$subject = $this->getSubjectFromRequest($context->getHttpRequest());
 		
 		// the `resource` parameter is required
-		if ($subject === null || $subject === '') {
+		if ($subject === '') {
 			return new JrdResponse('', Http::STATUS_BAD_REQUEST);
 		}
 		


### PR DESCRIPTION
* Resolves: #1888 <!-- related github issue -->
* Target version: master 

### Summary

`resource` is a required parameter. Avoid a 500 error when it's missing or empty. Instead generate a proper 400 bad request response.

Refs:

- https://datatracker.ietf.org/doc/html/rfc7033#section-4.2

P.S. Semi-related: Our default setup checks in `server` aren't compatible with `social` being enabled since they only check for 200 or 404 (neither of which are applicable when `social` is enabled and when querying `/.well-known/webfinger` without any parameterst):

https://github.com/nextcloud/server/blob/16812837157395c078a9689cd51530a6382e17d2/apps/settings/lib/SetupChecks/WellKnownUrls.php#L48

This PR doesn't impact those either way directly (since the prior 500 nor the 400 added via this PR would have ever passed). I'll try to take a closer look at those over in `server`. EDIT: nextcloud/server#49440
