### PR TITLE
Fix Content-Type for ActivityPub requests

### DIFF
--- a/lib/Controller/ActivityPubController.php
+++ b/lib/Controller/ActivityPubController.php
@@ -81,6 +81,17 @@ class ActivityPubController extends Controller {
 		$this->streamService = $streamService;
 		$this->configService = $configService;
 		$this->logger = $logger;
+
+		$this->registerResponder('activity+json', function($response) {
+			$resp = new \OCP\AppFramework\Http\JSONResponse($response->getData());
+			$resp->addHeader('Content-Type', 'application/activity+json; charset=utf-8');
+			return $resp;
+		});
+		$this->registerResponder('ld+json; profile="https://www.w3.org/ns/activitystreams"', function($response) {
+			$resp = new \OCP\AppFramework\Http\JSONResponse($response->getData());
+			$resp->addHeader('Content-Type', 'ld+json; profile="https://www.w3.org/ns/activitystreams"; charset=utf-8');
+			return $resp;
+		});
 	}
 
 


### PR DESCRIPTION
I was not able to find my nextcloud social account with any of my other fediverse accounts because the Content-Type header sent by the server does not match the ActivityPub spec.

This updates the ActivityPubController to register a responder for `application/ld+json; profile="https://www.w3.org/ns/activitystreams"` (defined by the AP spec and used by Mastodon) as well as `application/activity+json` (also considered valid by the spec and used by misskey/sharkey/etc) according to the Accept header of the request.

I believe this fixes #1734. (For me webfinger was working, but other AP servers are discarding the response when trying to retrieve the profile because of the incorrect Content-Type header.)