### PR TITLE
test: add backend and frontend unit test suites

### DIFF
--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -1,0 +1,92 @@
+# Frontend unit tests (Vitest). Structure mirrors the organisation's lint-eslint
+# template so branch protection can key on the summary job name.
+#
+# SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
+
+name: Frontend unit tests
+
+on: pull_request
+
+permissions:
+  contents: read
+
+concurrency:
+  group: vitest-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest-low
+    permissions:
+      contents: read
+      pull-requests: read
+
+    outputs:
+      src: ${{ steps.changes.outputs.src}}
+
+    steps:
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changes
+        continue-on-error: true
+        with:
+          filters: |
+            src:
+              - '.github/workflows/**'
+              - 'src/**'
+              - 'tests/js/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'vitest.config.js'
+              - '**.js'
+              - '**.vue'
+
+  test:
+    runs-on: ubuntu-latest
+
+    needs: changes
+    if: needs.changes.outputs.src != 'false'
+
+    name: NPM test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Read package.json node and npm engines version
+        uses: skjnldsv/read-package-engines-version-actions@06d6baf7d8f41934ab630e97d9e6c0bc9c9ac5e4 # v3
+        id: versions
+        with:
+          fallbackNode: '^20'
+          fallbackNpm: '^10'
+
+      - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+        with:
+          node-version: ${{ steps.versions.outputs.nodeVersion }}
+
+      - name: Set up npm ${{ steps.versions.outputs.npmVersion }}
+        run: npm i -g 'npm@${{ steps.versions.outputs.npmVersion }}'
+
+      - name: Install dependencies
+        env:
+          CYPRESS_INSTALL_BINARY: 0
+          PUPPETEER_SKIP_DOWNLOAD: true
+        run: npm ci
+
+      - name: Test
+        run: npm test
+
+  summary:
+    permissions:
+      contents: none
+    runs-on: ubuntu-latest-low
+    needs: [changes, test]
+
+    if: always()
+
+    name: vitest
+
+    steps:
+      - name: Summary status
+        run: if ${{ needs.changes.outputs.src != 'false' && needs.test.result != 'success' }}; then exit 1; fi

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ js/*.map
 *.csr
 *.crt
 RELEASE.md
+
+# test artefacts
+tests/.phpunit.result.cache
+coverage/

--- a/README.md
+++ b/README.md
@@ -41,6 +41,26 @@ If an uploaded banner does not appear immediately:
 - Check server logs for upload or permission errors.
 - Re-fetch the account data or sign out/sign in to refresh the local cache.
 
+## ✅ Tests
+
+Backend and frontend unit tests run without a Nextcloud server or database.
+
+```bash
+composer install            # PHPUnit + OCP interface stubs
+composer run test:unit      # PHP: vendor/bin/phpunit -c tests/phpunit.xml
+
+npm ci
+npm test                    # JS: vitest run (tests/js/** and src/**/*.test.js)
+npm run test:coverage       # with a coverage report in coverage/js
+```
+
+PHP tests live in `tests/` mirroring `lib/` (`lib/Service/PostService.php` →
+`tests/Service/PostServiceTest.php`). Everything a class needs is mocked; code that
+reaches the container statically finds a `TestContainer` behind `\OC::$server`
+(see `tests/Helper/TestContainer.php`). Frontend tests use Vitest with
+`@vue/test-utils` and jsdom; `tests/js/setup.js` provides the Nextcloud globals
+(`t`, `n`, `OC`, `OCA`, `localStorage`, router webroots).
+
 ## 🛠️ Contributing
 
 - Contributions welcome — open a pull request and run the build/tests locally before merging.

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,14 @@
 			"OCA\\Social\\": "lib/"
 		}
 	},
+	"autoload-dev": {
+		"psr-4": {
+			"OCA\\Social\\Tests\\": "tests/"
+		},
+		"exclude-from-classmap": [
+			"tests/bootstrap.php"
+		]
+	},
 	"require": {
 		"php": ">=8.1",
 		"gumlet/php-image-resize": "2.0.*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,10 @@
         "@nextcloud/eslint-config": "^8.4.2",
         "@nextcloud/stylelint-config": "^2.3.0",
         "@nextcloud/webpack-vue-config": "^6.0.0",
+        "@vitejs/plugin-vue": "^5.2.4",
+        "@vitest/coverage-v8": "^3.2.7",
         "@vue/compiler-sfc": "^3.5.35",
+        "@vue/test-utils": "^2.5.0",
         "babel-loader": "^10.1.1",
         "copy-webpack-plugin": "^14.0.0",
         "css-loader": "^7.1.4",
@@ -57,12 +60,12 @@
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-n": "^16.0.0",
         "eslint-plugin-vue": "^9.33.0",
-        "jest": "^29.5.0",
-        "jest-environment-jsdom": "^29.7.0",
+        "jsdom": "^26.1.0",
         "node-polyfill-webpack-plugin": "^4.0.0",
         "sass-loader": "^16.0.8",
         "style-loader": "^4.0.0",
         "ts-loader": "^9.5.7",
+        "vitest": "^3.2.7",
         "vue-loader": "^17.4.2",
         "wait-on": "^7.0.1",
         "webpack": "^5.106.2",
@@ -72,6 +75,136 @@
         "node": "^20.0.0",
         "npm": "^10.0.0"
       }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -607,61 +740,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-syntax-async-generators": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
-      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-bigint": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
-      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-class-properties": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
-      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.12.13"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-class-static-block": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
-      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-syntax-dynamic-import": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
@@ -707,32 +785,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-syntax-import-meta": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
-      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.10.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-json-strings": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
-      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-syntax-jsx": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
@@ -749,45 +801,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
-      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.10.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
-      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-numeric-separator": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
-      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.10.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-syntax-object-rest-spread": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
@@ -796,80 +809,6 @@
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
-      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-optional-chaining": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
-      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-private-property-in-object": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
-      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-top-level-await": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
-      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
-      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -2038,11 +1977,14 @@
       "license": "Apache-2.0"
     },
     "node_modules/@bcoe/v8-coverage": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
-      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@buttercup/fetch": {
       "version": "0.2.1",
@@ -2067,6 +2009,26 @@
       },
       "peerDependencies": {
         "vue": "^3.2.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
@@ -2344,6 +2306,448 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2658,111 +3062,107 @@
       "license": "BSD-3-Clause",
       "peer": true
     },
-    "node_modules/@istanbuljs/load-nyc-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
-      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "camelcase": "^5.3.1",
-        "find-up": "^4.1.0",
-        "get-package-type": "^0.1.0",
-        "js-yaml": "^3.13.1",
-        "resolve-from": "^5.0.0"
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       }
     },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "p-limit": "^2.2.0"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/@istanbuljs/schema": {
@@ -2773,314 +3173,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@jest/console": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
-      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "jest-message-util": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/core": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
-      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/console": "^29.7.0",
-        "@jest/reporters": "^29.7.0",
-        "@jest/test-result": "^29.7.0",
-        "@jest/transform": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.2.9",
-        "jest-changed-files": "^29.7.0",
-        "jest-config": "^29.7.0",
-        "jest-haste-map": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-regex-util": "^29.6.3",
-        "jest-resolve": "^29.7.0",
-        "jest-resolve-dependencies": "^29.7.0",
-        "jest-runner": "^29.7.0",
-        "jest-runtime": "^29.7.0",
-        "jest-snapshot": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "jest-validate": "^29.7.0",
-        "jest-watcher": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^29.7.0",
-        "slash": "^3.0.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@jest/core/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/environment": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
-      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/fake-timers": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "jest-mock": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/expect": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
-      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "expect": "^29.7.0",
-        "jest-snapshot": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/expect-utils": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
-      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jest-get-type": "^29.6.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/fake-timers": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
-      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@sinonjs/fake-timers": "^10.0.2",
-        "@types/node": "*",
-        "jest-message-util": "^29.7.0",
-        "jest-mock": "^29.7.0",
-        "jest-util": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/globals": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
-      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "^29.7.0",
-        "@jest/expect": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "jest-mock": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/reporters": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
-      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^29.7.0",
-        "@jest/test-result": "^29.7.0",
-        "@jest/transform": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@jridgewell/trace-mapping": "^0.3.18",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "collect-v8-coverage": "^1.0.0",
-        "exit": "^0.1.2",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.2.9",
-        "istanbul-lib-coverage": "^3.0.0",
-        "istanbul-lib-instrument": "^6.0.0",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-lib-source-maps": "^4.0.0",
-        "istanbul-reports": "^3.1.3",
-        "jest-message-util": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "jest-worker": "^29.7.0",
-        "slash": "^3.0.0",
-        "string-length": "^4.0.1",
-        "strip-ansi": "^6.0.0",
-        "v8-to-istanbul": "^9.0.1"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/source-map": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
-      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.18",
-        "callsites": "^3.0.0",
-        "graceful-fs": "^4.2.9"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/test-result": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
-      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/console": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "collect-v8-coverage": "^1.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/test-sequencer": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
-      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/test-result": "^29.7.0",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.7.0",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/transform": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
-      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.11.6",
-        "@jest/types": "^29.6.3",
-        "@jridgewell/trace-mapping": "^0.3.18",
-        "babel-plugin-istanbul": "^6.1.1",
-        "chalk": "^4.0.0",
-        "convert-source-map": "^2.0.0",
-        "fast-json-stable-stringify": "^2.1.0",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.7.0",
-        "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "pirates": "^4.0.4",
-        "slash": "^3.0.0",
-        "write-file-atomic": "^4.0.2"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -3116,7 +3208,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -3163,6 +3255,23 @@
       "resolved": "https://registry.npmjs.org/@mdi/js/-/js-7.4.47.tgz",
       "integrity": "sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.5",
@@ -3689,6 +3798,448 @@
         "node": "^22.18.0 || >=24.11.0"
       }
     },
+    "node_modules/@nextcloud/vue/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@nextcloud/vue/node_modules/@vue/devtools-api": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.1.2.tgz",
@@ -3710,16 +4261,138 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@nextcloud/vue/node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
     "node_modules/@nextcloud/vue/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@nextcloud/vue/node_modules/vite": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nextcloud/vue/node_modules/vue-router": {
@@ -3885,6 +4558,24 @@
       "peer": true,
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@one-ini/wasm": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.2.1.tgz",
+      "integrity": "sha512-TUqERXGNTifZ9y2g3wPxQrw3HpHv/02DsW3D90T9x0hhonrL1ZqpSmNrU2XkoIq0fP1N6gZfVQzy2Fw1ZvGBNg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.148.0.tgz",
+      "integrity": "sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/oxc-project"
       }
     },
     "node_modules/@parcel/watcher": {
@@ -4473,6 +5164,17 @@
       "license": "0BSD",
       "peer": true
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -4539,39 +5241,625 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.7.tgz",
+      "integrity": "sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.7.tgz",
+      "integrity": "sha512-l17HE9EweWaqJZhuUuNBN/FzM62xw+DECVnJyvMsxn8vJFAGLy5QfLDoYAcronkAN8VxKZHezDpulHDPx95vFw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.7.tgz",
+      "integrity": "sha512-8ED8ELFvHXc6OCETIn4gXObPiaR6bckM/ipXtbzlPVDRMBfEGjCKgO90F9YtfdpDatVx/ZQw7aZ1vUMf/+T3Mw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.7.tgz",
+      "integrity": "sha512-/WPripjtiAIZ2tWY7ddijORT0Ujg87wxWW/qcoFVCKAWVDPhtY0xr7Dj0M3GyNGz60jGwTElhro/mkF9dT7dDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.7.tgz",
+      "integrity": "sha512-14DI4NcqpvbICxSnGLx3PmtDaWqRP/KGSGb6C+JLLVPeZRl6dKdHba3pGsqT3vpdTqhEYIPG0MMQ8c0xYqoJxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.7.tgz",
+      "integrity": "sha512-bxrWIRvHWQvbJwi+VIie/kDJmQxcNE6xxWwZdqF/ExVAigtHkv54WTLQPb+QsZdnFy18fg7JPfWGL0RH6vwIlQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.7.tgz",
+      "integrity": "sha512-toOY2BChBZyuxU7OYX6Tn389di4IzAqPTycVcci0O7FSfBqzRB3RZn+K5Is6ANf4tmgRd/K1yZTsNTXbkXsnLg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.7.tgz",
+      "integrity": "sha512-lAIXTH/aiLRLxsTgQvfhjo4K1ydWIp00+V0voOr9beb/9ZmkUFrSIb03dXNFRgMNvkE6oGsF10ioQ6UsI+vS5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.7.tgz",
+      "integrity": "sha512-kdnwS28Pkenp/mZMRwjXXXwxQ7pIsm+bF919LUK93BOyhcLsrVKdP2p9fxpiPNPAbNuch8ypQt0pm2P2LYCAGg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.7.tgz",
+      "integrity": "sha512-516OdsyLdr5E65paF3yBF55t8mfm9+gmtCsK3xI7XKXIT7EfRlHhxL8K/NR6Hu8BWSgF5+1w74lTL0+nxcc8Qw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.7.tgz",
+      "integrity": "sha512-r8/z8n7GFaYRln3xmP1Cxy0HH/HLM0uBUPkEuSVEfKGDA89M0FsZRZJRSwe/tJjRx+fpH/gjorfhB8tmEbSFLA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.7.tgz",
+      "integrity": "sha512-pAsE8iiDxUg1xBqdhrTfg45AVDVpirjz00sblEYClGNNcMnDb+e8beQgqIAw6LvauX/APvgxUnwrgun/YYGBhw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.7.tgz",
+      "integrity": "sha512-lTcIYmmnQQA8Or/2DatS6oSqcdLHvendjS+zLu+FwgToynWMRSmQdpM65fTANJgIS4mjbMOo5KT2lnT9SAb96w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.7.tgz",
+      "integrity": "sha512-e3Gu3WxbNk/UqQhxqU7YIYO+9ZBvWNz3U+h/qRFosscMFzdRPbXYSaSWgSnklv2fz1TgzBTcti2z35c/7irsHw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.7.tgz",
+      "integrity": "sha512-W/jg5qoRSqjsEv0+dZi4e687mcHqmVuU0P4fK6qS/xjetW2Gmc1W8j//z5nAeNcC8Ttm0hV46IjcYeuVwYhuiw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz",
+      "integrity": "sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.1.tgz",
+      "integrity": "sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.1.tgz",
+      "integrity": "sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.1.tgz",
+      "integrity": "sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.1.tgz",
+      "integrity": "sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.1.tgz",
+      "integrity": "sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.1.tgz",
+      "integrity": "sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.1.tgz",
+      "integrity": "sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.1.tgz",
+      "integrity": "sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.1.tgz",
+      "integrity": "sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.1.tgz",
+      "integrity": "sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.1.tgz",
+      "integrity": "sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.1.tgz",
+      "integrity": "sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.1.tgz",
+      "integrity": "sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.1.tgz",
+      "integrity": "sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.1.tgz",
+      "integrity": "sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.1.tgz",
+      "integrity": "sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.1.tgz",
+      "integrity": "sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.1.tgz",
+      "integrity": "sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.1.tgz",
+      "integrity": "sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.1.tgz",
+      "integrity": "sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.1.tgz",
+      "integrity": "sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz",
+      "integrity": "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@sinonjs/commons": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
-      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "node_modules/@sinonjs/fake-timers": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.0"
-      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -4585,16 +5873,6 @@
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
       "license": "MIT"
-    },
-    "node_modules/@tootallnate/once": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
-      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
@@ -4617,51 +5895,6 @@
       "optional": true,
       "peer": true
     },
-    "node_modules/@types/babel__core": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.20.7",
-        "@babel/types": "^7.20.7",
-        "@types/babel__generator": "*",
-        "@types/babel__template": "*",
-        "@types/babel__traverse": "*"
-      }
-    },
-    "node_modules/@types/babel__generator": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
-      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__template": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__traverse": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
-      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.28.2"
-      }
-    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -4683,6 +5916,17 @@
       "peer": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/connect": {
@@ -4716,6 +5960,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/escape-html": {
       "version": "1.0.4",
@@ -4766,16 +6017,6 @@
         "@types/send": "*"
       }
     },
-    "node_modules/@types/graceful-fs": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
-      "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -4804,33 +6045,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/istanbul-lib-coverage": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
-      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/istanbul-lib-report": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
-      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "*"
-      }
-    },
-    "node_modules/@types/istanbul-reports": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
-      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-report": "*"
-      }
-    },
     "node_modules/@types/jquery": {
       "version": "3.5.16",
       "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.16.tgz",
@@ -4838,18 +6052,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/sizzle": "*"
-      }
-    },
-    "node_modules/@types/jsdom": {
-      "version": "20.0.1",
-      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
-      "integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/tough-cookie": "*",
-        "parse5": "^7.0.0"
       }
     },
     "node_modules/@types/jsesc": {
@@ -4907,7 +6109,7 @@
       "version": "25.9.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
       "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
@@ -5023,13 +6225,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/stack-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
-      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/tmp": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
@@ -5042,13 +6237,6 @@
       "version": "1.12.4",
       "resolved": "https://registry.npmjs.org/@types/toastify-js/-/toastify-js-1.12.4.tgz",
       "integrity": "sha512-zfZHU4tKffPCnZRe7pjv/eFKzTVHozKewFCKaCjZ4gFinKgJRz/t0bkZiMCXJxPhv/ZoeDGNOeRD09R0kQZ/nw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/tough-cookie": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
-      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
@@ -5080,23 +6268,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/yargs": {
-      "version": "17.0.35",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
-      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/@types/yargs-parser": {
-      "version": "21.0.3",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
-      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.18.0",
@@ -5668,6 +6839,179 @@
       ],
       "peer": true
     },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.7.tgz",
+      "integrity": "sha512-NEGWJS2XNu2PfRLQwOO3CTKj1tTETxNBdk454vDxVBhxJYhPaA/eS0nAI0c+1El1P7a60z8+i+ZrQoGESweGKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.7",
+        "vitest": "3.2.7"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@vue-macros/common": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@vue-macros/common/-/common-3.1.2.tgz",
@@ -5844,6 +7188,27 @@
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.38.tgz",
       "integrity": "sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==",
       "license": "MIT"
+    },
+    "node_modules/@vue/test-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.5.0.tgz",
+      "integrity": "sha512-6Clu5EKR/r6cDPYrKsu+8wenciWJJ3rhS9OEGsfDlZeZIhlJeEPGIZQHxE4lHRJCzPSq3EWMsFxQUqCvrbHQuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-beautify": "^2.0.0",
+        "vue-component-type-helpers": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@vue/compiler-dom": "3.x",
+        "@vue/server-renderer": "3.x",
+        "vue": "3.x"
+      },
+      "peerDependenciesMeta": {
+        "@vue/server-renderer": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vuepic/vue-datepicker": {
       "version": "11.0.3",
@@ -6133,13 +7498,15 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/abab": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
-      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
-      "deprecated": "Use your platform's native atob() and btoa() methods instead",
+    "node_modules/abbrev": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-5.0.0.tgz",
+      "integrity": "sha512-/XrFJgzQQQHpti1raDJC6m4ws6aNktmjBlhk8Fdlk7LwCEuDoieEJJY9OFHjfiFJFFRM2tK+Ky/IsfbbmlMu1w==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "ISC",
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -6187,30 +7554,6 @@
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-globals": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
-      "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.1.0",
-        "acorn-walk": "^8.0.2"
-      }
-    },
-    "node_modules/acorn-globals/node_modules/acorn-walk": {
-      "version": "8.3.5",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
-      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.11.0"
       },
       "engines": {
         "node": ">=0.4.0"
@@ -6345,35 +7688,6 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.21.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ansi-escapes/node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/ansi-html-community": {
       "version": "0.0.8",
@@ -6709,6 +8023,16 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-kit": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.2.0.tgz",
@@ -6724,6 +8048,35 @@
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ast-walker-scope": {
       "version": "0.9.0",
@@ -6826,28 +8179,6 @@
         "proxy-from-env": "^2.1.0"
       }
     },
-    "node_modules/babel-jest": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
-      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/transform": "^29.7.0",
-        "@types/babel__core": "^7.1.14",
-        "babel-plugin-istanbul": "^6.1.1",
-        "babel-preset-jest": "^29.6.3",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.8.0"
-      }
-    },
     "node_modules/babel-loader": {
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-10.1.1.tgz",
@@ -6880,56 +8211,6 @@
       "integrity": "sha512-g+8yxHUZ60RcyaUpfNzy56OtWW+x9cyEe9j+CranqLiqbju2yf/Cy6ZtYK40EZxtrdHllzlVZgLmcOUCTlJ7Jg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/babel-plugin-istanbul": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
-      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@istanbuljs/load-nyc-config": "^1.0.0",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-instrument": "^5.0.4",
-        "test-exclude": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/core": "^7.12.3",
-        "@babel/parser": "^7.14.7",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/babel-plugin-jest-hoist": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
-      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.3.3",
-        "@babel/types": "^7.3.3",
-        "@types/babel__core": "^7.1.14",
-        "@types/babel__traverse": "^7.0.6"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.17",
@@ -6971,50 +8252,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-      }
-    },
-    "node_modules/babel-preset-current-node-syntax": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
-      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/plugin-syntax-async-generators": "^7.8.4",
-        "@babel/plugin-syntax-bigint": "^7.8.3",
-        "@babel/plugin-syntax-class-properties": "^7.12.13",
-        "@babel/plugin-syntax-class-static-block": "^7.14.5",
-        "@babel/plugin-syntax-import-attributes": "^7.24.7",
-        "@babel/plugin-syntax-import-meta": "^7.10.4",
-        "@babel/plugin-syntax-json-strings": "^7.8.3",
-        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
-        "@babel/plugin-syntax-top-level-await": "^7.14.5"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0 || ^8.0.0-0"
-      }
-    },
-    "node_modules/babel-preset-jest": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
-      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-jest-hoist": "^29.6.3",
-        "babel-preset-current-node-syntax": "^1.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/babelify": {
@@ -7510,16 +8747,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/bser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
-      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "node-int64": "^0.4.0"
-      }
-    },
     "node_modules/buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
@@ -7535,7 +8762,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/buffer-xor": {
@@ -7643,6 +8870,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cached-path-relative": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.1.0.tgz",
@@ -7716,16 +8953,7 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
-      "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -7824,6 +9052,23 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -7852,16 +9097,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/char-regex": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
-      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/character-entities": {
@@ -7911,6 +9146,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -7976,13 +9221,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/cjs-module-lexer": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
-      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
@@ -8155,17 +9393,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">= 1.0.0",
-        "node": ">= 0.12.0"
-      }
-    },
     "node_modules/coffeeify": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/coffeeify/-/coffeeify-3.0.1.tgz",
@@ -8200,13 +9427,6 @@
       "engines": {
         "node": ">=0.8.0"
       }
-    },
-    "node_modules/collect-v8-coverage": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
-      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -8411,6 +9631,24 @@
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
       "license": "MIT"
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
+    "node_modules/config-chain/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/connect-history-api-fallback": {
       "version": "2.0.0",
@@ -8633,28 +9871,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "node_modules/create-jest": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
-      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "chalk": "^4.0.0",
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.2.9",
-        "jest-config": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "prompts": "^2.0.1"
-      },
-      "bin": {
-        "create-jest": "bin/create-jest.js"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -8794,32 +10010,19 @@
         "node": ">=4"
       }
     },
-    "node_modules/cssom": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
-      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cssstyle": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cssom": "~0.3.6"
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       }
-    },
-    "node_modules/cssstyle/node_modules/cssom": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -8970,18 +10173,17 @@
       }
     },
     "node_modules/data-urls": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
-      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "abab": "^2.0.6",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^11.0.0"
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/data-view-buffer": {
@@ -9153,19 +10355,14 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/dedent": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
-      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "dev": true,
       "license": "MIT",
-      "peerDependencies": {
-        "babel-plugin-macros": "^3.1.0"
-      },
-      "peerDependenciesMeta": {
-        "babel-plugin-macros": {
-          "optional": true
-        }
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -9175,16 +10372,6 @@
       "dev": true,
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/deepmerge": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/default-browser": {
       "version": "5.5.0",
@@ -9356,16 +10543,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/detect-newline": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
-      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/detect-node": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
@@ -9403,16 +10580,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/diff-sequences": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
-      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/diffie-hellman": {
@@ -9580,20 +10747,6 @@
       "license": "BSD-2-Clause",
       "peer": true
     },
-    "node_modules/domexception": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
-      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/domhandler": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
@@ -9660,6 +10813,13 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -9670,6 +10830,87 @@
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/editorconfig": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-3.0.2.tgz",
+      "integrity": "sha512-T0ix8GhtxyKVfUFEcvdNDt3YGqlwkFHbD4/5bgFUDgFmxhI/cSRAeJ87/Sz//Cq8Eam6JX/e23RkoFO71P7aAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@one-ini/wasm": "0.2.1",
+        "commander": "^14.0.3",
+        "minimatch": "~10.2.4",
+        "semver": "^7.7.4"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/editorconfig/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/editorconfig/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/editorconfig/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/editorconfig/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/editorconfig/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ee-first": {
@@ -9693,19 +10934,6 @@
       "integrity": "sha512-tAyQ9RrgApb0X66D1enKmBjHCoZNFELl/W8FCfD2b7TsxBKnh9UUJStEwYBg8qWFCwoovzB96tufoHR4BH3Clw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/emittery": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
-      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
-      }
     },
     "node_modules/emoji-mart-vue-fast": {
       "version": "15.0.5",
@@ -9807,6 +11035,7 @@
       "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -9963,6 +11192,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -9991,49 +11262,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/escodegen": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/escodegen/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/eslint": {
@@ -10666,20 +11894,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/esquery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -10857,30 +12071,14 @@
         "node": ">=4"
       }
     },
-    "node_modules/exit": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/expect": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
-      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/expect-utils": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "jest-matcher-utils": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-util": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -11017,7 +12215,8 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -11122,16 +12321,6 @@
       },
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/fb-watchman": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
-      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bser": "2.1.1"
       }
     },
     "node_modules/fetch-blob": {
@@ -11347,6 +12536,36 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -11442,7 +12661,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11569,16 +12787,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-package-type": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
-      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/get-proto": {
@@ -12198,16 +13406,16 @@
       }
     },
     "node_modules/html-encoding-sniffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
-      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "whatwg-encoding": "^2.0.0"
+        "whatwg-encoding": "^3.1.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/html-escaper": {
@@ -12331,18 +13539,27 @@
       }
     },
     "node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/http-proxy-middleware": {
@@ -12576,6 +13793,7 @@
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -12774,7 +13992,8 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
@@ -13039,16 +14258,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-generator-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
-      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
@@ -13308,6 +14517,7 @@
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -13508,36 +14718,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/istanbul-lib-instrument": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
-      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/core": "^7.23.9",
-        "@babel/parser": "^7.23.9",
-        "@istanbuljs/schema": "^0.1.3",
-        "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
@@ -13567,28 +14747,18 @@
       }
     },
     "node_modules/istanbul-lib-source-maps": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
-      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
         "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^3.0.0",
-        "source-map": "^0.6.1"
+        "istanbul-lib-coverage": "^3.0.0"
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/istanbul-reports": {
@@ -13605,691 +14775,20 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
-      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dev": true,
-      "license": "MIT",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@jest/core": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "import-local": "^3.0.2",
-        "jest-cli": "^29.7.0"
-      },
-      "bin": {
-        "jest": "bin/jest.js"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-changed-files": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
-      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "execa": "^5.0.0",
-        "jest-util": "^29.7.0",
-        "p-limit": "^3.1.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-changed-files/node_modules/execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
+        "@isaacs/cliui": "^8.0.2"
       },
       "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/jest-changed-files/node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/jest-changed-files/node_modules/human-signals": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.17.0"
-      }
-    },
-    "node_modules/jest-circus": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
-      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "^29.7.0",
-        "@jest/expect": "^29.7.0",
-        "@jest/test-result": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "co": "^4.6.0",
-        "dedent": "^1.0.0",
-        "is-generator-fn": "^2.0.0",
-        "jest-each": "^29.7.0",
-        "jest-matcher-utils": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-runtime": "^29.7.0",
-        "jest-snapshot": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "p-limit": "^3.1.0",
-        "pretty-format": "^29.7.0",
-        "pure-rand": "^6.0.0",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-cli": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
-      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/core": "^29.7.0",
-        "@jest/test-result": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "chalk": "^4.0.0",
-        "create-jest": "^29.7.0",
-        "exit": "^0.1.2",
-        "import-local": "^3.0.2",
-        "jest-config": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "jest-validate": "^29.7.0",
-        "yargs": "^17.3.1"
-      },
-      "bin": {
-        "jest": "bin/jest.js"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-config": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
-      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.11.6",
-        "@jest/test-sequencer": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "babel-jest": "^29.7.0",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "deepmerge": "^4.2.2",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.2.9",
-        "jest-circus": "^29.7.0",
-        "jest-environment-node": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "jest-regex-util": "^29.6.3",
-        "jest-resolve": "^29.7.0",
-        "jest-runner": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "jest-validate": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "parse-json": "^5.2.0",
-        "pretty-format": "^29.7.0",
-        "slash": "^3.0.0",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "@types/node": "*",
-        "ts-node": ">=9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "ts-node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-config/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-diff": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
-      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^29.6.3",
-        "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-docblock": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
-      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "detect-newline": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-each": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
-      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "chalk": "^4.0.0",
-        "jest-get-type": "^29.6.3",
-        "jest-util": "^29.7.0",
-        "pretty-format": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-environment-jsdom": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
-      "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "^29.7.0",
-        "@jest/fake-timers": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/jsdom": "^20.0.0",
-        "@types/node": "*",
-        "jest-mock": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "jsdom": "^20.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "canvas": "^2.5.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-environment-node": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
-      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "^29.7.0",
-        "@jest/fake-timers": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "jest-mock": "^29.7.0",
-        "jest-util": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-get-type": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
-      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-haste-map": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/graceful-fs": "^4.1.3",
-        "@types/node": "*",
-        "anymatch": "^3.0.3",
-        "fb-watchman": "^2.0.0",
-        "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.7.0",
-        "jest-worker": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "walker": "^1.0.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "url": "https://github.com/sponsors/isaacs"
       },
       "optionalDependencies": {
-        "fsevents": "^2.3.2"
-      }
-    },
-    "node_modules/jest-leak-detector": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
-      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-matcher-utils": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
-      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "jest-diff": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-message-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.6.3",
-        "@types/stack-utils": "^2.0.0",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^29.7.0",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-mock": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
-      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "jest-util": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-pnp-resolver": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
-      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "jest-resolve": "*"
-      },
-      "peerDependenciesMeta": {
-        "jest-resolve": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-regex-util": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
-      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-resolve": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
-      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.7.0",
-        "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^29.7.0",
-        "jest-validate": "^29.7.0",
-        "resolve": "^1.20.0",
-        "resolve.exports": "^2.0.0",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-resolve-dependencies": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
-      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jest-regex-util": "^29.6.3",
-        "jest-snapshot": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-runner": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
-      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/console": "^29.7.0",
-        "@jest/environment": "^29.7.0",
-        "@jest/test-result": "^29.7.0",
-        "@jest/transform": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "emittery": "^0.13.1",
-        "graceful-fs": "^4.2.9",
-        "jest-docblock": "^29.7.0",
-        "jest-environment-node": "^29.7.0",
-        "jest-haste-map": "^29.7.0",
-        "jest-leak-detector": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-resolve": "^29.7.0",
-        "jest-runtime": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "jest-watcher": "^29.7.0",
-        "jest-worker": "^29.7.0",
-        "p-limit": "^3.1.0",
-        "source-map-support": "0.5.13"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-runtime": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
-      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "^29.7.0",
-        "@jest/fake-timers": "^29.7.0",
-        "@jest/globals": "^29.7.0",
-        "@jest/source-map": "^29.6.3",
-        "@jest/test-result": "^29.7.0",
-        "@jest/transform": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "cjs-module-lexer": "^1.0.0",
-        "collect-v8-coverage": "^1.0.0",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-mock": "^29.7.0",
-        "jest-regex-util": "^29.6.3",
-        "jest-resolve": "^29.7.0",
-        "jest-snapshot": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "slash": "^3.0.0",
-        "strip-bom": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-snapshot": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
-      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.11.6",
-        "@babel/generator": "^7.7.2",
-        "@babel/plugin-syntax-jsx": "^7.7.2",
-        "@babel/plugin-syntax-typescript": "^7.7.2",
-        "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^29.7.0",
-        "@jest/transform": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "babel-preset-current-node-syntax": "^1.0.0",
-        "chalk": "^4.0.0",
-        "expect": "^29.7.0",
-        "graceful-fs": "^4.2.9",
-        "jest-diff": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "jest-matcher-utils": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-util": "^29.7.0",
-        "natural-compare": "^1.4.0",
-        "pretty-format": "^29.7.0",
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-util/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-validate": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
-      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "camelcase": "^6.2.0",
-        "chalk": "^4.0.0",
-        "jest-get-type": "^29.6.3",
-        "leven": "^3.1.0",
-        "pretty-format": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-validate/node_modules/camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/jest-watcher": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
-      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/test-result": "^29.7.0",
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.0.0",
-        "emittery": "^0.13.1",
-        "jest-util": "^29.7.0",
-        "string-length": "^4.0.1"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-worker": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
-      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "jest-util": "^29.7.0",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/joi": {
@@ -14310,6 +14809,92 @@
       "engines": {
         "node": ">= 20"
       }
+    },
+    "node_modules/js-beautify": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-2.0.3.tgz",
+      "integrity": "sha512-cyFbh3tkPhknnTD/0bLf0T0yy2ZIbqL05mttzbt4y1Zfr7NxqXQZ62dkBLKs3oHH/lpjmDRAnciJiSUyOy8XwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^3.0.2",
+        "glob": "^13.0.6",
+        "js-cookie": "^3.0.8",
+        "nopt": "^10.0.1"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-beautify/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/js-beautify/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/js-beautify/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-beautify/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -14362,44 +14947,38 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
-      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "abab": "^2.0.6",
-        "acorn": "^8.8.1",
-        "acorn-globals": "^7.0.0",
-        "cssom": "^0.5.0",
-        "cssstyle": "^2.3.0",
-        "data-urls": "^3.0.2",
-        "decimal.js": "^10.4.2",
-        "domexception": "^4.0.0",
-        "escodegen": "^2.0.0",
-        "form-data": "^4.0.0",
-        "html-encoding-sniffer": "^3.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.1",
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.2",
-        "parse5": "^7.1.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.1.2",
-        "w3c-xmlserializer": "^4.0.0",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^2.0.0",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^11.0.0",
-        "ws": "^8.11.0",
-        "xml-name-validator": "^4.0.0"
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "canvas": "^2.5.0"
+        "canvas": "^3.0.0"
       },
       "peerDependenciesMeta": {
         "canvas": {
@@ -14407,40 +14986,38 @@
         }
       }
     },
-    "node_modules/jsdom/node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+    "node_modules/jsdom/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6"
+        "node": ">= 14"
       }
     },
-    "node_modules/jsdom/node_modules/tough-cookie": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+    "node_modules/jsdom/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
-      "license": "BSD-3-Clause",
+      "license": "MIT",
       "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
+        "agent-base": "^7.1.2",
+        "debug": "4"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">= 14"
       }
     },
-    "node_modules/jsdom/node_modules/universalify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+    "node_modules/jsdom/node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "dev": true,
-      "license": "MIT",
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/jsesc": {
@@ -14468,7 +15045,8 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-schema": {
       "version": "0.4.0",
@@ -14612,16 +15190,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/kleur": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/known-css-properties": {
       "version": "0.29.0",
       "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.29.0.tgz",
@@ -14659,16 +15227,6 @@
       "integrity": "sha512-tv754Ki2dXpPVApOrjTyRo4/QegVb9eVFq4mjqp4+NM5NaX7syQvN5BBNfV/ZpAHCEHV24XdUVrBAoka4jt3pA==",
       "license": "MIT"
     },
-    "node_modules/leven": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -14684,12 +15242,286 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "license": "MPL-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/linkify-plugin-mention": {
       "version": "4.3.3",
@@ -14976,6 +15808,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lowlight": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
@@ -15025,6 +15864,18 @@
         "url": "https://github.com/sponsors/sxzz"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -15042,9 +15893,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -15052,16 +15903,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/makeerror": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
-      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tmpl": "1.0.5"
       }
     },
     "node_modules/map-obj": {
@@ -16500,6 +17341,7 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -16564,6 +17406,16 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mitt": {
@@ -16683,9 +17535,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -16811,13 +17663,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
       }
-    },
-    "node_modules/node-int64": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/node-polyfill-webpack-plugin": {
       "version": "4.0.0",
@@ -17030,6 +17875,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/nopt": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-10.0.1.tgz",
+      "integrity": "sha512-df3sBr/6ax9hSGuC3CspvLlbnX8cP5L5nZwXF8cGN8l0zSWR6BvzmQ6jPUKjvo6+/xdpkNvEcucBNUdBeeV13g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^5.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
     "node_modules/normalize-package-data": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
@@ -17077,6 +17938,7 @@
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "path-key": "^3.0.0"
       },
@@ -17098,9 +17960,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.25",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.25.tgz",
-      "integrity": "sha512-kktSgNDIbyEIs/LrE6dtEMnfzxSDpXViFl6c4gFjz/CgtnL4GDCR3wyZXzjvAXsNB8dXU4dAfvIOgLMH2/vwLg==",
+      "version": "2.2.27",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.27.tgz",
+      "integrity": "sha512-gQPNF78qebCQ6tvVFBYrvJdBNOrYZm90ZlXgpIFm06p6qHDHq/XC4TnJftN6OMbxVE0UTBAoRgcsDeJBBooITw==",
       "dev": true,
       "license": "MIT"
     },
@@ -17283,6 +18145,7 @@
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -17464,6 +18327,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -17543,6 +18413,7 @@
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -17668,6 +18539,33 @@
       "integrity": "sha512-1gJ0WpNIiYcQydgg3Ed8KzvIqTsDpNwq+cjBCssvBtuTWjEqY1AW+i+OepiEMqDCzyro9B2sLAe4RBPajMYFiA==",
       "license": "ISC"
     },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
@@ -17692,6 +18590,16 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/pbkdf2": {
       "version": "3.1.6",
@@ -17761,16 +18669,6 @@
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pirates": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
-      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/pixelmatch": {
@@ -17914,9 +18812,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
       "funding": [
         {
           "type": "opencollective",
@@ -17933,7 +18831,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.18",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -18165,34 +19063,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/pretty-format": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -18210,20 +19080,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/prompts": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "kleur": "^3.0.3",
-        "sisteransi": "^1.0.5"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/property-information": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
@@ -18233,6 +19089,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/protobufjs": {
       "version": "7.6.4",
@@ -18293,29 +19156,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/psl": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/lupomontero"
-      }
-    },
-    "node_modules/psl/node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
@@ -18354,23 +19194,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/pure-rand": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
-      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/dubzzz"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fast-check"
-        }
-      ],
       "license": "MIT"
     },
     "node_modules/pvtsutils": {
@@ -18534,13 +19357,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/read-only-stream": {
       "version": "2.0.0",
@@ -19035,6 +19851,7 @@
       "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -19166,6 +19983,94 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.7.tgz",
+      "integrity": "sha512-g0EtLvBjTUB7jhyV0S/TCup3v/XSVl45vUIGbOGU4QPiyjTenCe4mKuFvW9fEgYmS2Fo42AUssRmNuMziXdrig==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@oxc-project/types": "=0.148.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm-eabi": "1.2.7",
+        "@rolldown/binding-android-arm64": "1.2.7",
+        "@rolldown/binding-darwin-arm64": "1.2.7",
+        "@rolldown/binding-darwin-x64": "1.2.7",
+        "@rolldown/binding-freebsd-x64": "1.2.7",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.7",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.7",
+        "@rolldown/binding-linux-arm64-musl": "1.2.7",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.7",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.7",
+        "@rolldown/binding-linux-x64-gnu": "1.2.7",
+        "@rolldown/binding-linux-x64-musl": "1.2.7",
+        "@rolldown/binding-openharmony-arm64": "1.2.7",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.7",
+        "@rolldown/binding-win32-x64-msvc": "1.2.7"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.1.tgz",
+      "integrity": "sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.1",
+        "@rollup/rollup-android-arm64": "4.63.1",
+        "@rollup/rollup-darwin-arm64": "4.63.1",
+        "@rollup/rollup-darwin-x64": "4.63.1",
+        "@rollup/rollup-freebsd-arm64": "4.63.1",
+        "@rollup/rollup-freebsd-x64": "4.63.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.1",
+        "@rollup/rollup-linux-arm64-musl": "4.63.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.1",
+        "@rollup/rollup-linux-loong64-musl": "4.63.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-musl": "4.63.1",
+        "@rollup/rollup-openbsd-x64": "4.63.1",
+        "@rollup/rollup-openharmony-arm64": "4.63.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.1",
+        "@rollup/rollup-win32-x64-gnu": "4.63.1",
+        "@rollup/rollup-win32-x64-msvc": "4.63.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/run-applescript": {
       "version": "7.1.0",
@@ -19898,12 +20803,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
@@ -19926,19 +20839,13 @@
       ],
       "license": "MIT"
     },
-    "node_modules/sisteransi": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -20002,27 +20909,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/source-map-support/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -20159,13 +21045,6 @@
         "vue": "^3.2.0"
       }
     },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ssh2": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
@@ -20219,28 +21098,12 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/stack-utils": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
-      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/stack-utils/node_modules/escape-string-regexp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",
@@ -20252,6 +21115,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -20338,20 +21208,6 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "node_modules/string-length": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
-      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "char-regex": "^1.0.2",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -20363,6 +21219,32 @@
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
       },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -20464,12 +21346,16 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-bom": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
       "engines": {
         "node": ">=8"
       }
@@ -20480,6 +21366,7 @@
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -20504,12 +21391,33 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/striptags": {
       "version": "3.2.0",
@@ -21088,7 +21996,7 @@
       "version": "5.48.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
       "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -21183,14 +22091,14 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/terser/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -21200,7 +22108,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -21208,42 +22116,119 @@
       }
     },
     "node_modules/test-exclude": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
-      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
-        "glob": "^7.1.4",
-        "minimatch": "^3.0.4"
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       }
     },
-    "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
-        "node": "*"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/text-table": {
@@ -21303,6 +22288,20 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -21348,13 +22347,42 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.6.tgz",
+      "integrity": "sha512-u8KszXvGfU68hVcZpRHKG28T0krMuv2G5nDhiHaMLen/gIuFEgIJhaJuO69qjnXg5paSrbPMFfx3brNuN8eVSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tldts": {
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
       "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tldts-core": "^6.1.86"
       },
@@ -21367,8 +22395,7 @@
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
       "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tmp": {
       "version": "0.2.7",
@@ -21380,13 +22407,6 @@
       "engines": {
         "node": ">=14.14"
       }
-    },
-    "node_modules/tmpl": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
-      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/to-buffer": {
       "version": "1.2.2",
@@ -21446,7 +22466,6 @@
       "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "tldts": "^6.1.32"
       },
@@ -21455,16 +22474,16 @@
       }
     },
     "node_modules/tr46": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "punycode": "^2.1.1"
+        "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/tr46/node_modules/punycode": {
@@ -21729,16 +22748,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/type-fest": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
@@ -21929,7 +22938,7 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -22368,21 +23377,6 @@
         "uuid": "dist-node/bin/uuid"
       }
     },
-    "node_modules/v8-to-istanbul": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
-      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.12",
-        "@types/istanbul-lib-coverage": "^2.0.1",
-        "convert-source-map": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.12.0"
-      }
-    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -22470,6 +23464,228 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/vm-browserify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
@@ -22497,6 +23713,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vue-component-type-helpers": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.3.11.tgz",
+      "integrity": "sha512-LwcxzeliO9fkQcpJG0PoX8X5kmAhKmH9wkpDLxNabwzkQ9Zeib2YVHwFV4pcWmMLfXVfjr/dSV+DaJ3cIPgSNA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vue-eslint-parser": {
       "version": "9.4.3",
@@ -22642,16 +23865,26 @@
       }
     },
     "node_modules/w3c-xmlserializer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
-      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "xml-name-validator": "^4.0.0"
+        "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
+      }
+    },
+    "node_modules/w3c-xmlserializer/node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/wait-on": {
@@ -22672,16 +23905,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/walker": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
-      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "makeerror": "1.0.12"
       }
     },
     "node_modules/watchify": {
@@ -23345,9 +24568,9 @@
       }
     },
     "node_modules/whatwg-encoding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
-      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
       "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
       "dev": true,
       "license": "MIT",
@@ -23355,7 +24578,7 @@
         "iconv-lite": "0.6.3"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/whatwg-encoding/node_modules/iconv-lite": {
@@ -23372,27 +24595,27 @@
       }
     },
     "node_modules/whatwg-mimetype": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/whatwg-url": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tr46": "^3.0.0",
+        "tr46": "^5.1.0",
         "webidl-conversions": "^7.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -23507,6 +24730,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wildcard": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
@@ -23539,6 +24779,25 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -23622,20 +24881,6 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/write-file-atomic": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.7"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
     },
     "node_modules/ws": {
       "version": "8.21.0",

--- a/package.json
+++ b/package.json
@@ -16,16 +16,17 @@
     "watch": "NODE_ENV=development webpack --progress --watch --config webpack.common.js",
     "build": "NODE_ENV=production webpack --progress --config webpack.common.js",
     "serve": "NODE_ENV=development webpack serve --progress --config webpack.common.js",
-    "lint": "eslint --ext .js,.vue src",
-    "lint:fix": "eslint --ext .js,.vue src --fix",
+    "lint": "eslint --ext .js,.vue src tests/js",
+    "lint:fix": "eslint --ext .js,.vue src tests/js --fix",
     "stylelint": "stylelint src",
     "stylelint:fix": "stylelint src --fix",
-    "test": "jest",
-    "test:coverage": "jest --coverage",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "cypress": "cypress run --e2e",
     "cypress:e2e": "cypress run --e2e",
     "cypress:gui": "cypress open",
-    "precypress:update-snapshots": "TESTING=true npm run dev"
+    "precypress:update-snapshots": "TESTING=true npm run dev",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@nextcloud/auth": "^2.0.0",
@@ -75,7 +76,10 @@
     "@nextcloud/eslint-config": "^8.4.2",
     "@nextcloud/stylelint-config": "^2.3.0",
     "@nextcloud/webpack-vue-config": "^6.0.0",
+    "@vitejs/plugin-vue": "^5.2.4",
+    "@vitest/coverage-v8": "^3.2.7",
     "@vue/compiler-sfc": "^3.5.35",
+    "@vue/test-utils": "^2.5.0",
     "babel-loader": "^10.1.1",
     "copy-webpack-plugin": "^14.0.0",
     "css-loader": "^7.1.4",
@@ -86,12 +90,12 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-n": "^16.0.0",
     "eslint-plugin-vue": "^9.33.0",
-    "jest": "^29.5.0",
-    "jest-environment-jsdom": "^29.7.0",
+    "jsdom": "^26.1.0",
     "node-polyfill-webpack-plugin": "^4.0.0",
     "sass-loader": "^16.0.8",
     "style-loader": "^4.0.0",
     "ts-loader": "^9.5.7",
+    "vitest": "^3.2.7",
     "vue-loader": "^17.4.2",
     "wait-on": "^7.0.1",
     "webpack": "^5.106.2",
@@ -102,17 +106,5 @@
     "fast-xml-parser": ">=5.7.0",
     "joi": ">=18.2.1",
     "@nextcloud/axios": "2.5.2"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "vue"
-    ],
-    "moduleNameMapper": {
-      "^@/(.*)$": "<rootDir>/src/$1"
-    },
-    "transform": {
-      "^.+\\.js$": "<rootDir>/node_modules/babel-jest"
-    }
   }
 }

--- a/tests/APTest.php
+++ b/tests/APTest.php
@@ -1,0 +1,332 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests;
+
+use OCA\Social\AP;
+use OCA\Social\Exceptions\ItemUnknownException;
+use OCA\Social\Exceptions\RedundancyLimitException;
+use OCA\Social\Interfaces\Activity\AcceptInterface;
+use OCA\Social\Interfaces\Activity\AddInterface;
+use OCA\Social\Interfaces\Activity\BlockInterface;
+use OCA\Social\Interfaces\Activity\CreateInterface;
+use OCA\Social\Interfaces\Activity\DeleteInterface;
+use OCA\Social\Interfaces\Activity\MoveInterface;
+use OCA\Social\Interfaces\Activity\RejectInterface;
+use OCA\Social\Interfaces\Activity\RemoveInterface;
+use OCA\Social\Interfaces\Activity\UndoInterface;
+use OCA\Social\Interfaces\Activity\UpdateInterface;
+use OCA\Social\Interfaces\Actor\PersonInterface;
+use OCA\Social\Interfaces\Actor\ServiceInterface;
+use OCA\Social\Interfaces\Internal\SocialAppNotificationInterface;
+use OCA\Social\Interfaces\Object\AnnounceInterface;
+use OCA\Social\Interfaces\Object\DocumentInterface;
+use OCA\Social\Interfaces\Object\FollowInterface;
+use OCA\Social\Interfaces\Object\ImageInterface;
+use OCA\Social\Interfaces\Object\LikeInterface;
+use OCA\Social\Interfaces\Object\NoteInterface;
+use OCA\Social\Model\ActivityPub\Activity\Accept;
+use OCA\Social\Model\ActivityPub\Activity\Add;
+use OCA\Social\Model\ActivityPub\Activity\Block;
+use OCA\Social\Model\ActivityPub\Activity\Create;
+use OCA\Social\Model\ActivityPub\Activity\Delete;
+use OCA\Social\Model\ActivityPub\Activity\Move;
+use OCA\Social\Model\ActivityPub\Activity\Reject;
+use OCA\Social\Model\ActivityPub\Activity\Remove;
+use OCA\Social\Model\ActivityPub\Activity\Undo;
+use OCA\Social\Model\ActivityPub\Activity\Update;
+use OCA\Social\Model\ActivityPub\Actor\Application;
+use OCA\Social\Model\ActivityPub\Actor\Group;
+use OCA\Social\Model\ActivityPub\Actor\Organization;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Actor\Service;
+use OCA\Social\Model\ActivityPub\Internal\SocialAppNotification;
+use OCA\Social\Model\ActivityPub\Object\Announce;
+use OCA\Social\Model\ActivityPub\Object\Document;
+use OCA\Social\Model\ActivityPub\Object\Follow;
+use OCA\Social\Model\ActivityPub\Object\Image;
+use OCA\Social\Model\ActivityPub\Object\Like;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Model\ActivityPub\Object\Tombstone;
+use OCA\Social\Model\ActivityPub\OrderedCollection;
+use OCA\Social\Model\ActivityPub\Stream;
+use OCA\Social\Tests\Model\TActivityPubMocks;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/Model/TActivityPubMocks.php';
+
+class APTest extends TestCase {
+	use TActivityPubMocks;
+
+	private AP $ap;
+
+	protected function setUp(): void {
+		$this->ap = $this->installActivityPub();
+		// Stream::import() always resolves the URL generator, even without attachments
+		\OC::$server->register(IURLGenerator::class, $this->createMock(IURLGenerator::class));
+	}
+
+	protected function tearDown(): void {
+		AP::$activityPub = null;
+		\OC::$server->reset();
+	}
+
+	public function knownTypeProvider(): array {
+		return [
+			'Accept' => ['Accept', Accept::class],
+			'Add' => ['Add', Add::class],
+			'Announce' => ['Announce', Announce::class],
+			'Block' => ['Block', Block::class],
+			'Move' => ['Move', Move::class],
+			'Create' => ['Create', Create::class],
+			'Delete' => ['Delete', Delete::class],
+			'Document' => ['Document', Document::class],
+			'Follow' => ['Follow', Follow::class],
+			'Image' => ['Image', Image::class],
+			'Like' => ['Like', Like::class],
+			'Note' => ['Note', Note::class],
+			'OrderedCollection' => ['OrderedCollection', OrderedCollection::class],
+			'SocialAppNotification' => ['SocialAppNotification', SocialAppNotification::class],
+			'Stream' => ['Stream', Stream::class],
+			'Person' => ['Person', Person::class],
+			'Reject' => ['Reject', Reject::class],
+			'Remove' => ['Remove', Remove::class],
+			'Service' => ['Service', Service::class],
+			'Group' => ['Group', Group::class],
+			'Organization' => ['Organization', Organization::class],
+			'Application' => ['Application', Application::class],
+			'Tombstone' => ['Tombstone', Tombstone::class],
+			'Undo' => ['Undo', Undo::class],
+			'Update' => ['Update', Update::class],
+		];
+	}
+
+	/**
+	 * @dataProvider knownTypeProvider
+	 */
+	public function testGetItemFromTypeMapsEveryKnownType(string $type, string $class): void {
+		$item = $this->ap->getItemFromType($type);
+
+		$this->assertInstanceOf($class, $item);
+		$this->assertSame(self::cloudUrl(), $item->getUrlCloud());
+	}
+
+	public function unknownTypeProvider(): array {
+		return [
+			'unsupported AS2 type' => ['Question'],
+			'empty' => [''],
+			'wrong case' => ['note'],
+		];
+	}
+
+	/**
+	 * @dataProvider unknownTypeProvider
+	 */
+	public function testGetItemFromTypeRejectsUnknownTypes(string $type): void {
+		$this->expectException(ItemUnknownException::class);
+
+		$this->ap->getItemFromType($type);
+	}
+
+	public function testOnlyAnnouncesAreMarkedToFilterDuplicates(): void {
+		/** @var Announce $announce */
+		$announce = $this->ap->getItemFromType('Announce');
+		/** @var Note $note */
+		$note = $this->ap->getItemFromType('Note');
+
+		$this->assertTrue($announce->isFilterDuplicate());
+		$this->assertFalse($note->isFilterDuplicate());
+	}
+
+	public function interfaceProvider(): array {
+		return [
+			'Accept' => ['Accept', AcceptInterface::class],
+			'Add' => ['Add', AddInterface::class],
+			'Announce' => ['Announce', AnnounceInterface::class],
+			'Block' => ['Block', BlockInterface::class],
+			'Create' => ['Create', CreateInterface::class],
+			'Delete' => ['Delete', DeleteInterface::class],
+			'Document' => ['Document', DocumentInterface::class],
+			'Follow' => ['Follow', FollowInterface::class],
+			'Image' => ['Image', ImageInterface::class],
+			'Like' => ['Like', LikeInterface::class],
+			'Move' => ['Move', MoveInterface::class],
+			'Note' => ['Note', NoteInterface::class],
+			'SocialAppNotification' => ['SocialAppNotification', SocialAppNotificationInterface::class],
+			'Person' => ['Person', PersonInterface::class],
+			'Reject' => ['Reject', RejectInterface::class],
+			'Remove' => ['Remove', RemoveInterface::class],
+			'Service' => ['Service', ServiceInterface::class],
+			'Undo' => ['Undo', UndoInterface::class],
+			'Update' => ['Update', UpdateInterface::class],
+		];
+	}
+
+	/**
+	 * @dataProvider interfaceProvider
+	 */
+	public function testGetInterfaceFromTypeReturnsTheInjectedInterface(string $type, string $interfaceClass): void {
+		$this->assertSame($this->apInterface($interfaceClass), $this->ap->getInterfaceFromType($type));
+	}
+
+	public function testGetInterfaceFromTypeRejectsUnknownTypes(): void {
+		$this->expectException(ItemUnknownException::class);
+
+		$this->ap->getInterfaceFromType('Question');
+	}
+
+	public function testGetInterfaceForItemDispatchesOnTheItemType(): void {
+		$this->assertSame($this->apInterface(LikeInterface::class), $this->ap->getInterfaceForItem(new Like()));
+		$this->assertSame($this->apInterface(NoteInterface::class), $this->ap->getInterfaceForItem(new Note()));
+	}
+
+	public function actorProvider(): array {
+		return [
+			'Person' => [new Person(), true],
+			'Service' => [new Service(), true],
+			'Group' => [new Group(), true],
+			'Organization' => [new Organization(), true],
+			'Application' => [new Application(), true],
+			'Note' => [new Note(), false],
+			'Create' => [new Create(), false],
+			'Document' => [new Document(), false],
+		];
+	}
+
+	/**
+	 * @dataProvider actorProvider
+	 */
+	public function testIsActorRecognisesTheFiveActorTypes(object $item, bool $expected): void {
+		$this->assertSame($expected, $this->ap->isActor($item));
+	}
+
+	public function testGetSimpleItemFromDataImportsAndKeepsTheRawSource(): void {
+		$data = [
+			'id' => 'https://mastodon.social/users/alice#likes/1',
+			'type' => 'Like',
+			'actor' => 'https://mastodon.social/users/alice',
+			'object' => 'https://cloud.example.org/@bob/status/2',
+		];
+
+		$item = $this->ap->getSimpleItemFromData($data);
+
+		$this->assertInstanceOf(Like::class, $item);
+		$this->assertSame('https://mastodon.social/users/alice#likes/1', $item->getId());
+		$this->assertSame('https://mastodon.social/users/alice', $item->getActorId());
+		$this->assertSame('https://cloud.example.org/@bob/status/2', $item->getObjectId());
+		$this->assertSame(json_encode($data, JSON_UNESCAPED_SLASHES), $item->getSource());
+	}
+
+	public function testNestedObjectIsParsedRecursivelyAndLinkedToItsParent(): void {
+		$item = $this->ap->getItemFromData([
+			'id' => 'https://mastodon.social/users/alice/statuses/1/activity',
+			'type' => 'Create',
+			'actor' => 'https://mastodon.social/users/alice',
+			'object' => [
+				'id' => 'https://mastodon.social/users/alice/statuses/1',
+				'type' => 'Note',
+				'content' => '<p>hello</p>',
+				'attributedTo' => 'https://mastodon.social/users/alice',
+			],
+		]);
+
+		$this->assertInstanceOf(Create::class, $item);
+		$this->assertTrue($item->hasObject());
+		$note = $item->getObject();
+		$this->assertInstanceOf(Note::class, $note);
+		$this->assertSame('<p>hello</p>', $note->getContent());
+		$this->assertSame($item, $note->getParent());
+		$this->assertSame($item, $note->getRoot());
+		$this->assertSame('https://mastodon.social/users/alice/statuses/1', $item->getObjectId());
+		$this->assertTrue($item->isRoot());
+	}
+
+	public function testObjectGivenAsAnIdOnlySetsTheObjectId(): void {
+		$item = $this->ap->getItemFromData([
+			'id' => 'https://mastodon.social/users/alice#follows/1',
+			'type' => 'Follow',
+			'actor' => 'https://mastodon.social/users/alice',
+			'object' => 'https://cloud.example.org/@bob',
+		]);
+
+		$this->assertFalse($item->hasObject());
+		$this->assertSame('https://cloud.example.org/@bob', $item->getObjectId());
+	}
+
+	public function testNestedObjectOfUnknownTypeIsDropped(): void {
+		$item = $this->ap->getItemFromData([
+			'id' => 'https://mastodon.social/users/alice/statuses/1/activity',
+			'type' => 'Create',
+			'object' => [
+				'id' => 'https://mastodon.social/users/alice/statuses/1',
+				'type' => 'Question',
+			],
+		]);
+
+		$this->assertFalse($item->hasObject());
+		$this->assertSame('', $item->getObjectId());
+	}
+
+	public function testActorInfoIsParsedIntoTheActor(): void {
+		$item = $this->ap->getItemFromData([
+			'id' => 'https://mastodon.social/users/alice#likes/1',
+			'type' => 'Like',
+			'actor' => 'https://mastodon.social/users/alice',
+			'object' => 'https://cloud.example.org/@bob/status/2',
+			'actor_info' => [
+				'id' => 'https://mastodon.social/users/alice',
+				'type' => 'Person',
+				'preferredUsername' => 'alice',
+				'inbox' => 'https://mastodon.social/users/alice/inbox',
+			],
+		]);
+
+		$this->assertTrue($item->hasActor());
+		$actor = $item->getActor();
+		$this->assertInstanceOf(Person::class, $actor);
+		$this->assertSame('alice', $actor->getPreferredUsername());
+		$this->assertSame('https://mastodon.social/users/alice', $item->getActorId());
+		$this->assertSame($item, $actor->getParent());
+	}
+
+	public function testGivenParentIsAttached(): void {
+		$parent = new Create();
+
+		$item = $this->ap->getItemFromData(['type' => 'Like', 'id' => 'https://a.example/l/1'], $parent);
+
+		$this->assertSame($parent, $item->getParent());
+	}
+
+	private function nestedAccepts(int $depth): array {
+		$data = ['type' => 'Accept', 'id' => 'https://a.example/accept/0'];
+		for ($i = 1; $i <= $depth; $i++) {
+			$data = ['type' => 'Accept', 'id' => 'https://a.example/accept/' . $i, 'object' => $data];
+		}
+
+		return $data;
+	}
+
+	public function testNestingUpToTheRedundancyLimitIsAccepted(): void {
+		$item = $this->ap->getItemFromData($this->nestedAccepts(AP::REDUNDANCY_LIMIT - 1));
+
+		$depth = 1;
+		while ($item->hasObject()) {
+			$item = $item->getObject();
+			$depth++;
+		}
+		$this->assertSame(AP::REDUNDANCY_LIMIT, $depth);
+	}
+
+	public function testNestingBeyondTheRedundancyLimitIsRejected(): void {
+		$this->expectException(RedundancyLimitException::class);
+
+		$this->ap->getItemFromData($this->nestedAccepts(AP::REDUNDANCY_LIMIT));
+	}
+}

--- a/tests/AppInfo/ApplicationTest.php
+++ b/tests/AppInfo/ApplicationTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\AppInfo;
+
+use OCA\Social\AppInfo\Application;
+use OCA\Social\Dashboard\SocialTimelineWidget;
+use OCA\Social\Dashboard\SocialWidget;
+use OCA\Social\Listeners\ProfileSectionListener;
+use OCA\Social\Listeners\UserAccountListener;
+use OCA\Social\Notification\Notifier;
+use OCA\Social\Search\UnifiedSearchProvider;
+use OCA\Social\WellKnown\WebfingerHandler;
+use OCP\Accounts\UserUpdatedEvent;
+use OCP\AppFramework\Bootstrap\IBootContext;
+use OCP\AppFramework\Bootstrap\IBootstrap;
+use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\Profile\BeforeTemplateRenderedEvent;
+use PHPUnit\Framework\TestCase;
+
+class ApplicationTest extends TestCase {
+	/**
+	 * App::__construct() needs the server container, so the bootstrap methods
+	 * are exercised on an instance created without it.
+	 */
+	private function application(): Application {
+		return (new \ReflectionClass(Application::class))->newInstanceWithoutConstructor();
+	}
+
+	public function testIsABootstrappedAppNamedSocial(): void {
+		$this->assertInstanceOf(IBootstrap::class, $this->application());
+		$this->assertSame('social', Application::APP_ID);
+		$this->assertSame('Social', Application::APP_NAME);
+	}
+
+	public function testRegisterWiresUpEveryIntegrationPoint(): void {
+		$context = $this->createMock(IRegistrationContext::class);
+		$context->expects($this->once())->method('registerSearchProvider')->with(UnifiedSearchProvider::class);
+		$context->expects($this->once())->method('registerWellKnownHandler')->with(WebfingerHandler::class);
+		$context->expects($this->once())->method('registerNotifierService')->with(Notifier::class);
+
+		$listeners = [];
+		$context->expects($this->exactly(2))->method('registerEventListener')
+			->willReturnCallback(function (string $event, string $listener) use (&$listeners): void {
+				$listeners[$event] = $listener;
+			});
+		$widgets = [];
+		$context->expects($this->exactly(2))->method('registerDashboardWidget')
+			->willReturnCallback(function (string $widget) use (&$widgets): void {
+				$widgets[] = $widget;
+			});
+
+		$this->application()->register($context);
+
+		$this->assertSame([
+			BeforeTemplateRenderedEvent::class => ProfileSectionListener::class,
+			UserUpdatedEvent::class => UserAccountListener::class,
+		], $listeners);
+		$this->assertSame([SocialWidget::class, SocialTimelineWidget::class], $widgets);
+	}
+
+	public function testRegisterDoesNotTouchOtherRegistrationApis(): void {
+		$context = $this->createMock(IRegistrationContext::class);
+		$context->expects($this->never())->method('registerMiddleware');
+		$context->expects($this->never())->method('registerService');
+		$context->expects($this->never())->method('registerCapability');
+
+		$this->application()->register($context);
+	}
+
+	public function testBootDoesNothing(): void {
+		$context = $this->createMock(IBootContext::class);
+		$context->expects($this->never())->method($this->anything());
+
+		$this->application()->boot($context);
+	}
+}

--- a/tests/Command/CommandsTest.php
+++ b/tests/Command/CommandsTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The occ commands (lib/Command/*) extend the server-internal
+ * OC\Core\Command\Base, itself a Symfony Console command. Neither the server
+ * nor symfony/console is part of this standalone harness, so the command
+ * classes cannot even be autoloaded here (a fatal, not an exception), and
+ * Symfony's CommandTester is unavailable. This placeholder documents the gap.
+ */
+class CommandsTest extends TestCase {
+	public function testCommandsNeedTheServerAndSymfonyConsole(): void {
+		if (class_exists(\OC\Core\Command\Base::class) && class_exists(\Symfony\Component\Console\Tester\CommandTester::class)) {
+			$this->fail('The command dependencies are now available: write the tests/Command/*Test.php suite.');
+		}
+
+		$this->markTestSkipped('OC\Core\Command\Base and symfony/console are not available in the unit-test harness.');
+	}
+}

--- a/tests/Controller/ActivityPubControllerTest.php
+++ b/tests/Controller/ActivityPubControllerTest.php
@@ -1,0 +1,538 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Controller;
+
+use OCA\Social\Controller\ActivityPubController;
+use OCA\Social\Controller\SocialPubController;
+use OCA\Social\Exceptions\AccountDoesNotExistException;
+use OCA\Social\Exceptions\CacheActorDoesNotExistException;
+use OCA\Social\Exceptions\ItemUnknownException;
+use OCA\Social\Exceptions\SignatureException;
+use OCA\Social\Exceptions\SignatureIsGoneException;
+use OCA\Social\Exceptions\StreamNotFoundException;
+use OCA\Social\Exceptions\UnauthorizedFediverseException;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\OrderedCollection;
+use OCA\Social\Model\ActivityPub\Stream;
+use OCA\Social\Service\AccountService;
+use OCA\Social\Service\CacheActorService;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\FediverseService;
+use OCA\Social\Service\FollowService;
+use OCA\Social\Service\ImportService;
+use OCA\Social\Service\SignatureService;
+use OCA\Social\Service\StreamQueueService;
+use OCA\Social\Service\StreamService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IInitialStateService;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * TAsync::async() closes PHPUnit's output buffer and sends headers; the
+ * controller under test is subclassed so the call is recorded instead.
+ */
+class AsyncFreeActivityPubController extends ActivityPubController {
+	public int $asyncCalls = 0;
+
+	public function async(string $result = ''): void {
+		$this->asyncCalls++;
+	}
+}
+
+class ActivityPubControllerTest extends TestCase {
+	private const SOCIAL_URL = 'https://cloud.example/apps/social/';
+	private const LD_JSON = 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"';
+
+	/** @var IRequest&MockObject */
+	private $request;
+	/** @var SocialPubController&MockObject */
+	private $socialPubController;
+	/** @var FediverseService&MockObject */
+	private $fediverseService;
+	/** @var CacheActorService&MockObject */
+	private $cacheActorService;
+	/** @var SignatureService&MockObject */
+	private $signatureService;
+	/** @var StreamQueueService&MockObject */
+	private $streamQueueService;
+	/** @var ImportService&MockObject */
+	private $importService;
+	/** @var AccountService&MockObject */
+	private $accountService;
+	/** @var FollowService&MockObject */
+	private $followService;
+	/** @var StreamService&MockObject */
+	private $streamService;
+	/** @var ConfigService&MockObject */
+	private $configService;
+	/** @var IInitialStateService&MockObject */
+	private $initialStateService;
+	private AsyncFreeActivityPubController $controller;
+
+	protected function setUp(): void {
+		$this->request = $this->createMock(IRequest::class);
+		$this->socialPubController = $this->createMock(SocialPubController::class);
+		$this->fediverseService = $this->createMock(FediverseService::class);
+		$this->cacheActorService = $this->createMock(CacheActorService::class);
+		$this->signatureService = $this->createMock(SignatureService::class);
+		$this->streamQueueService = $this->createMock(StreamQueueService::class);
+		$this->importService = $this->createMock(ImportService::class);
+		$this->accountService = $this->createMock(AccountService::class);
+		$this->followService = $this->createMock(FollowService::class);
+		$this->streamService = $this->createMock(StreamService::class);
+		$this->configService = $this->createMock(ConfigService::class);
+		$this->initialStateService = $this->createMock(IInitialStateService::class);
+
+		$this->configService->method('getSocialUrl')->willReturn(self::SOCIAL_URL);
+
+		// Response::getHeaders() stamps X-Request-Id from the container's request
+		\OC::$server->register(IRequest::class, $this->request);
+
+		$this->controller = new AsyncFreeActivityPubController(
+			$this->request,
+			$this->socialPubController,
+			$this->fediverseService,
+			$this->cacheActorService,
+			$this->signatureService,
+			$this->streamQueueService,
+			$this->importService,
+			$this->accountService,
+			$this->followService,
+			$this->streamService,
+			$this->configService,
+			$this->initialStateService,
+			new NullLogger()
+		);
+	}
+
+	protected function tearDown(): void {
+		\OC::$server->reset();
+	}
+
+	private function acceptHeader(string $accept): void {
+		$this->request->method('getHeader')->with('Accept')->willReturn($accept);
+	}
+
+	/** @return Person&MockObject */
+	private function localActor(string $username, ?Person $actor = null): Person {
+		$actor ??= $this->createMock(Person::class);
+		$this->cacheActorService->method('getFromLocalAccount')->with($username)->willReturn($actor);
+
+		return $actor;
+	}
+
+	private function assertActivityPubResponse(DataResponse $response, object $expectedData): void {
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($expectedData, $response->getData());
+		$this->assertSame(self::LD_JSON, $response->getHeaders()['Content-Type']);
+	}
+
+	private function assertFailure(DataResponse $response, string $exceptionClass, int $status = Http::STATUS_INTERNAL_SERVER_ERROR): void {
+		$this->assertSame($status, $response->getStatus());
+		$data = $response->getData();
+		$this->assertSame(-1, $data['status']);
+		$this->assertSame($exceptionClass, $data['exception']);
+	}
+
+
+	// actor()
+
+	/** @return iterable<string, array{string}> */
+	public function activityStreamsAcceptHeaders(): iterable {
+		yield 'activity+json' => ['application/activity+json'];
+		yield 'ld+json with profile' => ['application/ld+json; profile="https://www.w3.org/ns/activitystreams"'];
+		yield 'ld+json among other types' => ['text/html, application/ld+json;q=0.9'];
+		yield 'whitespace around type' => [' application/activity+json '];
+	}
+
+	/** @dataProvider activityStreamsAcceptHeaders */
+	public function testActorReturnsActivityPubJsonForActivityStreamsClients(string $accept): void {
+		$this->acceptHeader($accept);
+		$actor = $this->localActor('alice');
+		$actor->expects($this->once())->method('setDisplayW3ContextSecurity')->with(true);
+		$this->socialPubController->expects($this->never())->method('actor');
+
+		$response = $this->controller->actor('alice');
+
+		$this->assertActivityPubResponse($response, $actor);
+	}
+
+	/** @return iterable<string, array{string}> */
+	public function humanAcceptHeaders(): iterable {
+		yield 'browser' => ['text/html,application/xhtml+xml,*/*;q=0.8'];
+		yield 'plain json' => ['application/json'];
+		yield 'no header' => [''];
+	}
+
+	/** @dataProvider humanAcceptHeaders */
+	public function testActorFallsBackToPublicPageForBrowsers(string $accept): void {
+		$this->acceptHeader($accept);
+		$page = new TemplateResponse('social', 'main');
+		$this->socialPubController->expects($this->once())->method('actor')->with('alice')->willReturn($page);
+		$this->cacheActorService->expects($this->never())->method('getFromLocalAccount');
+
+		$this->assertSame($page, $this->controller->actor('alice'));
+	}
+
+	public function testActorAliasBehavesLikeActor(): void {
+		$this->acceptHeader('application/activity+json');
+		$actor = $this->localActor('alice');
+
+		$this->assertActivityPubResponse($this->controller->actorAlias('alice'), $actor);
+	}
+
+	public function testActorAliasFallsBackToPublicPageForBrowsers(): void {
+		$this->acceptHeader('text/html');
+		$page = new TemplateResponse('social', 'main');
+		$this->socialPubController->method('actor')->with('bob')->willReturn($page);
+
+		$this->assertSame($page, $this->controller->actorAlias('bob'));
+	}
+
+	public function testUnknownActorIsA404(): void {
+		$this->acceptHeader('application/activity+json');
+		$this->cacheActorService->method('getFromLocalAccount')
+			->willThrowException(new CacheActorDoesNotExistException('nope'));
+
+		$response = $this->controller->actor('ghost');
+
+		$this->assertFailure($response, CacheActorDoesNotExistException::class, Http::STATUS_NOT_FOUND);
+		$this->assertSame('nope', $response->getData()['message']);
+	}
+
+
+	// sharedInbox() / inbox()
+
+	private function signedRequestFrom(string $origin, int $time = 1700000000): void {
+		$this->signatureService->method('checkRequest')
+			->willReturnCallback(function (IRequest $request, string $body, int &$requestTime) use ($origin, $time): string {
+				$requestTime = $time;
+
+				return $origin;
+			});
+	}
+
+	/** @return ACore&MockObject */
+	private function incomingActivity(string $token = 'req-token'): ACore {
+		$activity = $this->createMock(ACore::class);
+		$activity->method('getRequestToken')->willReturn($token);
+		$this->importService->method('importFromJson')->willReturn($activity);
+
+		return $activity;
+	}
+
+	public function testSharedInboxRejectsRequestsWithInvalidSignature(): void {
+		$this->signatureService->method('checkRequest')->willThrowException(new SignatureException('bad signature'));
+		$this->importService->expects($this->never())->method('importFromJson');
+		$this->importService->expects($this->never())->method('parseIncomingRequest');
+
+		$response = $this->controller->sharedInbox();
+
+		$this->assertFailure($response, SignatureException::class);
+		$this->assertSame('bad signature', $response->getData()['message']);
+		$this->assertSame(0, $this->controller->asyncCalls);
+	}
+
+	public function testSharedInboxAcknowledgesActivitiesFromGoneActorsWithoutImporting(): void {
+		$this->signatureService->method('checkRequest')->willThrowException(new SignatureIsGoneException());
+		$this->importService->expects($this->never())->method('importFromJson');
+
+		$response = $this->controller->sharedInbox();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['result' => [], 'status' => 1], $response->getData());
+	}
+
+	public function testSharedInboxRejectsUnauthorizedInstances(): void {
+		$this->signedRequestFrom('https://blocked.example');
+		$this->fediverseService->method('authorized')->with('https://blocked.example')
+			->willThrowException(new UnauthorizedFediverseException('blocked'));
+		$this->importService->expects($this->never())->method('importFromJson');
+
+		$this->assertFailure($this->controller->sharedInbox(), UnauthorizedFediverseException::class);
+	}
+
+	public function testSharedInboxImportsTheActivityAndTagsItsOrigin(): void {
+		$this->signedRequestFrom('https://remote.example', 1234);
+		$this->fediverseService->expects($this->once())->method('authorized')->with('https://remote.example')->willReturn(true);
+		$activity = $this->incomingActivity('tok-1');
+		$this->signatureService->method('checkObject')->with($activity)->willReturn(false);
+		$activity->expects($this->once())->method('setOrigin')
+			->with('https://remote.example', SignatureService::ORIGIN_HEADER, 1234);
+		$this->importService->expects($this->once())->method('parseIncomingRequest')->with($activity);
+		$this->streamQueueService->expects($this->once())->method('cacheStreamByToken')->with('tok-1');
+
+		$response = $this->controller->sharedInbox();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(1, $response->getData()['status']);
+		$this->assertSame(1, $this->controller->asyncCalls, 'response is flushed before the queue is processed');
+	}
+
+	public function testSharedInboxKeepsLinkedDataSignatureOriginWhenPresent(): void {
+		$this->signedRequestFrom('https://remote.example');
+		$activity = $this->incomingActivity();
+		$this->signatureService->method('checkObject')->willReturn(true);
+		$activity->expects($this->never())->method('setOrigin');
+
+		$this->assertSame(Http::STATUS_OK, $this->controller->sharedInbox()->getStatus());
+	}
+
+	public function testSharedInboxIgnoresUnknownActivityTypes(): void {
+		$this->signedRequestFrom('https://remote.example');
+		$this->incomingActivity('tok-2');
+		$this->importService->method('parseIncomingRequest')->willThrowException(new ItemUnknownException());
+		$this->streamQueueService->expects($this->once())->method('cacheStreamByToken')->with('tok-2');
+
+		$response = $this->controller->sharedInbox();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(1, $response->getData()['status']);
+	}
+
+	public function testInboxRejectsRequestsWithInvalidSignature(): void {
+		$this->signatureService->method('checkRequest')->willThrowException(new SignatureException('bad'));
+		$this->cacheActorService->expects($this->never())->method('getFromLocalAccount');
+		$this->importService->expects($this->never())->method('importFromJson');
+
+		$this->assertFailure($this->controller->inbox('alice'), SignatureException::class);
+	}
+
+	public function testInboxFailsForUnknownLocalUser(): void {
+		$this->signedRequestFrom('https://remote.example');
+		$this->cacheActorService->method('getFromLocalAccount')->with('ghost')
+			->willThrowException(new CacheActorDoesNotExistException());
+		$this->importService->expects($this->never())->method('importFromJson');
+
+		$this->assertFailure($this->controller->inbox('ghost'), CacheActorDoesNotExistException::class);
+	}
+
+	public function testInboxImportsActivityForExistingLocalUser(): void {
+		$this->signedRequestFrom('https://remote.example', 99);
+		$this->localActor('alice');
+		$activity = $this->incomingActivity('tok-3');
+		$this->signatureService->method('checkObject')->willReturn(false);
+		$activity->expects($this->once())->method('setOrigin')->with('https://remote.example', SignatureService::ORIGIN_HEADER, 99);
+		$this->importService->expects($this->once())->method('parseIncomingRequest')->with($activity);
+		$this->streamQueueService->expects($this->once())->method('cacheStreamByToken')->with('tok-3');
+
+		$response = $this->controller->inbox('alice');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(1, $this->controller->asyncCalls);
+	}
+
+	public function testInboxAcknowledgesGoneSignatures(): void {
+		$this->signatureService->method('checkRequest')->willThrowException(new SignatureIsGoneException());
+
+		$response = $this->controller->inbox('alice');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(1, $response->getData()['status']);
+	}
+
+
+	// getInbox()
+
+	public function testGetInboxReturnsAnEmptyOrderedCollection(): void {
+		$actor = $this->localActor('alice');
+		$actor->method('getInbox')->willReturn('https://cloud.example/apps/social/@alice/inbox');
+
+		$response = $this->controller->getInbox('alice');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(self::LD_JSON, $response->getHeaders()['Content-Type']);
+		$collection = $response->getData();
+		$this->assertInstanceOf(OrderedCollection::class, $collection);
+		$this->assertSame('https://cloud.example/apps/social/@alice/inbox', $collection->getId());
+		$this->assertSame(0, $collection->getTotalItems());
+		$this->assertSame('OrderedCollection', $collection->jsonSerialize()['type']);
+	}
+
+	public function testGetInboxOfUnknownUserIs404(): void {
+		$this->cacheActorService->method('getFromLocalAccount')->willThrowException(new CacheActorDoesNotExistException());
+
+		$response = $this->controller->getInbox('ghost');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame([], $response->getData());
+	}
+
+
+	// outbox() / followers() / following()
+
+	public function testOutboxReturnsTheActorsOutboxCollection(): void {
+		$actor = $this->localActor('alice');
+		$collection = new OrderedCollection();
+		$this->streamService->method('getOutboxCollection')->with($actor)->willReturn($collection);
+
+		$this->assertActivityPubResponse($this->controller->outbox('alice'), $collection);
+	}
+
+	public function testOutboxOfUnknownUserFails(): void {
+		$this->cacheActorService->method('getFromLocalAccount')->willThrowException(new CacheActorDoesNotExistException());
+
+		$this->assertFailure($this->controller->outbox('ghost'), CacheActorDoesNotExistException::class);
+	}
+
+	public function testFollowersReturnsCollectionForActivityStreamsClients(): void {
+		$this->acceptHeader('application/activity+json');
+		$actor = $this->localActor('alice');
+		$collection = new OrderedCollection();
+		$this->followService->method('getFollowersCollection')->with($actor)->willReturn($collection);
+
+		$this->assertActivityPubResponse($this->controller->followers('alice'), $collection);
+	}
+
+	public function testFollowersFallsBackToPublicPageForBrowsers(): void {
+		$this->acceptHeader('text/html');
+		$page = new TemplateResponse('social', 'main');
+		$this->socialPubController->expects($this->once())->method('followers')->with('alice')->willReturn($page);
+		$this->followService->expects($this->never())->method('getFollowersCollection');
+
+		$this->assertSame($page, $this->controller->followers('alice'));
+	}
+
+	public function testFollowingReturnsCollectionForActivityStreamsClients(): void {
+		$this->acceptHeader('application/ld+json');
+		$actor = $this->localActor('alice');
+		$collection = new OrderedCollection();
+		$this->followService->method('getFollowingCollection')->with($actor)->willReturn($collection);
+
+		$this->assertActivityPubResponse($this->controller->following('alice'), $collection);
+	}
+
+	public function testFollowingFallsBackToPublicPageForBrowsers(): void {
+		$this->acceptHeader('text/html');
+		$page = new TemplateResponse('social', 'main');
+		$this->socialPubController->expects($this->once())->method('following')->with('alice')->willReturn($page);
+
+		$this->assertSame($page, $this->controller->following('alice'));
+	}
+
+	public function testFollowersOfUnknownUserFails(): void {
+		$this->acceptHeader('application/activity+json');
+		$this->cacheActorService->method('getFromLocalAccount')->willThrowException(new CacheActorDoesNotExistException());
+
+		$this->assertFailure($this->controller->followers('ghost'), CacheActorDoesNotExistException::class);
+	}
+
+
+	// displayPost()
+
+	/** @return iterable<string, array{string, string}> */
+	public function reservedTokens(): iterable {
+		yield 'outbox' => ['outbox', 'getOutboxCollection'];
+		yield 'Outbox, mixed case' => ['Outbox', 'getOutboxCollection'];
+	}
+
+	/** @dataProvider reservedTokens */
+	public function testDisplayPostRoutesReservedTokensToTheCollections(string $token, string $method): void {
+		$this->acceptHeader('application/activity+json');
+		$actor = $this->localActor('alice');
+		$collection = new OrderedCollection();
+		$this->streamService->expects($this->once())->method($method)->with($actor)->willReturn($collection);
+		$this->streamService->expects($this->never())->method('getStreamById');
+
+		$this->assertActivityPubResponse($this->controller->displayPost('alice', $token), $collection);
+	}
+
+	public function testDisplayPostRoutesFollowersTokenToTheFollowersCollection(): void {
+		$this->acceptHeader('application/activity+json');
+		$actor = $this->localActor('alice');
+		$collection = new OrderedCollection();
+		$this->followService->expects($this->once())->method('getFollowersCollection')->with($actor)->willReturn($collection);
+
+		$this->assertActivityPubResponse($this->controller->displayPost('alice', 'FOLLOWERS'), $collection);
+	}
+
+	public function testDisplayPostRoutesFollowingTokenToTheFollowingCollection(): void {
+		$this->acceptHeader('application/activity+json');
+		$actor = $this->localActor('alice');
+		$collection = new OrderedCollection();
+		$this->followService->expects($this->once())->method('getFollowingCollection')->with($actor)->willReturn($collection);
+
+		$this->assertActivityPubResponse($this->controller->displayPost('alice', 'following'), $collection);
+	}
+
+	public function testDisplayPostReturnsTheStreamAsActivityPub(): void {
+		$this->acceptHeader('application/activity+json');
+		$viewer = $this->createMock(Person::class);
+		$this->accountService->method('getCurrentViewer')->willReturn($viewer);
+		$this->streamService->expects($this->once())->method('setViewer')->with($viewer);
+		$stream = $this->createMock(Stream::class);
+		$this->streamService->method('getStreamById')->with(self::SOCIAL_URL . '@alice/abc123', true)->willReturn($stream);
+		$stream->expects($this->once())->method('setCompleteDetails')->with(false);
+
+		$this->assertActivityPubResponse($this->controller->displayPost('alice', 'abc123'), $stream);
+	}
+
+	public function testDisplayPostWorksForAnonymousActivityPubClients(): void {
+		$this->acceptHeader('application/activity+json');
+		$this->accountService->method('getCurrentViewer')->willThrowException(new AccountDoesNotExistException());
+		$this->streamService->expects($this->never())->method('setViewer');
+		$stream = $this->createMock(Stream::class);
+		$this->streamService->method('getStreamById')->willReturn($stream);
+
+		$this->assertActivityPubResponse($this->controller->displayPost('alice', 'abc123'), $stream);
+	}
+
+	public function testDisplayPostOfUnknownStreamIs404WithTheLookedUpId(): void {
+		$this->acceptHeader('application/activity+json');
+		$this->accountService->method('getCurrentViewer')->willThrowException(new AccountDoesNotExistException());
+		$this->streamService->method('getStreamById')->willThrowException(new StreamNotFoundException());
+
+		$response = $this->controller->displayPost('alice', 'missing');
+
+		$this->assertFailure($response, StreamNotFoundException::class, Http::STATUS_NOT_FOUND);
+		$this->assertSame(self::SOCIAL_URL . '@alice/missing', $response->getData()['stream']);
+	}
+
+	public function testDisplayPostRendersPublicPageWithTheItemForBrowsers(): void {
+		$this->acceptHeader('text/html');
+		$stream = $this->createMock(Stream::class);
+		$this->streamService->method('getStreamById')->with(self::SOCIAL_URL . '@alice/abc123', true)->willReturn($stream);
+
+		$states = [];
+		$this->initialStateService->method('provideInitialState')
+			->willReturnCallback(function (string $app, string $key, $data) use (&$states): void {
+				$states[$app][$key] = $data;
+			});
+
+		$response = $this->controller->displayPost('alice', 'abc123');
+
+		$this->assertInstanceOf(TemplateResponse::class, $response);
+		$this->assertSame('main', $response->getTemplateName());
+		$this->assertSame(['public' => true, 'firstrun' => false, 'setup' => false], $states['social']['serverData']);
+		$this->assertSame($stream, $states['social']['item']);
+	}
+
+	public function testDisplayPostRendersPublicPageWithoutItemWhenStreamIsUnknown(): void {
+		$this->acceptHeader('text/html');
+		$this->streamService->method('getStreamById')->willThrowException(new StreamNotFoundException());
+
+		$keys = [];
+		$this->initialStateService->method('provideInitialState')
+			->willReturnCallback(function (string $app, string $key, $data) use (&$keys): void {
+				$keys[] = $key;
+			});
+
+		$response = $this->controller->displayPost('alice', 'missing');
+
+		$this->assertInstanceOf(TemplateResponse::class, $response);
+		$this->assertSame(['serverData'], $keys);
+	}
+}

--- a/tests/Controller/ApiControllerTest.php
+++ b/tests/Controller/ApiControllerTest.php
@@ -1,0 +1,845 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Controller;
+
+use OCA\Social\AP;
+use OCA\Social\Controller\ApiController;
+use OCA\Social\Exceptions\CacheActorDoesNotExistException;
+use OCA\Social\Exceptions\ClientNotFoundException;
+use OCA\Social\Exceptions\InvalidActionException;
+use OCA\Social\Exceptions\StreamNotFoundException;
+use OCA\Social\Interfaces\IActivityPubInterface;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Document;
+use OCA\Social\Model\ActivityPub\Stream;
+use OCA\Social\Model\Client\MediaAttachment;
+use OCA\Social\Model\Client\Options\ProbeOptions;
+use OCA\Social\Model\Client\SocialClient;
+use OCA\Social\Model\Instance;
+use OCA\Social\Model\Post;
+use OCA\Social\Service\AccountService;
+use OCA\Social\Service\ActionService;
+use OCA\Social\Service\CacheActorService;
+use OCA\Social\Service\CacheDocumentService;
+use OCA\Social\Service\ClientService;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\CurlService;
+use OCA\Social\Service\DocumentService;
+use OCA\Social\Service\FollowService;
+use OCA\Social\Service\InstanceService;
+use OCA\Social\Service\PostService;
+use OCA\Social\Service\StreamService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\FileDisplayResponse;
+use OCP\Files\NotFoundException;
+use OCP\Files\SimpleFS\ISimpleFile;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class ApiControllerTest extends TestCase {
+	private const REVOKED = 'the access_token was revoked';
+
+	/** @var IRequest&MockObject */
+	private $request;
+	/** @var IURLGenerator&MockObject */
+	private $urlGenerator;
+	/** @var IUserSession&MockObject */
+	private $userSession;
+	/** @var InstanceService&MockObject */
+	private $instanceService;
+	/** @var ClientService&MockObject */
+	private $clientService;
+	/** @var AccountService&MockObject */
+	private $accountService;
+	/** @var CacheActorService&MockObject */
+	private $cacheActorService;
+	/** @var CacheDocumentService&MockObject */
+	private $cacheDocumentService;
+	/** @var DocumentService&MockObject */
+	private $documentService;
+	/** @var FollowService&MockObject */
+	private $followService;
+	/** @var StreamService&MockObject */
+	private $streamService;
+	/** @var ActionService&MockObject */
+	private $actionService;
+	/** @var PostService&MockObject */
+	private $postService;
+	/** @var ConfigService&MockObject */
+	private $configService;
+	/** @var CurlService&MockObject */
+	private $curlService;
+
+	private array $filesBackup;
+
+	protected function setUp(): void {
+		$this->filesBackup = $_FILES;
+		$_FILES = [];
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->instanceService = $this->createMock(InstanceService::class);
+		$this->clientService = $this->createMock(ClientService::class);
+		$this->accountService = $this->createMock(AccountService::class);
+		$this->cacheActorService = $this->createMock(CacheActorService::class);
+		$this->cacheDocumentService = $this->createMock(CacheDocumentService::class);
+		$this->documentService = $this->createMock(DocumentService::class);
+		$this->followService = $this->createMock(FollowService::class);
+		$this->streamService = $this->createMock(StreamService::class);
+		$this->actionService = $this->createMock(ActionService::class);
+		$this->postService = $this->createMock(PostService::class);
+		$this->configService = $this->createMock(ConfigService::class);
+		$this->curlService = $this->createMock(CurlService::class);
+
+		\OC::$server->register(IRequest::class, $this->request);
+	}
+
+	protected function tearDown(): void {
+		$_FILES = $this->filesBackup;
+		AP::$activityPub = null;
+		\OC::$server->reset();
+	}
+
+	private function controller(string $authorization = ''): ApiController {
+		$this->request->method('getHeader')->willReturnCallback(
+			fn (string $name): string => $name === 'Authorization' ? $authorization : ''
+		);
+
+		return new ApiController(
+			$this->request,
+			$this->urlGenerator,
+			$this->userSession,
+			new NullLogger(),
+			$this->instanceService,
+			$this->clientService,
+			$this->accountService,
+			$this->cacheActorService,
+			$this->cacheDocumentService,
+			$this->documentService,
+			$this->followService,
+			$this->streamService,
+			$this->actionService,
+			$this->postService,
+			$this->configService,
+			$this->curlService
+		);
+	}
+
+	/**
+	 * A session user "alice" whose actor is cached: what initViewer() needs.
+	 * @return Person&MockObject
+	 */
+	private function loggedInAs(string $uid = 'alice'): Person {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$this->userSession->method('getUser')->willReturn($user);
+
+		$account = $this->createMock(Person::class);
+		$account->method('getPreferredUsername')->willReturn($uid);
+		$account->method('getId')->willReturn('https://cloud.example/apps/social/@' . $uid);
+		$this->accountService->method('getActorFromUserId')->with($uid, true)->willReturn($account);
+
+		$viewer = $this->createMock(Person::class);
+		$viewer->method('getPreferredUsername')->willReturn($uid);
+		$viewer->method('getId')->willReturn('https://cloud.example/apps/social/@' . $uid);
+		$this->cacheActorService->method('getFromLocalAccount')->with($uid)->willReturn($viewer);
+
+		return $viewer;
+	}
+
+	private function assertUnauthorized(DataResponse $response, string $error = self::REVOKED): void {
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['error' => $error], $response->getData());
+	}
+
+	/**
+	 * Captures the ProbeOptions handed to StreamService::getTimeline().
+	 */
+	private function captureTimelineOptions(array $posts = []): \Closure {
+		$captured = null;
+		$this->streamService->method('getTimeline')
+			->willReturnCallback(function (ProbeOptions $options) use (&$captured, $posts): array {
+				$captured = $options;
+
+				return $posts;
+			});
+
+		return function () use (&$captured): ProbeOptions {
+			$this->assertInstanceOf(ProbeOptions::class, $captured, 'getTimeline() was not called');
+
+			return $captured;
+		};
+	}
+
+
+	// credentials
+
+	public function testAppsCredentialsRequiresAViewer(): void {
+		$this->assertUnauthorized($this->controller()->appsCredentials());
+	}
+
+	public function testAppsCredentialsForSessionUserIsTheBuiltInClient(): void {
+		$this->loggedInAs();
+
+		$response = $this->controller()->appsCredentials();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(
+			['name' => 'Nextcloud Social', 'website' => 'https://github.com/nextcloud/social/'],
+			$response->getData()
+		);
+	}
+
+	public function testAppsCredentialsForBearerTokenDescribesTheOAuthClient(): void {
+		$client = new SocialClient();
+		$client->setAppName('Tusky')->setAppWebsite('https://tusky.app')->setAuthUserId('alice');
+		$this->clientService->method('getFromToken')->with('s3cret')->willReturn($client);
+		$this->userSession->method('getUser')->willReturn(null);
+
+		$account = $this->createMock(Person::class);
+		$account->method('getPreferredUsername')->willReturn('alice');
+		$this->accountService->method('getActorFromUserId')->with('alice', true)->willReturn($account);
+		$this->cacheActorService->method('getFromLocalAccount')->with('alice')->willReturn($this->createMock(Person::class));
+
+		$response = $this->controller('Bearer s3cret')->appsCredentials();
+
+		$this->assertSame(['name' => 'Tusky', 'website' => 'https://tusky.app'], $response->getData());
+	}
+
+	public function testNonBearerAuthorizationIsIgnored(): void {
+		$this->clientService->expects($this->never())->method('getFromToken');
+
+		$this->assertUnauthorized($this->controller('Basic abc')->appsCredentials());
+	}
+
+	public function testRevokedBearerTokenIsUnauthorized(): void {
+		$this->clientService->method('getFromToken')->willThrowException(new ClientNotFoundException());
+
+		$this->assertUnauthorized($this->controller('Bearer gone')->verifyCredentials());
+	}
+
+	public function testVerifyCredentialsReturnsTheViewerInLocalFormat(): void {
+		$viewer = $this->loggedInAs();
+		$viewer->expects($this->once())->method('setExportFormat')->with(ACore::FORMAT_LOCAL);
+		$this->streamService->expects($this->once())->method('setViewer')->with($viewer);
+		$this->followService->expects($this->once())->method('setViewer')->with($viewer);
+		$this->cacheActorService->expects($this->once())->method('setViewer')->with($viewer);
+
+		$response = $this->controller()->verifyCredentials();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($viewer, $response->getData());
+	}
+
+	public function testVerifyCredentialsIsUnauthorizedForAnonymous(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+
+		$this->assertUnauthorized($this->controller()->verifyCredentials());
+	}
+
+	public function testViewerIsCachedOnDemandWhenMissingFromCache(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$this->userSession->method('getUser')->willReturn($user);
+		$account = $this->createMock(Person::class);
+		$account->method('getPreferredUsername')->willReturn('alice');
+		$this->accountService->method('getActorFromUserId')->willReturn($account);
+
+		$viewer = $this->createMock(Person::class);
+		$this->cacheActorService->method('getFromLocalAccount')->with('alice')
+			->will($this->onConsecutiveCalls($this->throwException(new CacheActorDoesNotExistException()), $viewer));
+		$this->accountService->expects($this->once())->method('cacheLocalActorByUsername')->with('alice');
+
+		$this->assertSame($viewer, $this->controller()->verifyCredentials()->getData());
+	}
+
+	public function testSavedSearchesIsEmptyForAViewerAndUnauthorizedOtherwise(): void {
+		$this->assertUnauthorized($this->controller()->savedSearches());
+
+		$this->loggedInAs();
+		$response = $this->controller()->savedSearches();
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame([], $response->getData());
+	}
+
+
+	// instance / emojis
+
+	public function testInstanceReturnsTheLocalInstanceInLocalFormat(): void {
+		$instance = new Instance();
+		$this->instanceService->expects($this->once())->method('getLocal')->with(Stream::FORMAT_LOCAL)->willReturn($instance);
+
+		$response = $this->controller()->instance();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($instance, $response->getData());
+	}
+
+	public function testCustomEmojisIsAnEmptyList(): void {
+		$response = $this->controller()->customEmojis();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame([], $response->getData());
+	}
+
+
+	// timelines
+
+	/** @return iterable<string, array{string}> */
+	public function supportedTimelines(): iterable {
+		yield 'home' => ['home'];
+		yield 'account' => ['account'];
+		yield 'public' => ['public'];
+		yield 'direct' => ['direct'];
+		yield 'favourites' => ['favourites'];
+		yield 'case-insensitive' => ['HOME'];
+	}
+
+	/** @dataProvider supportedTimelines */
+	public function testTimelinesProbesTheRequestedTimelineWithPagination(string $timeline): void {
+		$this->loggedInAs();
+		$posts = [$this->createMock(Stream::class)];
+		$options = $this->captureTimelineOptions($posts);
+
+		$response = $this->controller()->timelines($timeline, true, 15, 300, 100, 200);
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($posts, $response->getData());
+		$probe = $options();
+		$this->assertSame(strtolower($timeline), $probe->getProbe());
+		$this->assertTrue($probe->isLocal());
+		$this->assertSame(15, $probe->getLimit());
+		$this->assertSame(300, $probe->getMaxId());
+		$this->assertSame(100, $probe->getMinId());
+		$this->assertSame(200, $probe->getSince());
+		$this->assertSame(ACore::FORMAT_LOCAL, $probe->getFormat());
+	}
+
+	/** @return iterable<string, array{string}> */
+	public function unsupportedTimelines(): iterable {
+		yield 'trending' => ['trending'];
+		yield 'notifications' => ['notifications'];
+		yield 'hashtag' => ['hashtag'];
+		yield 'empty' => [''];
+	}
+
+	/** @dataProvider unsupportedTimelines */
+	public function testTimelinesRejectsUnknownTimelineNames(string $timeline): void {
+		$this->loggedInAs();
+		$this->streamService->expects($this->never())->method('getTimeline');
+
+		$this->assertUnauthorized($this->controller()->timelines($timeline), 'unknown timeline');
+	}
+
+	public function testTimelinesRequiresAViewer(): void {
+		$this->streamService->expects($this->never())->method('getTimeline');
+
+		$this->assertUnauthorized($this->controller()->timelines('home'));
+	}
+
+	public function testTimelinesReportsServiceFailures(): void {
+		$this->loggedInAs();
+		$this->streamService->method('getTimeline')->willThrowException(new \RuntimeException('db down'));
+
+		$this->assertUnauthorized($this->controller()->timelines('home'), 'db down');
+	}
+
+
+	// statuses
+
+	public function testStatusGetReturnsTheStreamInLocalFormatEvenAnonymously(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$item = $this->createMock(Stream::class);
+		$this->streamService->method('getStreamByNid')->with(42)->willReturn($item);
+		$item->expects($this->once())->method('setExportFormat')->with(ACore::FORMAT_LOCAL);
+
+		$response = $this->controller()->statusGet(42);
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($item, $response->getData());
+	}
+
+	public function testStatusGetOfUnknownStatusIsAnError(): void {
+		$this->streamService->method('getStreamByNid')->willThrowException(new StreamNotFoundException('not found'));
+
+		$this->assertUnauthorized($this->controller()->statusGet(42), 'not found');
+	}
+
+	public function testStatusContextReturnsAncestorsAndDescendants(): void {
+		$context = ['ancestors' => [], 'descendants' => [$this->createMock(Stream::class)]];
+		$this->streamService->method('getContextByNid')->with(7)->willReturn($context);
+
+		$response = $this->controller()->statusContext(7);
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($context, $response->getData());
+	}
+
+	/** @return iterable<string, array{string}> */
+	public function statusActions(): iterable {
+		yield 'favourite' => ['favourite'];
+		yield 'unfavourite' => ['unfavourite'];
+		yield 'reblog' => ['reblog'];
+		yield 'unreblog' => ['unreblog'];
+	}
+
+	/** @dataProvider statusActions */
+	public function testStatusActionDispatchesToActionServiceAsTheViewersActor(string $action): void {
+		$this->loggedInAs();
+		$actor = $this->createMock(Person::class);
+		$this->accountService->method('getActor')->with('alice')->willReturn($actor);
+		$item = $this->createMock(Stream::class);
+		$this->actionService->expects($this->once())->method('action')->with($actor, 12, $action)->willReturn($item);
+		$item->expects($this->once())->method('setExportFormat')->with(ACore::FORMAT_LOCAL);
+		$this->streamService->expects($this->never())->method('getStreamByNid');
+
+		$response = $this->controller()->statusAction(12, $action);
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($item, $response->getData());
+	}
+
+	public function testStatusActionFallsBackToTheStatusWhenActionReturnsNothing(): void {
+		$this->loggedInAs();
+		$this->accountService->method('getActor')->willReturn($this->createMock(Person::class));
+		$this->actionService->method('action')->willReturn(null);
+		$item = $this->createMock(Stream::class);
+		$this->streamService->expects($this->once())->method('getStreamByNid')->with(12)->willReturn($item);
+
+		$this->assertSame($item, $this->controller()->statusAction(12, 'translate')->getData());
+	}
+
+	public function testStatusActionRejectsUnknownActions(): void {
+		$this->loggedInAs();
+		$this->accountService->method('getActor')->willReturn($this->createMock(Person::class));
+		$this->actionService->method('action')->willThrowException(new InvalidActionException('unknown action'));
+
+		$this->assertUnauthorized($this->controller()->statusAction(12, 'explode'), 'unknown action');
+	}
+
+	public function testStatusActionRequiresAViewer(): void {
+		$this->actionService->expects($this->never())->method('action');
+
+		$this->assertUnauthorized($this->controller()->statusAction(12, 'favourite'));
+	}
+
+
+	// statusNew / statusUpdate
+
+	public function testStatusNewCreatesAPostFromTheFormParameters(): void {
+		$this->loggedInAs();
+		$this->request->method('getParams')->willReturn([
+			'status' => "hello\nworld",
+			'visibility' => 'unlisted',
+			'in_reply_to_id' => 7,
+		]);
+		$parent = $this->createMock(Stream::class);
+		$parent->method('getId')->willReturn('https://remote.example/notes/7');
+		$this->streamService->method('getStreamByNid')->with(7)->willReturn($parent);
+
+		$activity = $this->createMock(ACore::class);
+		$activity->method('getObjectId')->willReturn('https://cloud.example/apps/social/@alice/n1');
+		$created = null;
+		$this->postService->expects($this->once())->method('createPost')
+			->willReturnCallback(function (Post $post) use (&$created, $activity): ACore {
+				$created = $post;
+
+				return $activity;
+			});
+		$item = $this->createMock(Stream::class);
+		$this->streamService->method('getStreamById')
+			->with('https://cloud.example/apps/social/@alice/n1', true, ACore::FORMAT_LOCAL)
+			->willReturn($item);
+
+		$response = $this->controller()->statusNew();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($item, $response->getData());
+		$this->assertSame("hello<br />\nworld", $created->getContent());
+		$this->assertSame('unlisted', $created->getType());
+		$this->assertSame('https://remote.example/notes/7', $created->getReplyTo());
+	}
+
+	public function testStatusNewIgnoresAMissingParent(): void {
+		$this->loggedInAs();
+		$this->request->method('getParams')->willReturn(['status' => 'hi', 'in_reply_to_id' => 99]);
+		$this->streamService->method('getStreamByNid')->willThrowException(new StreamNotFoundException());
+		$activity = $this->createMock(ACore::class);
+		$activity->method('getObjectId')->willReturn('id');
+		$created = null;
+		$this->postService->method('createPost')->willReturnCallback(function (Post $post) use (&$created, $activity): ACore {
+			$created = $post;
+
+			return $activity;
+		});
+		$this->streamService->method('getStreamById')->willReturn($this->createMock(Stream::class));
+
+		$this->controller()->statusNew();
+
+		$this->assertSame('', $created->getReplyTo());
+	}
+
+	public function testStatusNewIsABadRequestForAnonymous(): void {
+		$this->postService->expects($this->never())->method('createPost');
+
+		$response = $this->controller()->statusNew();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => self::REVOKED], $response->getData());
+	}
+
+	public function testStatusUpdateEditsTheStatusWithSpoilerAndSensitivity(): void {
+		$this->loggedInAs();
+		$this->request->method('getParams')->willReturn([
+			'status' => "edited\ntext",
+			'spoiler_text' => 'cw',
+			'sensitive' => true,
+		]);
+		$item = $this->createMock(Stream::class);
+		$this->postService->expects($this->once())->method('editPost')
+			->with(5, $this->isInstanceOf(Person::class), "edited<br />\ntext", 'cw', true)
+			->willReturn($item);
+		$item->expects($this->once())->method('setExportFormat')->with(ACore::FORMAT_LOCAL);
+
+		$response = $this->controller()->statusUpdate(5);
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($item, $response->getData());
+	}
+
+	public function testStatusUpdateWithoutSpoilerPassesNull(): void {
+		$this->loggedInAs();
+		$this->request->method('getParams')->willReturn(['status' => 'x']);
+		$this->postService->expects($this->once())->method('editPost')
+			->with(5, $this->anything(), 'x', null, false)
+			->willReturn($this->createMock(Stream::class));
+
+		$this->controller()->statusUpdate(5);
+	}
+
+	public function testStatusUpdateFailureIsABadRequest(): void {
+		$this->loggedInAs();
+		$this->request->method('getParams')->willReturn(['status' => 'x']);
+		$this->postService->method('editPost')->willThrowException(new StreamNotFoundException('gone'));
+
+		$response = $this->controller()->statusUpdate(5);
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'gone'], $response->getData());
+	}
+
+
+	// relationships / accounts
+
+	public function testRelationshipsAreResolvedByFollowService(): void {
+		$this->loggedInAs();
+		$this->followService->expects($this->once())->method('getRelationships')->with([1, 2])->willReturn(['r1', 'r2']);
+
+		$response = $this->controller()->relationships([1, 2]);
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['r1', 'r2'], $response->getData());
+	}
+
+	public function testRelationshipsRequireAViewer(): void {
+		$this->assertUnauthorized($this->controller()->relationships([1]));
+	}
+
+	public function testAccountStatusesSyncsThenProbesTheAccountTimeline(): void {
+		$actor = $this->createMock(Person::class);
+		$actor->method('getId')->willReturn('https://remote.example/users/bob');
+		$this->cacheActorService->method('getFromAccount')->with('bob@remote.example')->willReturn($actor);
+		$this->streamService->expects($this->once())->method('syncRemoteTimeline')->with($actor);
+		$options = $this->captureTimelineOptions(['p']);
+
+		$response = $this->controller()->accountStatuses('bob@remote.example', 5, 40, 10, 20);
+
+		$this->assertSame(['p'], $response->getData());
+		$probe = $options();
+		$this->assertSame(ProbeOptions::ACCOUNT, $probe->getProbe());
+		$this->assertSame('https://remote.example/users/bob', $probe->getAccountId());
+		$this->assertSame(5, $probe->getLimit());
+		$this->assertSame(40, $probe->getMaxId());
+		$this->assertSame(10, $probe->getMinId());
+		$this->assertSame(20, $probe->getSince());
+	}
+
+	public function testAccountStatusesOfUnknownAccountIsAnError(): void {
+		$this->cacheActorService->method('getFromAccount')->willThrowException(new CacheActorDoesNotExistException('who?'));
+
+		$this->assertUnauthorized($this->controller()->accountStatuses('nobody'), 'who?');
+	}
+
+	private function localHosts(): void {
+		$this->configService->method('getCloudHost')->willReturn('cloud.example');
+		$this->configService->method('getSocialAddress')->willReturn('social.example');
+	}
+
+	public function testAccountFollowersOfLocalAccountAreProbedLocally(): void {
+		$this->localHosts();
+		$actor = $this->createMock(Person::class);
+		$actor->method('getId')->willReturn('https://cloud.example/apps/social/@alice');
+		$this->cacheActorService->method('getFromAccount')->with('alice@cloud.example')->willReturn($actor);
+		$this->curlService->expects($this->never())->method('retrieveObject');
+		$captured = null;
+		$this->cacheActorService->method('probeActors')->willReturnCallback(function (ProbeOptions $o) use (&$captured): array {
+			$captured = $o;
+
+			return ['f'];
+		});
+
+		$response = $this->controller()->accountFollowers('alice@cloud.example', 3, 9, 8, 7);
+
+		$this->assertSame(['f'], $response->getData());
+		$this->assertSame(ProbeOptions::FOLLOWERS, $captured->getProbe());
+		$this->assertSame('https://cloud.example/apps/social/@alice', $captured->getAccountId());
+		$this->assertSame([3, 9, 8, 7], [$captured->getLimit(), $captured->getMaxId(), $captured->getMinId(), $captured->getSince()]);
+	}
+
+	public function testAccountFollowingOfBareUsernameIsProbedLocally(): void {
+		$this->localHosts();
+		$actor = $this->createMock(Person::class);
+		$this->cacheActorService->method('getFromAccount')->with('alice')->willReturn($actor);
+		$captured = null;
+		$this->cacheActorService->method('probeActors')->willReturnCallback(function (ProbeOptions $o) use (&$captured): array {
+			$captured = $o;
+
+			return [];
+		});
+
+		$this->controller()->accountFollowing('alice');
+
+		$this->assertSame(ProbeOptions::FOLLOWING, $captured->getProbe());
+	}
+
+	public function testAccountFollowersOfRemoteAccountAreFetchedFromTheirCollection(): void {
+		$this->localHosts();
+		$actor = $this->createMock(Person::class);
+		$actor->method('getFollowers')->willReturn('https://remote.example/users/bob/followers');
+		$this->cacheActorService->method('getFromAccount')->willReturn($actor);
+		$this->curlService->method('retrieveObject')->willReturnMap([
+			['https://remote.example/users/bob/followers', true, ['first' => 'https://remote.example/users/bob/followers?page=1']],
+			['https://remote.example/users/bob/followers?page=1', true, ['orderedItems' => [
+				'https://remote.example/users/x',
+				'https://remote.example/users/y',
+				'https://remote.example/users/z',
+			]]],
+		]);
+		$x = $this->createMock(Person::class);
+		$y = $this->createMock(Person::class);
+		$this->cacheActorService->method('getFromId')->willReturnMap([
+			['https://remote.example/users/x', false, $x],
+			['https://remote.example/users/y', false, $y],
+		]);
+		$x->expects($this->once())->method('setExportFormat')->with(ACore::FORMAT_LOCAL);
+		$this->cacheActorService->expects($this->never())->method('probeActors');
+
+		$response = $this->controller()->accountFollowers('bob@remote.example', 2);
+
+		$this->assertSame([$x, $y], $response->getData(), 'limit is applied and the third actor is never fetched');
+	}
+
+	public function testAccountFollowingOfRemoteAccountSkipsUnresolvableActors(): void {
+		$this->localHosts();
+		$actor = $this->createMock(Person::class);
+		$actor->method('getFollowing')->willReturn('https://remote.example/users/bob/following');
+		$this->cacheActorService->method('getFromAccount')->willReturn($actor);
+		$this->curlService->method('retrieveObject')->willReturn(['items' => ['https://remote.example/users/x', '']]);
+		$this->cacheActorService->method('getFromId')->willThrowException(new CacheActorDoesNotExistException());
+
+		$response = $this->controller()->accountFollowing('bob@remote.example');
+
+		$this->assertSame([], $response->getData());
+	}
+
+	public function testRemoteCollectionFetchFailureYieldsAnEmptyList(): void {
+		$this->localHosts();
+		$actor = $this->createMock(Person::class);
+		$actor->method('getFollowers')->willReturn('https://remote.example/users/bob/followers');
+		$this->cacheActorService->method('getFromAccount')->willReturn($actor);
+		$this->curlService->method('retrieveObject')->willThrowException(new \RuntimeException('timeout'));
+
+		$response = $this->controller()->accountFollowers('bob@remote.example');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame([], $response->getData());
+	}
+
+
+	// favourites / notifications / tag
+
+	public function testFavouritesProbeTheFavouritesTimeline(): void {
+		$this->loggedInAs();
+		$options = $this->captureTimelineOptions(['fav']);
+
+		$response = $this->controller()->favourites(4, 30, 20, 10);
+
+		$this->assertSame(['fav'], $response->getData());
+		$probe = $options();
+		$this->assertSame(ProbeOptions::FAVOURITES, $probe->getProbe());
+		$this->assertSame([4, 30, 20, 10], [$probe->getLimit(), $probe->getMaxId(), $probe->getMinId(), $probe->getSince()]);
+	}
+
+	public function testFavouritesRequireAViewer(): void {
+		$this->assertUnauthorized($this->controller()->favourites());
+	}
+
+	public function testNotificationsForwardTypeFilters(): void {
+		$this->loggedInAs();
+		$options = $this->captureTimelineOptions();
+
+		$this->controller()->notifications(10, 0, 0, 0, ['mention', 'follow'], ['reblog'], 'https://x/acct');
+
+		$probe = $options();
+		$this->assertSame(ProbeOptions::NOTIFICATIONS, $probe->getProbe());
+		$this->assertSame(['mention', 'follow'], $probe->getTypes());
+		$this->assertSame(['reblog'], $probe->getExcludeTypes());
+		$this->assertSame('https://x/acct', $probe->getAccountId());
+		$this->assertSame(10, $probe->getLimit());
+	}
+
+	public function testNotificationsRequireAViewer(): void {
+		$this->assertUnauthorized($this->controller()->notifications());
+	}
+
+	public function testTagProbesTheHashtagTimeline(): void {
+		$this->loggedInAs();
+		$options = $this->captureTimelineOptions(['t']);
+
+		$response = $this->controller()->tag('nextcloud', 6, 0, 0, 0, true, true);
+
+		$this->assertSame(['t'], $response->getData());
+		$probe = $options();
+		$this->assertSame(ProbeOptions::HASHTAG, $probe->getProbe());
+		$this->assertSame('nextcloud', $probe->getArgument());
+		$this->assertTrue($probe->isLocal());
+		$this->assertTrue($probe->isOnlyMedia());
+		$this->assertSame(6, $probe->getLimit());
+	}
+
+
+	// media
+
+	public function testMediaNewWithoutUploadIsABadRequest(): void {
+		$this->loggedInAs();
+
+		$response = $this->controller()->mediaNew();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'no media found'], $response->getData());
+	}
+
+	public function testMediaNewRequiresAViewer(): void {
+		$_FILES['file'] = ['tmp_name' => '/tmp/x', 'size' => 1, 'type' => 'image/png', 'error' => UPLOAD_ERR_OK];
+		$this->cacheDocumentService->expects($this->never())->method('saveFromTempToCache');
+
+		$response = $this->controller()->mediaNew();
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => self::REVOKED], $response->getData());
+	}
+
+	public function testMediaNewReportsFailedUploads(): void {
+		$this->loggedInAs();
+		$_FILES['file'] = ['tmp_name' => '', 'size' => 0, 'type' => '', 'error' => UPLOAD_ERR_PARTIAL];
+
+		$this->assertSame(['error' => 'error during upload'], $this->controller()->mediaNew()->getData());
+	}
+
+	public function testMediaNewRejectsUploadsWithoutAType(): void {
+		$this->loggedInAs();
+		$_FILES['file'] = ['tmp_name' => '/tmp/upload', 'size' => 10, 'type' => '', 'error' => UPLOAD_ERR_OK];
+		$this->cacheDocumentService->expects($this->never())->method('saveFromTempToCache');
+
+		$this->assertSame(['error' => 'missing details'], $this->controller()->mediaNew()->getData());
+	}
+
+	public function testMediaNewStoresTheUploadAsAPublicLocalDocument(): void {
+		$this->loggedInAs();
+		$_FILES['file'] = ['tmp_name' => '/tmp/php-upload', 'size' => 10, 'type' => 'image/png', 'error' => UPLOAD_ERR_OK];
+		$this->configService->method('getCloudUrl')->willReturn('https://cloud.example');
+
+		$saved = null;
+		$this->cacheDocumentService->expects($this->once())->method('saveFromTempToCache')
+			->willReturnCallback(function (Document $document, string $tmpPath) use (&$saved): void {
+				$this->assertSame('/tmp/php-upload', $tmpPath);
+				$saved = $document;
+			});
+
+		$interface = $this->createMock(IActivityPubInterface::class);
+		$interface->expects($this->once())->method('save')->with($this->isInstanceOf(Document::class));
+		AP::$activityPub = $this->createMock(AP::class);
+		AP::$activityPub->method('getInterfaceForItem')->willReturn($interface);
+
+		$response = $this->controller()->mediaNew();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertInstanceOf(MediaAttachment::class, $response->getData());
+		$this->assertTrue($saved->isLocal());
+		$this->assertTrue($saved->isPublic());
+		$this->assertSame('alice', $saved->getAccount());
+		$this->assertStringStartsWith('https://cloud.example/documents/local/', $saved->getId());
+	}
+
+	public function testMediaGetIsAStubReturningNothing(): void {
+		$response = $this->controller()->mediaGet('1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame([], $response->getData());
+	}
+
+	public function testMediaOpenServesTheFileWithMimeDerivedFromExtension(): void {
+		$file = $this->createMock(ISimpleFile::class);
+		$file->method('getName')->willReturn('abc');
+		$file->method('getETag')->willReturn('etag');
+		$file->method('getMTime')->willReturn(1700000000);
+		$this->documentService->expects($this->once())->method('getFromUuid')->with('abc')->willReturn($file);
+
+		$response = $this->controller()->mediaOpen('abc.png');
+
+		$this->assertInstanceOf(FileDisplayResponse::class, $response);
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame('image/png', $response->getHeaders()['Content-Type']);
+	}
+
+	public function testMediaOpenWithoutExtensionHasNoContentType(): void {
+		$file = $this->createMock(ISimpleFile::class);
+		$file->method('getName')->willReturn('abc');
+		$this->documentService->method('getFromUuid')->with('abc')->willReturn($file);
+
+		$this->assertSame('', $this->controller()->mediaOpen('abc')->getHeaders()['Content-Type']);
+	}
+
+	public function testMediaOpenOfUnknownFileIs404(): void {
+		$this->documentService->method('getFromUuid')->willThrowException(new NotFoundException('no file'));
+
+		$response = $this->controller()->mediaOpen('abc.png');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame(['error' => 'no file'], $response->getData());
+	}
+
+	public function testMediaOpenOtherFailuresAreBadRequests(): void {
+		$this->documentService->method('getFromUuid')->willThrowException(new \RuntimeException('boom'));
+
+		$response = $this->controller()->mediaOpen('abc.png');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'boom'], $response->getData());
+	}
+}

--- a/tests/Controller/ConfigControllerTest.php
+++ b/tests/Controller/ConfigControllerTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Controller;
+
+use OCA\Social\Controller\ConfigController;
+use OCA\Social\Exceptions\SocialAppConfigException;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\MiscService;
+use OCA\Social\Service\TestService;
+use OCA\Social\Tools\Model\SimpleDataStore;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ConfigControllerTest extends TestCase {
+	/** @var TestService&MockObject */
+	private $testService;
+	/** @var ConfigService&MockObject */
+	private $configService;
+	private ConfigController $controller;
+
+	protected function setUp(): void {
+		$this->testService = $this->createMock(TestService::class);
+		$this->configService = $this->createMock(ConfigService::class);
+
+		$this->controller = new ConfigController(
+			'social',
+			$this->createMock(IRequest::class),
+			$this->testService,
+			$this->configService,
+			$this->createMock(MiscService::class)
+		);
+	}
+
+	protected function tearDown(): void {
+		\OC::$server->reset();
+	}
+
+	public function testSetCloudAddressStoresTheAddress(): void {
+		$this->configService->expects($this->once())->method('setCloudUrl')->with('https://cloud.example');
+
+		$response = $this->controller->setCloudAddress('https://cloud.example');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame([], $response->getData());
+	}
+
+	public function testLocalReportsVersionAndCompletedSetup(): void {
+		$this->configService->method('getCloudUrl')->willReturn('https://cloud.example');
+		$this->configService->method('getAppValue')->with('installed_version')->willReturn('0.10.0');
+
+		$response = $this->controller->local();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['result' => ['version' => '0.10.0', 'setup' => true], 'status' => 1], $response->getData());
+	}
+
+	public function testLocalReportsMissingSetup(): void {
+		$this->configService->method('getCloudUrl')->willThrowException(new SocialAppConfigException());
+		$this->configService->method('getAppValue')->willReturn('0.10.0');
+
+		$this->assertFalse($this->controller->local()->getData()['result']['setup']);
+	}
+
+	public function testRemoteWithoutAccountFallsBackToLocal(): void {
+		$this->configService->method('getCloudUrl')->willReturn('https://cloud.example');
+		$this->configService->method('getAppValue')->willReturn('1.0');
+		$this->testService->expects($this->never())->method('testWebfinger');
+
+		$this->assertSame(['version' => '1.0', 'setup' => true], $this->controller->remote('')->getData()['result']);
+	}
+
+	public function testRemoteWithoutTestEndpointFallsBackToLocal(): void {
+		$this->configService->method('getSystemValue')->with('social.tests')->willReturn('');
+		$this->configService->method('getCloudUrl')->willReturn('https://cloud.example');
+		$this->configService->method('getAppValue')->willReturn('1.0');
+		$this->testService->expects($this->never())->method('testWebfinger');
+
+		$this->assertSame(['version' => '1.0', 'setup' => true], $this->controller->remote('alice@cloud.example')->getData()['result']);
+	}
+
+	public function testRemoteReportsUnconfiguredLocalInstance(): void {
+		$this->configService->method('getSystemValue')->willReturn('https://tests.example');
+		$this->configService->method('getCloudUrl')->willThrowException(new SocialAppConfigException());
+		$this->testService->expects($this->never())->method('testWebfinger');
+
+		$this->assertSame(
+			['error' => 'error on my side: my own Social App is not configured'],
+			$this->controller->remote('alice@cloud.example')->getData()['result']
+		);
+	}
+
+	public function testRemoteRunsTheWebfingerTestAgainstTheEndpoint(): void {
+		$this->configService->method('getSystemValue')->willReturn('https://tests.example');
+		$this->configService->method('getCloudUrl')->willReturn('https://cloud.example');
+		$this->testService->expects($this->once())->method('testWebfinger')
+			->with($this->callback(function (SimpleDataStore $tests): bool {
+				return $tests->g('account') === 'alice@cloud.example'
+					&& $tests->g('endpoint') === 'https://tests.example';
+			}));
+
+		$response = $this->controller->remote('alice@cloud.example');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(1, $response->getData()['status']);
+		$this->assertInstanceOf(SimpleDataStore::class, $response->getData()['result'][0]);
+	}
+
+	public function testRemoteReportsAFailedWebfingerTestWithStatus200(): void {
+		$this->configService->method('getSystemValue')->willReturn('https://tests.example');
+		$this->configService->method('getCloudUrl')->willReturn('https://cloud.example');
+		$this->testService->method('testWebfinger')->willThrowException(new \RuntimeException('webfinger down'));
+
+		$response = $this->controller->remote('alice@cloud.example');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$data = $response->getData();
+		$this->assertSame(-1, $data['status']);
+		$this->assertSame(\RuntimeException::class, $data['exception']);
+		$this->assertSame('webfinger down', $data['message']);
+		$this->assertInstanceOf(SimpleDataStore::class, $data['result']);
+	}
+}

--- a/tests/Controller/LocalControllerTest.php
+++ b/tests/Controller/LocalControllerTest.php
@@ -1,0 +1,729 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Controller;
+
+use OCA\Social\Controller\LocalController;
+use OCA\Social\Exceptions\AccountDoesNotExistException;
+use OCA\Social\Exceptions\CacheActorDoesNotExistException;
+use OCA\Social\Exceptions\FollowSameAccountException;
+use OCA\Social\Exceptions\InvalidResourceException;
+use OCA\Social\Exceptions\StreamNotFoundException;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Document;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Model\ActivityPub\Stream;
+use OCA\Social\Model\Post;
+use OCA\Social\Service\AccountService;
+use OCA\Social\Service\ActivityService;
+use OCA\Social\Service\ActorService;
+use OCA\Social\Service\BoostService;
+use OCA\Social\Service\CacheActorService;
+use OCA\Social\Service\CacheDocumentService;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\DocumentService;
+use OCA\Social\Service\FollowService;
+use OCA\Social\Service\HashtagService;
+use OCA\Social\Service\LikeService;
+use OCA\Social\Service\MiscService;
+use OCA\Social\Service\PostService;
+use OCA\Social\Service\SearchService;
+use OCA\Social\Service\StreamService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\FileDisplayResponse;
+use OCP\AppFramework\Http\RedirectResponse;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Files\SimpleFS\ISimpleFile;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class LocalControllerTest extends TestCase {
+	/** @var IRequest&MockObject */
+	private $request;
+	/** @var AccountService&MockObject */
+	private $accountService;
+	/** @var CacheActorService&MockObject */
+	private $cacheActorService;
+	/** @var HashtagService&MockObject */
+	private $hashtagService;
+	/** @var FollowService&MockObject */
+	private $followService;
+	/** @var PostService&MockObject */
+	private $postService;
+	/** @var StreamService&MockObject */
+	private $streamService;
+	/** @var SearchService&MockObject */
+	private $searchService;
+	/** @var BoostService&MockObject */
+	private $boostService;
+	/** @var LikeService&MockObject */
+	private $likeService;
+	/** @var DocumentService&MockObject */
+	private $documentService;
+	/** @var ConfigService&MockObject */
+	private $configService;
+	/** @var ActorService&MockObject */
+	private $actorService;
+	/** @var ActivityService&MockObject */
+	private $activityService;
+	/** @var CacheDocumentService&MockObject */
+	private $cacheDocumentService;
+
+	private array $filesBackup;
+
+	protected function setUp(): void {
+		$this->filesBackup = $_FILES;
+		$_FILES = [];
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->accountService = $this->createMock(AccountService::class);
+		$this->cacheActorService = $this->createMock(CacheActorService::class);
+		$this->hashtagService = $this->createMock(HashtagService::class);
+		$this->followService = $this->createMock(FollowService::class);
+		$this->postService = $this->createMock(PostService::class);
+		$this->streamService = $this->createMock(StreamService::class);
+		$this->searchService = $this->createMock(SearchService::class);
+		$this->boostService = $this->createMock(BoostService::class);
+		$this->likeService = $this->createMock(LikeService::class);
+		$this->documentService = $this->createMock(DocumentService::class);
+		$this->configService = $this->createMock(ConfigService::class);
+		$this->actorService = $this->createMock(ActorService::class);
+		$this->activityService = $this->createMock(ActivityService::class);
+		$this->cacheDocumentService = $this->createMock(CacheDocumentService::class);
+
+		\OC::$server->register(IRequest::class, $this->request);
+	}
+
+	protected function tearDown(): void {
+		$_FILES = $this->filesBackup;
+		\OC::$server->reset();
+	}
+
+	private function controller(?string $userId = 'alice'): LocalController {
+		return new LocalController(
+			$this->request,
+			$userId,
+			$this->accountService,
+			$this->cacheActorService,
+			$this->hashtagService,
+			$this->followService,
+			$this->postService,
+			$this->streamService,
+			$this->searchService,
+			$this->boostService,
+			$this->likeService,
+			$this->documentService,
+			$this->createMock(MiscService::class),
+			$this->configService,
+			new NullLogger(),
+			$this->actorService,
+			$this->activityService,
+			$this->cacheDocumentService
+		);
+	}
+
+	/** @return Person&MockObject */
+	private function actorForUser(string $userId = 'alice'): Person {
+		$actor = $this->createMock(Person::class);
+		$actor->method('getId')->willReturn('https://cloud.example/apps/social/@' . $userId);
+		$actor->method('getPreferredUsername')->willReturn($userId);
+		$this->accountService->method('getActorFromUserId')
+			->with($userId, $this->anything())
+			->willReturn($actor);
+
+		return $actor;
+	}
+
+	private function assertSuccess(DataResponse $response, $result): void {
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['result' => $result, 'status' => 1], $response->getData());
+	}
+
+	private function assertFailure(DataResponse $response, string $exceptionClass, ?string $message = null, int $status = Http::STATUS_INTERNAL_SERVER_ERROR): void {
+		$this->assertSame($status, $response->getStatus());
+		$data = $response->getData();
+		$this->assertSame(-1, $data['status']);
+		$this->assertSame($exceptionClass, $data['exception']);
+		if ($message !== null) {
+			$this->assertSame($message, $data['message']);
+		}
+	}
+
+	private function assertNotLoggedIn(DataResponse $response): void {
+		$this->assertFailure($response, AccountDoesNotExistException::class, 'User not logged in');
+	}
+
+
+	// postCreate()
+
+	public function testPostCreateBuildsThePostFromTheRequest(): void {
+		$actor = $this->actorForUser();
+		$object = $this->createMock(Note::class);
+		$activity = $this->createMock(ACore::class);
+		$activity->method('getObject')->willReturn($object);
+
+		$created = null;
+		$this->postService->expects($this->once())->method('createPost')
+			->willReturnCallback(function (Post $post, string &$token) use (&$created, $activity): ACore {
+				$created = $post;
+				$token = 'tok-123';
+
+				return $activity;
+			});
+
+		$response = $this->controller()->postCreate(
+			'Hello <b>world</b>', ['bob@remote.example'], 'followers', 'https://remote.example/n/1',
+			['https://cloud.example/documents/1'], ['nextcloud']
+		);
+
+		$this->assertSuccess($response, ['post' => $object, 'token' => 'tok-123']);
+		$this->assertSame($actor, $created->getActor());
+		$this->assertSame('Hello <b>world</b>', $created->getContent());
+		$this->assertSame(['bob@remote.example'], $created->getTo());
+		$this->assertSame('followers', $created->getType());
+		$this->assertSame('https://remote.example/n/1', $created->getReplyTo());
+		$this->assertSame(['https://cloud.example/documents/1'], $created->getAttachments());
+		$this->assertSame(['nextcloud'], $created->getHashtags());
+	}
+
+	public function testPostCreateDefaultsToAPublicTopLevelPost(): void {
+		$this->actorForUser();
+		$created = null;
+		$this->postService->method('createPost')->willReturnCallback(function (Post $post) use (&$created): ACore {
+			$created = $post;
+
+			return $this->createMock(ACore::class);
+		});
+
+		$this->controller()->postCreate('just text');
+
+		$this->assertSame(Stream::TYPE_PUBLIC, $created->getType());
+		$this->assertSame('', $created->getReplyTo());
+		$this->assertSame([], $created->getTo());
+		$this->assertSame([], $created->getAttachments());
+		$this->assertSame([], $created->getHashtags());
+	}
+
+	public function testPostCreateRequiresALoggedInUser(): void {
+		$this->postService->expects($this->never())->method('createPost');
+
+		$this->assertNotLoggedIn($this->controller(null)->postCreate('x'));
+	}
+
+	public function testPostCreateReportsServiceFailures(): void {
+		$this->actorForUser();
+		$this->postService->method('createPost')->willThrowException(new \RuntimeException('cannot post'));
+
+		$this->assertFailure($this->controller()->postCreate('x'), \RuntimeException::class, 'cannot post');
+	}
+
+
+	// postGet() / postReplies() / postDelete()
+
+	public function testPostGetReturnsTheStreamDirectly(): void {
+		$this->actorForUser();
+		$stream = $this->createMock(Stream::class);
+		$this->streamService->method('getStreamById')->with('https://x/n/1', true)->willReturn($stream);
+
+		$response = $this->controller()->postGet('https://x/n/1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($stream, $response->getData());
+	}
+
+	public function testPostGetWorksAnonymously(): void {
+		$stream = $this->createMock(Stream::class);
+		$this->streamService->method('getStreamById')->willReturn($stream);
+		$this->accountService->expects($this->never())->method('getActorFromUserId');
+
+		$this->assertSame($stream, $this->controller(null)->postGet('https://x/n/1')->getData());
+	}
+
+	public function testPostGetOfUnknownStreamFails(): void {
+		$this->streamService->method('getStreamById')->willThrowException(new StreamNotFoundException());
+
+		$this->assertFailure($this->controller(null)->postGet('https://x/n/404'), StreamNotFoundException::class);
+	}
+
+	public function testPostRepliesPassPagination(): void {
+		$this->actorForUser();
+		$this->streamService->expects($this->once())->method('getRepliesByParentId')
+			->with('https://x/n/1', 100, 20, true)->willReturn(['r']);
+
+		$this->assertSuccess($this->controller()->postReplies('https://x/n/1', 100, 20), ['r']);
+	}
+
+	public function testPostDeleteRemovesTheUsersOwnNote(): void {
+		$this->actorForUser();
+		$note = $this->createMock(Stream::class);
+		$note->method('getAttributedTo')->willReturn('https://cloud.example/apps/social/@alice');
+		$this->streamService->method('getStreamById')->with('https://x/n/1')->willReturn($note);
+		$this->streamService->expects($this->once())->method('deleteLocalItem')->with($note, Note::TYPE);
+
+		$this->assertSuccess($this->controller()->postDelete('https://x/n/1'), []);
+	}
+
+	public function testPostDeleteRefusesSomeoneElsesNote(): void {
+		$this->actorForUser();
+		$note = $this->createMock(Stream::class);
+		$note->method('getAttributedTo')->willReturn('https://remote.example/users/bob');
+		$this->streamService->method('getStreamById')->willReturn($note);
+		$this->streamService->expects($this->never())->method('deleteLocalItem');
+
+		$this->assertFailure($this->controller()->postDelete('https://x/n/1'), InvalidResourceException::class, 'user have no rights');
+	}
+
+	public function testPostDeleteRequiresALoggedInUser(): void {
+		$this->streamService->expects($this->never())->method('getStreamById');
+
+		$this->assertNotLoggedIn($this->controller(null)->postDelete('https://x/n/1'));
+	}
+
+
+	// like / boost
+
+	/** @return iterable<string, array{string, string, string, string}> */
+	public function reactions(): iterable {
+		yield 'like' => ['postLike', 'likeService', 'create', 'like'];
+		yield 'unlike' => ['postUnlike', 'likeService', 'delete', 'like'];
+		yield 'boost' => ['postBoost', 'boostService', 'create', 'boost'];
+		yield 'unboost' => ['postUnboost', 'boostService', 'delete', 'boost'];
+	}
+
+	/** @dataProvider reactions */
+	public function testReactionsAreCreatedForTheViewer(string $action, string $service, string $method, string $key): void {
+		$viewer = $this->actorForUser();
+		$activity = $this->createMock(ACore::class);
+		$this->$service->expects($this->once())->method($method)
+			->willReturnCallback(function (Person $actor, string $postId, string &$token) use ($viewer, $activity): ACore {
+				$this->assertSame($viewer, $actor);
+				$this->assertSame('https://x/n/1', $postId);
+				$token = 'tok';
+
+				return $activity;
+			});
+
+		$this->assertSuccess($this->controller()->$action('https://x/n/1'), [$key => $activity, 'token' => 'tok']);
+	}
+
+	/** @dataProvider reactions */
+	public function testReactionsRequireALoggedInUser(string $action, string $service, string $method): void {
+		$this->$service->expects($this->never())->method($method);
+
+		$this->assertFailure($this->controller(null)->$action('https://x/n/1'), AccountDoesNotExistException::class, 'userId not defined');
+	}
+
+	public function testReactionFailuresAreReported(): void {
+		$this->actorForUser();
+		$this->likeService->method('create')->willThrowException(new StreamNotFoundException('no such post'));
+
+		$this->assertFailure($this->controller()->postLike('https://x/n/404'), StreamNotFoundException::class, 'no such post');
+	}
+
+
+	// follow / unfollow
+
+	public function testActionFollowFollowsAndRefreshesCounters(): void {
+		$actor = $this->actorForUser();
+		$this->followService->expects($this->once())->method('followAccount')->with($actor, 'bob@remote.example');
+		$this->accountService->expects($this->once())->method('cacheLocalActorDetailCount')->with($actor);
+
+		$this->assertSuccess($this->controller()->actionFollow('bob@remote.example'), []);
+	}
+
+	public function testActionFollowMapsServiceExceptionsToFailures(): void {
+		$this->actorForUser();
+		$this->followService->method('followAccount')->willThrowException(new FollowSameAccountException("Don't follow yourself, be your own lead"));
+		$this->accountService->expects($this->never())->method('cacheLocalActorDetailCount');
+
+		$this->assertFailure($this->controller()->actionFollow('alice'), FollowSameAccountException::class, "Don't follow yourself, be your own lead");
+	}
+
+	public function testActionFollowRequiresALoggedInUser(): void {
+		$this->followService->expects($this->never())->method('followAccount');
+
+		$this->assertNotLoggedIn($this->controller(null)->actionFollow('bob'));
+	}
+
+	public function testActionUnfollowUnfollowsAndRefreshesCounters(): void {
+		$actor = $this->actorForUser();
+		$this->followService->expects($this->once())->method('unfollowAccount')->with($actor, 'bob@remote.example');
+		$this->accountService->expects($this->once())->method('cacheLocalActorDetailCount')->with($actor);
+
+		$this->assertSuccess($this->controller()->actionUnfollow('bob@remote.example'), []);
+	}
+
+	public function testActionUnfollowMapsServiceExceptionsToFailures(): void {
+		$this->actorForUser();
+		$this->followService->method('unfollowAccount')->willThrowException(new CacheActorDoesNotExistException());
+
+		$this->assertFailure($this->controller()->actionUnfollow('ghost'), CacheActorDoesNotExistException::class);
+	}
+
+
+	// stream*()
+
+	/** @return iterable<string, array{string, array, string, array}> */
+	public function streams(): iterable {
+		yield 'home' => ['streamHome', [10, 25], 'getStreamHome', [10, 25]];
+		yield 'notifications' => ['streamNotifications', [3, 7], 'getStreamNotifications', [3, 7]];
+		yield 'direct' => ['streamDirect', [1, 2], 'getStreamDirect', [1, 2]];
+		yield 'local timeline' => ['streamTimeline', [5, 15], 'getStreamLocalTimeline', [5, 15]];
+		yield 'tag' => ['streamTag', ['nextcloud', 4, 8], 'getStreamLocalTag', ['nextcloud', 4, 8]];
+		yield 'federated' => ['streamFederated', [9, 9], 'getStreamGlobalTimeline', [9, 9]];
+		yield 'liked' => ['streamLiked', [0, 5], 'getStreamLiked', [0, 5]];
+	}
+
+	/** @dataProvider streams */
+	public function testStreamEndpointsPassSinceAndLimitToTheService(string $action, array $args, string $method, array $expected): void {
+		$viewer = $this->actorForUser();
+		$this->streamService->expects($this->once())->method('setViewer')->with($viewer);
+		$posts = [$this->createMock(Stream::class)];
+		$this->streamService->expects($this->once())->method($method)->with(...$expected)->willReturn($posts);
+
+		$this->assertSuccess($this->controller()->$action(...$args), $posts);
+	}
+
+	/** @dataProvider streams */
+	public function testStreamEndpointsRequireALoggedInUser(string $action, array $args, string $method): void {
+		$this->streamService->expects($this->never())->method($method);
+
+		$this->assertFailure($this->controller(null)->$action(...$args), AccountDoesNotExistException::class, 'userId not defined');
+	}
+
+	public function testStreamEndpointsFailWhenTheViewerCannotBeResolved(): void {
+		$this->accountService->method('getActorFromUserId')->willThrowException(new AccountDoesNotExistException('no actor'));
+
+		$response = $this->controller()->streamHome();
+
+		$this->assertFailure($response, AccountDoesNotExistException::class);
+		$this->assertStringContainsString('unable to initViewer', $response->getData()['message']);
+	}
+
+	public function testStreamAccountSyncsTheRemoteTimelineFirst(): void {
+		$account = $this->createMock(Person::class);
+		$account->method('getId')->willReturn('https://remote.example/users/bob');
+		$this->cacheActorService->method('getFromAccount')->with('bob@remote.example')->willReturn($account);
+		$this->streamService->expects($this->once())->method('syncRemoteTimeline')->with($account);
+		$this->streamService->expects($this->once())->method('getStreamAccount')
+			->with('https://remote.example/users/bob', 2, 6)->willReturn(['p']);
+
+		$this->assertSuccess($this->controller(null)->streamAccount('bob@remote.example', 2, 6), ['p']);
+	}
+
+
+	// current* / account* / global*
+
+	public function testCurrentInfoRefreshesAndReturnsTheCachedActor(): void {
+		$this->actorForUser();
+		$cached = $this->createMock(Person::class);
+		$this->accountService->expects($this->once())->method('cacheLocalActorByUsername')->with('alice');
+		$this->cacheActorService->method('getFromLocalAccount')->with('alice')->willReturn($cached);
+
+		$this->assertSuccess($this->controller()->currentInfo(), ['account' => $cached]);
+	}
+
+	public function testCurrentInfoRequiresALoggedInUser(): void {
+		$this->assertNotLoggedIn($this->controller(null)->currentInfo());
+	}
+
+	public function testCurrentFollowersAndFollowingListTheUsersRelations(): void {
+		$actor = $this->actorForUser();
+		$this->followService->method('getFollowers')->with($actor)->willReturn(['f1']);
+		$this->followService->method('getFollowing')->with($actor)->willReturn(['f2']);
+
+		$this->assertSuccess($this->controller()->currentFollowers(), ['f1']);
+		$this->assertSuccess($this->controller()->currentFollowing(), ['f2']);
+	}
+
+	public function testCurrentFollowersRequireALoggedInUser(): void {
+		$this->assertNotLoggedIn($this->controller(null)->currentFollowers());
+		$this->assertNotLoggedIn($this->controller(null)->currentFollowing());
+	}
+
+	public function testAccountInfoReturnsTheCompleteLocalActor(): void {
+		$actor = $this->createMock(Person::class);
+		$this->cacheActorService->method('getFromLocalAccount')->with('bob')->willReturn($actor);
+		$actor->expects($this->once())->method('setCompleteDetails')->with(true);
+		$actor->expects($this->once())->method('setExportFormat')->with(ACore::FORMAT_LOCAL);
+
+		$response = $this->controller(null)->accountInfo('bob');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($actor, $response->getData());
+	}
+
+	public function testAccountInfoRebuildsTheCacheOnAMiss(): void {
+		$actor = $this->createMock(Person::class);
+		$this->cacheActorService->method('getFromLocalAccount')->with('bob')
+			->will($this->onConsecutiveCalls($this->throwException(new CacheActorDoesNotExistException()), $actor));
+		$this->accountService->expects($this->once())->method('cacheLocalActorByUsername')->with('bob');
+
+		$this->assertSame($actor, $this->controller(null)->accountInfo('bob')->getData());
+	}
+
+	public function testAccountInfoOfUnknownUserFails(): void {
+		$this->cacheActorService->method('getFromLocalAccount')->willThrowException(new CacheActorDoesNotExistException());
+		$this->accountService->method('cacheLocalActorByUsername')->willThrowException(new AccountDoesNotExistException());
+
+		$this->assertFailure($this->controller(null)->accountInfo('ghost'), CacheActorDoesNotExistException::class);
+	}
+
+	public function testAccountFollowersAndFollowingOfALocalUser(): void {
+		$actor = $this->createMock(Person::class);
+		$this->cacheActorService->method('getFromLocalAccount')->with('bob')->willReturn($actor);
+		$this->followService->method('getFollowers')->with($actor)->willReturn(['f1']);
+		$this->followService->method('getFollowing')->with($actor)->willReturn(['f2']);
+
+		$this->assertSuccess($this->controller(null)->accountFollowers('bob'), ['f1']);
+		$this->assertSuccess($this->controller(null)->accountFollowing('bob'), ['f2']);
+	}
+
+	public function testGlobalAccountInfoEnsuresALocalActorExists(): void {
+		$actor = $this->createMock(Person::class);
+		$actor->method('isLocal')->willReturn(true);
+		$this->accountService->expects($this->once())->method('getActorFromUserId')->with('bob', true)->willReturn($this->createMock(Person::class));
+		$this->accountService->expects($this->once())->method('cacheLocalActorByUsername')->with('bob');
+		$this->cacheActorService->method('getFromLocalAccount')->with('bob')->willReturn($actor);
+		$this->cacheActorService->expects($this->never())->method('getFromAccount');
+		$this->cacheActorService->expects($this->never())->method('addRemoteActorDetailCount');
+		$actor->expects($this->once())->method('setExportFormat')->with(ACore::FORMAT_LOCAL);
+
+		$response = $this->controller(null)->globalAccountInfo('@bob');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($actor, $response->getData());
+	}
+
+	public function testGlobalAccountInfoTreatsOwnDomainAsLocal(): void {
+		$this->configService->method('getCloudHost')->willReturn('cloud.example');
+		$this->configService->method('getSocialAddress')->willReturn('social.example');
+		$actor = $this->createMock(Person::class);
+		$actor->method('isLocal')->willReturn(true);
+		$this->cacheActorService->method('getFromLocalAccount')->with('bob')->willReturn($actor);
+		$this->cacheActorService->expects($this->never())->method('getFromAccount');
+
+		$this->assertSame($actor, $this->controller(null)->globalAccountInfo('bob@social.example')->getData());
+	}
+
+	public function testGlobalAccountInfoFetchesRemoteActorsWithTheirCounters(): void {
+		$this->configService->method('getCloudHost')->willReturn('cloud.example');
+		$this->configService->method('getSocialAddress')->willReturn('cloud.example');
+		$actor = $this->createMock(Person::class);
+		$actor->method('isLocal')->willReturn(false);
+		$this->cacheActorService->method('getFromAccount')->with('bob@remote.example')->willReturn($actor);
+		$this->cacheActorService->expects($this->once())->method('addRemoteActorDetailCount')->with($actor);
+		$this->accountService->expects($this->never())->method('getActorFromUserId');
+
+		$this->assertSame($actor, $this->controller(null)->globalAccountInfo('bob@remote.example')->getData());
+	}
+
+	public function testGlobalAccountInfoToleratesCounterFailures(): void {
+		$this->configService->method('getCloudHost')->willReturn('cloud.example');
+		$actor = $this->createMock(Person::class);
+		$actor->method('isLocal')->willReturn(false);
+		$this->cacheActorService->method('getFromAccount')->willReturn($actor);
+		$this->cacheActorService->method('addRemoteActorDetailCount')->willThrowException(new \RuntimeException('offline'));
+
+		$this->assertSame(Http::STATUS_OK, $this->controller(null)->globalAccountInfo('bob@remote.example')->getStatus());
+	}
+
+	public function testGlobalAccountInfoOfUnknownRemoteAccountFails(): void {
+		$this->configService->method('getCloudHost')->willReturn('cloud.example');
+		$this->cacheActorService->method('getFromAccount')->willThrowException(new CacheActorDoesNotExistException());
+
+		$this->assertFailure($this->controller(null)->globalAccountInfo('ghost@remote.example'), CacheActorDoesNotExistException::class);
+	}
+
+	public function testGlobalActorInfoLooksUpById(): void {
+		$actor = $this->createMock(Person::class);
+		$this->cacheActorService->method('getFromId')->with('https://remote.example/users/bob')->willReturn($actor);
+
+		$this->assertSuccess($this->controller(null)->globalActorInfo('https://remote.example/users/bob'), ['actor' => $actor]);
+	}
+
+	public function testGlobalActorInfoOfUnknownIdFails(): void {
+		$this->cacheActorService->method('getFromId')->willThrowException(new CacheActorDoesNotExistException());
+
+		$this->assertFailure($this->controller(null)->globalActorInfo('https://x'), CacheActorDoesNotExistException::class);
+	}
+
+
+	// avatar / header
+
+	public function testGlobalActorAvatarServesTheCachedIcon(): void {
+		\OC::$server->register(ITimeFactory::class, $this->createMock(ITimeFactory::class));
+		$icon = $this->createMock(Document::class);
+		$icon->method('getId')->willReturn('https://remote.example/avatar.png');
+		$actor = $this->createMock(Person::class);
+		$actor->method('hasIcon')->willReturn(true);
+		$actor->method('getIcon')->willReturn($icon);
+		$this->cacheActorService->method('getFromId')->willReturn($actor);
+		$file = $this->createMock(ISimpleFile::class);
+		$file->method('getName')->willReturn('avatar');
+		$this->documentService->method('getFromCache')
+			->willReturnCallback(function (string $id, string &$mime) use ($file): ISimpleFile {
+				$this->assertSame('https://remote.example/avatar.png', $id);
+				$mime = 'image/png';
+
+				return $file;
+			});
+
+		$response = $this->controller(null)->globalActorAvatar('https://remote.example/users/bob');
+
+		$this->assertInstanceOf(FileDisplayResponse::class, $response);
+		$headers = $response->getHeaders();
+		$this->assertSame('image/png', $headers['Content-Type']);
+		$this->assertStringContainsString('max-age=86400', $headers['Cache-Control']);
+	}
+
+	public function testGlobalActorAvatarIs404WithoutIcon(): void {
+		$actor = $this->createMock(Person::class);
+		$actor->method('hasIcon')->willReturn(false);
+		$this->cacheActorService->method('getFromId')->willReturn($actor);
+
+		$this->assertFailure(
+			$this->controller(null)->globalActorAvatar('https://x'),
+			InvalidResourceException::class, 'no avatar for this Actor', Http::STATUS_NOT_FOUND
+		);
+	}
+
+	public function testGlobalActorHeaderRedirectsToTheHeaderImage(): void {
+		\OC::$server->register(ITimeFactory::class, $this->createMock(ITimeFactory::class));
+		$actor = $this->createMock(Person::class);
+		$actor->method('getHeader')->willReturn('https://remote.example/header.jpg');
+		$this->cacheActorService->method('getFromId')->willReturn($actor);
+
+		$response = $this->controller(null)->globalActorHeader('https://x');
+
+		$this->assertInstanceOf(RedirectResponse::class, $response);
+		$this->assertSame('https://remote.example/header.jpg', $response->getRedirectURL());
+		$this->assertStringContainsString('max-age=86400', $response->getHeaders()['Cache-Control']);
+	}
+
+	public function testGlobalActorHeaderIs404WithoutHeader(): void {
+		$actor = $this->createMock(Person::class);
+		$actor->method('getHeader')->willReturn('');
+		$this->cacheActorService->method('getFromId')->willReturn($actor);
+
+		$this->assertFailure(
+			$this->controller(null)->globalActorHeader('https://x'),
+			InvalidResourceException::class, 'no header for this Actor', Http::STATUS_NOT_FOUND
+		);
+	}
+
+
+	// search
+
+	public function testGlobalAccountsSearchWithEmptyTermIsEmpty(): void {
+		$this->cacheActorService->expects($this->never())->method('searchCachedAccounts');
+
+		$this->assertSuccess($this->controller()->globalAccountsSearch('@'), ['accounts' => [], 'exact' => []]);
+	}
+
+	public function testGlobalAccountsSearchStripsTheAtAndReturnsExactMatch(): void {
+		$this->actorForUser();
+		$exact = $this->createMock(Person::class);
+		$exact->expects($this->once())->method('setCompleteDetails')->with(true);
+		$this->cacheActorService->method('getFromAccount')->with('bob@remote.example', false)->willReturn($exact);
+		$this->cacheActorService->method('searchCachedAccounts')->with('bob@remote.example')->willReturn(['a1', 'a2']);
+
+		$this->assertSuccess(
+			$this->controller()->globalAccountsSearch('@bob@remote.example'),
+			['accounts' => ['a1', 'a2'], 'exact' => $exact]
+		);
+	}
+
+	public function testGlobalAccountsSearchWithoutExactMatch(): void {
+		$this->cacheActorService->method('getFromAccount')->willThrowException(new CacheActorDoesNotExistException());
+		$this->cacheActorService->method('searchCachedAccounts')->willReturn([]);
+
+		$this->assertSuccess($this->controller(null)->globalAccountsSearch('nobody'), ['accounts' => [], 'exact' => null]);
+	}
+
+	public function testGlobalTagsSearchWithEmptyTermIsEmpty(): void {
+		$this->hashtagService->expects($this->never())->method('searchHashtags');
+
+		$this->assertSuccess($this->controller(null)->globalTagsSearch('#'), ['tags' => [], 'exact' => []]);
+	}
+
+	public function testGlobalTagsSearchStripsTheHashAndReturnsExactMatch(): void {
+		$this->hashtagService->method('getHashtag')->with('nextcloud')->willReturn(['hashtag' => 'nextcloud']);
+		$this->hashtagService->method('searchHashtags')->with('nextcloud', false)->willReturn(['t1']);
+
+		$this->assertSuccess(
+			$this->controller(null)->globalTagsSearch('#nextcloud'),
+			['tags' => ['t1'], 'exact' => ['hashtag' => 'nextcloud']]
+		);
+	}
+
+	public function testSearchTrimsTheTermAndQueriesAllKinds(): void {
+		$this->searchService->method('searchAccounts')->with('term')->willReturn(['a']);
+		$this->searchService->method('searchHashtags')->with('term')->willReturn(['h']);
+		$this->searchService->method('searchStreamContent')->with('term')->willReturn(['c']);
+
+		$this->assertSuccess(
+			$this->controller(null)->search('  term '),
+			['accounts' => ['a'], 'hashtags' => ['h'], 'content' => ['c']]
+		);
+	}
+
+
+	// documents / uploads
+
+	public function testDocumentsCacheSkipsDocumentsThatCannotBeCached(): void {
+		$doc = $this->createMock(Document::class);
+		$this->documentService->method('cacheRemoteDocument')->willReturnCallback(function (string $id) use ($doc): Document {
+			if ($id === 'bad') {
+				throw new \RuntimeException('unreachable');
+			}
+
+			return $doc;
+		});
+
+		$this->assertSuccess($this->controller()->documentsCache(['good', 'bad']), [$doc]);
+	}
+
+	public function testUploadAttachementIsNotImplemented(): void {
+		$this->assertFailure($this->controller()->uploadAttachement(), \BadMethodCallException::class);
+	}
+
+	public function testUploadBannerRequiresALoggedInUser(): void {
+		$this->cacheDocumentService->expects($this->never())->method('saveFromTempToCache');
+
+		$this->assertNotLoggedIn($this->controller(null)->uploadBanner());
+	}
+
+	public function testUploadBannerRequiresAFile(): void {
+		$this->cacheDocumentService->expects($this->never())->method('saveFromTempToCache');
+
+		$this->assertFailure($this->controller()->uploadBanner(), \Exception::class, 'no banner file provided');
+	}
+
+	public function testUploadBannerRejectsFailedUploads(): void {
+		$_FILES['file'] = ['tmp_name' => '', 'error' => UPLOAD_ERR_NO_FILE];
+		$this->accountService->expects($this->never())->method('getActorFromUserId');
+
+		$this->assertFailure($this->controller()->uploadBanner(), \Exception::class, 'no banner file provided');
+	}
+
+	public function testUploadBannerByUrlRequiresALoggedInUser(): void {
+		$this->assertNotLoggedIn($this->controller(null)->uploadBannerByUrl('https://example.org/banner.png'));
+	}
+
+	public function testUploadBannerByUrlRequiresAUrl(): void {
+		$this->accountService->expects($this->never())->method('getActorFromUserId');
+
+		$this->assertFailure($this->controller()->uploadBannerByUrl(''), \Exception::class, 'No URL provided');
+	}
+}

--- a/tests/Controller/MediaApiControllerTest.php
+++ b/tests/Controller/MediaApiControllerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Controller;
+
+use OCA\Social\Controller\MediaApiController;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use PHPUnit\Framework\TestCase;
+
+class MediaApiControllerTest extends TestCase {
+	public function testUploadMediaReturnsAPlaceholderAttachment(): void {
+		$controller = new MediaApiController('social', $this->createMock(IRequest::class));
+
+		$response = $controller->uploadMedia();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(
+			['id' => 1, 'url' => '', 'preview_url' => '', 'remote_url' => null, 'description' => ''],
+			$response->getData()
+		);
+	}
+
+	public function testImageAllowlistCoversCommonWebFormatsOnly(): void {
+		foreach (['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/svg+xml'] as $mime) {
+			$this->assertContains($mime, MediaApiController::IMAGE_MIME_TYPES);
+		}
+		foreach (['text/html', 'application/pdf', 'video/mp4', 'image/tiff'] as $mime) {
+			$this->assertNotContains($mime, MediaApiController::IMAGE_MIME_TYPES);
+		}
+	}
+}

--- a/tests/Controller/NavigationControllerTest.php
+++ b/tests/Controller/NavigationControllerTest.php
@@ -1,0 +1,340 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Controller;
+
+use OCA\Social\Controller\NavigationController;
+use OCA\Social\Exceptions\AccountAlreadyExistsException;
+use OCA\Social\Exceptions\CacheDocumentDoesNotExistException;
+use OCA\Social\Exceptions\SocialAppConfigException;
+use OCA\Social\Service\AccountService;
+use OCA\Social\Service\CheckService;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\DocumentService;
+use OCA\Social\Service\MiscService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\FileDisplayResponse;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\Files\SimpleFS\ISimpleFile;
+use OCP\IConfig;
+use OCP\IGroupManager;
+use OCP\IInitialStateService;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class NavigationControllerTest extends TestCase {
+	/** @var IRequest&MockObject */
+	private $request;
+	/** @var IConfig&MockObject */
+	private $config;
+	/** @var IInitialStateService&MockObject */
+	private $initialStateService;
+	/** @var IURLGenerator&MockObject */
+	private $urlGenerator;
+	/** @var AccountService&MockObject */
+	private $accountService;
+	/** @var DocumentService&MockObject */
+	private $documentService;
+	/** @var ConfigService&MockObject */
+	private $configService;
+	/** @var CheckService&MockObject */
+	private $checkService;
+	/** @var IGroupManager&MockObject */
+	private $groupManager;
+	private array $states = [];
+	private string|false $frontControllerEnv;
+
+	protected function setUp(): void {
+		$this->frontControllerEnv = getenv('front_controller_active');
+		putenv('front_controller_active');
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->initialStateService = $this->createMock(IInitialStateService::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->accountService = $this->createMock(AccountService::class);
+		$this->documentService = $this->createMock(DocumentService::class);
+		$this->configService = $this->createMock(ConfigService::class);
+		$this->checkService = $this->createMock(CheckService::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+
+		$this->initialStateService->method('provideInitialState')
+			->willReturnCallback(function (string $app, string $key, $data): void {
+				$this->states[$app][$key] = $data;
+			});
+		$this->urlGenerator->method('getBaseUrl')->willReturn('https://cloud.example/');
+
+		\OC::$server->register(IRequest::class, $this->request);
+		\OC::$server->register(IGroupManager::class, $this->groupManager);
+	}
+
+	protected function tearDown(): void {
+		if ($this->frontControllerEnv === false) {
+			putenv('front_controller_active');
+		} else {
+			putenv('front_controller_active=' . $this->frontControllerEnv);
+		}
+		\OC::$server->reset();
+	}
+
+	private function controller(?string $userId = 'alice'): NavigationController {
+		return new NavigationController(
+			$this->createMock(IL10N::class),
+			$this->request,
+			$userId,
+			$this->config,
+			$this->initialStateService,
+			$this->urlGenerator,
+			$this->accountService,
+			$this->documentService,
+			$this->configService,
+			$this->checkService,
+			$this->createMock(MiscService::class),
+			new NullLogger()
+		);
+	}
+
+	private function systemValues(array $values): void {
+		$this->config->method('getSystemValue')
+			->willReturnCallback(fn (string $key, $default = '') => $values[$key] ?? $default);
+	}
+
+	private function configuredCloud(string $url = 'https://cloud.example/index.php'): void {
+		$this->configService->method('getCloudUrl')->willReturn($url);
+		$this->configService->method('getSocialUrl')->willReturn($url . '/apps/social/');
+	}
+
+	private function existingActor(): void {
+		$this->accountService->method('createActor')->willThrowException(new AccountAlreadyExistsException());
+	}
+
+	private function serverData(): array {
+		return $this->states['social']['serverData'];
+	}
+
+
+	// navigate()
+
+	public function testNavigateRendersTheAppForAReturningUser(): void {
+		$this->systemValues([]);
+		$this->configuredCloud();
+		$this->existingActor();
+		$this->groupManager->method('isAdmin')->with('alice')->willReturn(false);
+		$this->checkService->expects($this->never())->method('checkDefault');
+		$this->checkService->expects($this->never())->method('checkInstallationStatus');
+
+		$response = $this->controller()->navigate();
+
+		$this->assertInstanceOf(TemplateResponse::class, $response);
+		$this->assertSame('main', $response->getTemplateName());
+		$this->assertSame([
+			'public' => false,
+			'firstrun' => false,
+			'setup' => false,
+			'isAdmin' => false,
+			'cliUrl' => 'https://cloud.example/index.php',
+			'cloudAddress' => 'https://cloud.example/index.php',
+		], $this->serverData());
+	}
+
+	public function testNavigateCreatesTheActorOnFirstRun(): void {
+		$this->systemValues([]);
+		$this->configuredCloud();
+		$this->accountService->expects($this->once())->method('createActor')->with('alice', 'alice');
+
+		$this->controller()->navigate();
+
+		$this->assertTrue($this->serverData()['firstrun']);
+	}
+
+	public function testNavigateAddsChecksForAdmins(): void {
+		$this->systemValues([]);
+		$this->configuredCloud();
+		$this->existingActor();
+		$this->groupManager->method('isAdmin')->with('alice')->willReturn(true);
+		$this->checkService->method('checkDefault')->willReturn(['wellknown' => true]);
+
+		$this->controller()->navigate();
+
+		$this->assertTrue($this->serverData()['isAdmin']);
+		$this->assertSame(['wellknown' => true], $this->serverData()['checks']);
+	}
+
+	public function testNavigateOmitsIndexPhpWhenFrontControllerIsActive(): void {
+		$this->systemValues(['htaccess.IgnoreFrontController' => true]);
+		$this->configuredCloud();
+		$this->existingActor();
+
+		$this->controller()->navigate();
+
+		$this->assertSame('https://cloud.example', $this->serverData()['cliUrl']);
+	}
+
+	public function testNavigateAutoConfiguresTheCloudAddressFromCliUrl(): void {
+		$this->systemValues(['overwrite.cli.url' => 'https://cloud.example/']);
+		$this->configService->method('getCloudUrl')->willThrowException(new SocialAppConfigException());
+		$this->configService->method('getSocialUrl')->willReturn('x');
+		$this->checkService->expects($this->once())->method('checkInstallationStatus')->with(true);
+		$this->configService->expects($this->once())->method('setCloudUrl')->with('https://cloud.example/index.php');
+		$this->existingActor();
+
+		$this->controller()->navigate();
+
+		$this->assertSame('https://cloud.example/index.php', $this->serverData()['cloudAddress']);
+		$this->assertFalse($this->serverData()['setup']);
+	}
+
+	public function testNavigateShowsTheSetupPageToAdminsWhenNothingIsConfigured(): void {
+		$this->systemValues([]);
+		$this->configService->method('getCloudUrl')->willThrowException(new SocialAppConfigException());
+		$this->groupManager->method('isAdmin')->willReturn(true);
+		$this->request->method('getParam')->with('cloudAddress')->willReturn(null);
+		$this->accountService->expects($this->never())->method('createActor');
+		$this->checkService->expects($this->never())->method('checkDefault');
+
+		$response = $this->controller()->navigate();
+
+		$this->assertInstanceOf(TemplateResponse::class, $response);
+		$this->assertTrue($this->serverData()['setup']);
+		$this->assertTrue($this->serverData()['isAdmin']);
+		$this->assertArrayNotHasKey('cloudAddress', $this->serverData());
+	}
+
+	public function testNavigateStoresTheCloudAddressSubmittedByAnAdmin(): void {
+		$this->systemValues([]);
+		$this->configService->method('getCloudUrl')->willThrowException(new SocialAppConfigException());
+		$this->configService->method('getSocialUrl')->willReturn('x');
+		$this->groupManager->method('isAdmin')->willReturn(true);
+		$this->request->method('getParam')->with('cloudAddress')->willReturn('https://cloud.example/index.php');
+		$this->configService->expects($this->once())->method('setCloudUrl')->with('https://cloud.example/index.php');
+		$this->existingActor();
+
+		$this->controller()->navigate();
+
+		$this->assertTrue($this->serverData()['setup']);
+		$this->assertArrayHasKey('checks', $this->serverData());
+	}
+
+	public function testNavigateContinuesForNonAdminsWhenSetupIsMissing(): void {
+		$this->systemValues([]);
+		$this->configService->method('getCloudUrl')->willThrowException(new SocialAppConfigException());
+		$this->configService->method('getSocialUrl')->willReturn('x');
+		$this->groupManager->method('isAdmin')->willReturn(false);
+		$this->configService->expects($this->never())->method('setCloudUrl');
+		$this->existingActor();
+
+		$response = $this->controller()->navigate();
+
+		$this->assertInstanceOf(TemplateResponse::class, $response);
+		$this->assertTrue($this->serverData()['setup']);
+	}
+
+	public function testNavigateInitialisesTheSocialUrlWhenMissing(): void {
+		$this->systemValues([]);
+		$this->configService->method('getCloudUrl')->willReturn('https://cloud.example');
+		$this->configService->method('getSocialUrl')->willThrowException(new SocialAppConfigException());
+		$this->configService->expects($this->once())->method('setSocialUrl');
+		$this->existingActor();
+
+		$this->controller()->navigate();
+	}
+
+	public function testNavigateSurvivesActorCreationConfigErrors(): void {
+		$this->systemValues([]);
+		$this->configuredCloud();
+		$this->accountService->method('createActor')->willThrowException(new SocialAppConfigException());
+
+		$this->assertInstanceOf(TemplateResponse::class, $this->controller()->navigate());
+		$this->assertFalse($this->serverData()['firstrun']);
+	}
+
+	public function testTimelineAndAccountRenderTheSamePage(): void {
+		$this->systemValues([]);
+		$this->configuredCloud();
+		$this->existingActor();
+
+		$this->assertSame('main', $this->controller()->timeline('home')->getTemplateName());
+		$this->assertSame('main', $this->controller()->account('alice')->getTemplateName());
+	}
+
+
+	// documents
+
+	private function cachedFile(string $method, string $mime, ?bool $public): ISimpleFile {
+		$file = $this->createMock(ISimpleFile::class);
+		$file->method('getName')->willReturn('doc');
+		$this->documentService->expects($this->once())->method($method)
+			->willReturnCallback(function (string $id, string &$mimeType, bool $isPublic = false) use ($file, $mime, $public): ISimpleFile {
+				$this->assertSame('doc-1', $id);
+				if ($public !== null) {
+					$this->assertSame($public, $isPublic);
+				}
+				$mimeType = $mime;
+
+				return $file;
+			});
+
+		return $file;
+	}
+
+	private function assertServes(FileDisplayResponse|DataResponse $response, string $mime): void {
+		$this->assertInstanceOf(FileDisplayResponse::class, $response);
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($mime, $response->getHeaders()['Content-Type']);
+	}
+
+	public function testDocumentGetServesTheCachedDocument(): void {
+		$this->cachedFile('getFromCache', 'image/jpeg', false);
+
+		$this->assertServes($this->controller()->documentGet('doc-1'), 'image/jpeg');
+	}
+
+	public function testDocumentGetPublicOnlyServesPublicDocuments(): void {
+		$this->cachedFile('getFromCache', 'image/png', true);
+
+		$this->assertServes($this->controller(null)->documentGetPublic('doc-1'), 'image/png');
+	}
+
+	public function testResizedGetServesTheResizedCopy(): void {
+		$this->cachedFile('getResizedFromCache', 'image/webp', false);
+
+		$this->assertServes($this->controller()->resizedGet('doc-1'), 'image/webp');
+	}
+
+	public function testResizedGetPublicOnlyServesPublicDocuments(): void {
+		$this->cachedFile('getResizedFromCache', 'image/gif', true);
+
+		$this->assertServes($this->controller(null)->resizedGetPublic('doc-1'), 'image/gif');
+	}
+
+	/** @return iterable<string, array{string, string}> */
+	public function documentEndpoints(): iterable {
+		yield 'documentGet' => ['documentGet', 'getFromCache'];
+		yield 'documentGetPublic' => ['documentGetPublic', 'getFromCache'];
+		yield 'resizedGet' => ['resizedGet', 'getResizedFromCache'];
+		yield 'resizedGetPublic' => ['resizedGetPublic', 'getResizedFromCache'];
+	}
+
+	/** @dataProvider documentEndpoints */
+	public function testMissingDocumentsAreReportedAsFailures(string $action, string $method): void {
+		$this->documentService->method($method)->willThrowException(new CacheDocumentDoesNotExistException('missing'));
+
+		$response = $this->controller()->$action('doc-404');
+
+		$this->assertInstanceOf(DataResponse::class, $response);
+		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		$this->assertSame(-1, $response->getData()['status']);
+		$this->assertSame(CacheDocumentDoesNotExistException::class, $response->getData()['exception']);
+	}
+}

--- a/tests/Controller/OAuthControllerTest.php
+++ b/tests/Controller/OAuthControllerTest.php
@@ -1,0 +1,340 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Controller;
+
+use OCA\Social\Controller\OAuthController;
+use OCA\Social\Exceptions\ClientException;
+use OCA\Social\Exceptions\ClientNotFoundException;
+use OCA\Social\Exceptions\InstanceDoesNotExistException;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\Client\SocialClient;
+use OCA\Social\Model\Instance;
+use OCA\Social\Service\AccountService;
+use OCA\Social\Service\ClientService;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\InstanceService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Services\IInitialState;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class OAuthControllerTest extends TestCase {
+	private const OOB = 'urn:ietf:wg:oauth:2.0:oob';
+
+	/** @var IUserSession&MockObject */
+	private $userSession;
+	/** @var IURLGenerator&MockObject */
+	private $urlGenerator;
+	/** @var InstanceService&MockObject */
+	private $instanceService;
+	/** @var AccountService&MockObject */
+	private $accountService;
+	/** @var ClientService&MockObject */
+	private $clientService;
+	/** @var ConfigService&MockObject */
+	private $configService;
+	/** @var IInitialState&MockObject */
+	private $initialState;
+	private OAuthController $controller;
+
+	protected function setUp(): void {
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->instanceService = $this->createMock(InstanceService::class);
+		$this->accountService = $this->createMock(AccountService::class);
+		$this->clientService = $this->createMock(ClientService::class);
+		$this->configService = $this->createMock(ConfigService::class);
+		$this->initialState = $this->createMock(IInitialState::class);
+
+		$this->controller = new OAuthController(
+			$this->createMock(IRequest::class),
+			$this->userSession,
+			$this->urlGenerator,
+			$this->instanceService,
+			$this->accountService,
+			$this->clientService,
+			$this->configService,
+			new NullLogger(),
+			$this->initialState
+		);
+	}
+
+	protected function tearDown(): void {
+		\OC::$server->reset();
+	}
+
+	private function loggedIn(string $uid = 'alice'): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$this->userSession->method('getUser')->willReturn($user);
+		$actor = $this->createMock(Person::class);
+		$actor->method('getPreferredUsername')->willReturn($uid);
+		$this->accountService->method('getActorFromUserId')->with($uid)->willReturn($actor);
+	}
+
+	private function knownClient(string $clientId = 'client-1', string $appName = 'Tusky'): SocialClient {
+		$client = new SocialClient();
+		$client->setAppClientId($clientId)->setAppName($appName);
+		$this->clientService->method('getFromClientId')->with($clientId)->willReturn($client);
+
+		return $client;
+	}
+
+
+	// nodeinfo2()
+
+	public function testNodeinfo2DescribesTheLocalInstance(): void {
+		$instance = new Instance();
+		$instance->setTitle('My Social')->setVersion('0.10.1')->setUsage(['users' => ['total' => 3]])->setRegistrations(true);
+		$this->instanceService->method('getLocal')->willReturn($instance);
+		$this->urlGenerator->method('linkToRouteAbsolute')->with('social.Navigation.navigate')->willReturn('https://cloud.example/apps/social/');
+
+		$response = $this->controller->nodeinfo2();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame([
+			'version' => '2.0',
+			'software' => ['name' => 'My Social', 'version' => '0.10.1'],
+			'protocols' => ['activitypub'],
+			'rootUrl' => 'https://cloud.example/apps/social',
+			'usage' => ['users' => ['total' => 3]],
+			'openRegistrations' => true,
+		], $response->getData());
+	}
+
+	public function testNodeinfo2FallsBackToAppDefaultsWithoutAnInstance(): void {
+		$this->instanceService->method('getLocal')->willThrowException(new InstanceDoesNotExistException());
+		$this->configService->method('getAppValue')->with('installed_version')->willReturn('0.10.1');
+		$this->urlGenerator->method('linkToRouteAbsolute')->willReturn('https://cloud.example/apps/social/');
+
+		$data = $this->controller->nodeinfo2()->getData();
+
+		$this->assertSame(['name' => 'Nextcloud Social', 'version' => '0.10.1'], $data['software']);
+		$this->assertSame([], $data['usage']);
+		$this->assertFalse($data['openRegistrations']);
+	}
+
+
+	// apps()
+
+	public function testAppsRegistersAClientAndReturnsItsCredentials(): void {
+		$this->clientService->expects($this->once())->method('createApp')
+			->willReturnCallback(function (SocialClient $client): void {
+				$this->assertSame('Tusky', $client->getAppName());
+				$this->assertSame('https://tusky.app', $client->getAppWebsite());
+				$this->assertSame(['https://tusky.app/callback'], $client->getAppRedirectUris());
+				$this->assertSame(['read', 'write'], $client->getAppScopes());
+				$client->setId(7)->setAppClientId('cid')->setAppClientSecret('csecret');
+			});
+
+		$response = $this->controller->apps('Tusky', 'https://tusky.app/callback', 'https://tusky.app', 'read write');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame([
+			'id' => 7,
+			'name' => 'Tusky',
+			'website' => 'https://tusky.app',
+			'scopes' => 'read write',
+			'client_id' => 'cid',
+			'client_secret' => 'csecret',
+		], $response->getData());
+	}
+
+	public function testAppsAcceptsAListOfRedirectUris(): void {
+		$this->clientService->expects($this->once())->method('createApp')
+			->with($this->callback(fn (SocialClient $c): bool => $c->getAppRedirectUris() === ['https://a/cb', 'https://b/cb']));
+
+		$this->controller->apps('App', ['https://a/cb', 'https://b/cb']);
+	}
+
+	public function testAppsDefaultsToReadScope(): void {
+		$this->clientService->method('createApp');
+
+		$this->assertSame('read', $this->controller->apps('App', 'https://a/cb')->getData()['scopes']);
+	}
+
+
+	// authorize()
+
+	public function testAuthorizeRendersTheConsentPageForAKnownClient(): void {
+		$this->loggedIn();
+		$this->knownClient();
+		$this->initialState->expects($this->once())->method('provideInitialState')->with('appName', 'Tusky');
+
+		$response = $this->controller->authorize('client-1', self::OOB, 'code', 'read write');
+
+		$this->assertInstanceOf(TemplateResponse::class, $response);
+		$this->assertSame('oauth2', $response->getTemplateName());
+		$this->assertSame([
+			'request' => [
+				'clientId' => 'client-1',
+				'redirectUri' => self::OOB,
+				'responseType' => 'code',
+				'scope' => 'read write',
+			],
+		], $response->getParams());
+	}
+
+	public function testAuthorizeRejectsNonCodeResponseTypes(): void {
+		$this->loggedIn();
+		$this->clientService->expects($this->never())->method('getFromClientId');
+
+		$this->expectException(ClientNotFoundException::class);
+		$this->expectExceptionMessage('invalid response type');
+
+		$this->controller->authorize('client-1', self::OOB, 'token');
+	}
+
+	public function testAuthorizeRejectsUnknownClients(): void {
+		$this->loggedIn();
+		$this->clientService->method('getFromClientId')->willThrowException(new ClientNotFoundException('unknown'));
+
+		$this->expectException(ClientNotFoundException::class);
+
+		$this->controller->authorize('nope', self::OOB, 'code');
+	}
+
+
+	// authorizing()
+
+	public function testAuthorizingIssuesACodeBoundToTheUser(): void {
+		$this->loggedIn('alice');
+		$client = $this->knownClient();
+		$this->clientService->expects($this->once())->method('confirmData')
+			->with($client, $this->callback(fn (array $data): bool => $data['app_scopes'] === 'read write'));
+		$this->clientService->expects($this->once())->method('authClient')
+			->willReturnCallback(function (SocialClient $c): void {
+				$this->assertSame(['read', 'write'], $c->getAuthScopes());
+				$this->assertSame('alice', $c->getAuthAccount());
+				$this->assertSame('alice', $c->getAuthUserId());
+				$c->setAuthCode('auth-code-1');
+			});
+
+		$response = $this->controller->authorizing('client-1', self::OOB, 'code', 'read write');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['code' => 'auth-code-1'], $response->getData());
+	}
+
+	public function testAuthorizingRejectsNonCodeResponseTypes(): void {
+		$this->loggedIn();
+		$this->clientService->expects($this->never())->method('authClient');
+
+		$response = $this->controller->authorizing('client-1', self::OOB, 'token');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'invalid response type'], $response->getData());
+	}
+
+	public function testAuthorizingRejectsUnknownClients(): void {
+		$this->loggedIn();
+		$this->clientService->method('getFromClientId')->willThrowException(new ClientNotFoundException('unknown client'));
+
+		$response = $this->controller->authorizing('nope', self::OOB, 'code');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'unknown client'], $response->getData());
+	}
+
+	public function testAuthorizingRejectsMismatchingClientData(): void {
+		$this->loggedIn();
+		$this->knownClient();
+		$this->clientService->method('confirmData')->willThrowException(new ClientException('wrong scopes'));
+		$this->clientService->expects($this->never())->method('authClient');
+
+		$response = $this->controller->authorizing('client-1', self::OOB, 'code', 'admin');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'wrong scopes'], $response->getData());
+	}
+
+
+	// token()
+
+	public function testTokenExchangesAnAuthorizationCodeForABearerToken(): void {
+		$client = $this->knownClient();
+		$client->setCreation(1700000000);
+		$confirmations = [];
+		$this->clientService->method('confirmData')->willReturnCallback(function (SocialClient $c, array $data) use (&$confirmations): void {
+			$confirmations[] = $data;
+		});
+		$this->clientService->expects($this->once())->method('generateToken')
+			->willReturnCallback(fn (SocialClient $c) => $c->setToken('bearer-token'));
+
+		$response = $this->controller->token('client-1', 'secret', self::OOB, 'authorization_code', 'read', 'auth-code-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame([
+			'access_token' => 'bearer-token',
+			'token_type' => 'Bearer',
+			'scope' => 'read',
+			'created_at' => 1700000000,
+		], $response->getData());
+		$this->assertSame([
+			['client_secret' => 'secret', 'redirect_uri' => self::OOB, 'auth_scopes' => 'read'],
+			['code' => 'auth-code-1'],
+		], $confirmations);
+	}
+
+	public function testTokenRequiresACodeForTheAuthorizationCodeGrant(): void {
+		$this->knownClient();
+		$this->clientService->expects($this->never())->method('generateToken');
+
+		$response = $this->controller->token('client-1', 'secret', self::OOB, 'authorization_code');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'missing code'], $response->getData());
+	}
+
+	public function testTokenRejectsUnknownGrantTypes(): void {
+		$this->knownClient();
+
+		$response = $this->controller->token('client-1', 'secret', self::OOB, 'password');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'invalid value for grant_type'], $response->getData());
+	}
+
+	public function testTokenClientCredentialsGrantIsNotIssuedYet(): void {
+		$this->knownClient();
+		$this->clientService->expects($this->never())->method('generateToken');
+
+		$response = $this->controller->token('client-1', 'secret', self::OOB, 'client_credentials');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(['error' => 'issue generating access_token'], $response->getData());
+	}
+
+	public function testTokenRejectsUnknownClientIds(): void {
+		$this->clientService->method('getFromClientId')->willThrowException(new ClientNotFoundException());
+
+		$response = $this->controller->token('nope', 'secret', self::OOB, 'authorization_code', 'read', 'c');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['error' => 'unknown client_id'], $response->getData());
+	}
+
+	public function testTokenRejectsAWrongClientSecret(): void {
+		$this->knownClient();
+		$this->clientService->method('confirmData')->willThrowException(new ClientException('wrong client_secret'));
+		$this->clientService->expects($this->never())->method('generateToken');
+
+		$response = $this->controller->token('client-1', 'wrong', self::OOB, 'authorization_code', 'read', 'c');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame(['error' => 'wrong client_secret'], $response->getData());
+	}
+}

--- a/tests/Controller/OStatusControllerTest.php
+++ b/tests/Controller/OStatusControllerTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Controller;
+
+use OCA\Social\Controller\OStatusController;
+use OCA\Social\Exceptions\AccountDoesNotExistException;
+use OCA\Social\Exceptions\CacheActorDoesNotExistException;
+use OCA\Social\Exceptions\InvalidResourceException;
+use OCA\Social\Exceptions\RetrieveAccountFormatException;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Service\AccountService;
+use OCA\Social\Service\CacheActorService;
+use OCA\Social\Service\CurlService;
+use OCA\Social\Service\MiscService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IInitialStateService;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class OStatusControllerTest extends TestCase {
+	/** @var IInitialStateService&MockObject */
+	private $initialStateService;
+	/** @var CacheActorService&MockObject */
+	private $cacheActorService;
+	/** @var AccountService&MockObject */
+	private $accountService;
+	/** @var CurlService&MockObject */
+	private $curlService;
+	/** @var IUserSession&MockObject */
+	private $userSession;
+	private OStatusController $controller;
+	private array $states = [];
+
+	protected function setUp(): void {
+		$this->initialStateService = $this->createMock(IInitialStateService::class);
+		$this->cacheActorService = $this->createMock(CacheActorService::class);
+		$this->accountService = $this->createMock(AccountService::class);
+		$this->curlService = $this->createMock(CurlService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+
+		$this->initialStateService->method('provideInitialState')
+			->willReturnCallback(function (string $app, string $key, $data): void {
+				$this->states[$app][$key] = $data;
+			});
+
+		$this->controller = new OStatusController(
+			$this->createMock(IRequest::class),
+			$this->initialStateService,
+			$this->cacheActorService,
+			$this->accountService,
+			$this->curlService,
+			$this->createMock(MiscService::class),
+			$this->userSession
+		);
+	}
+
+	protected function tearDown(): void {
+		\OC::$server->reset();
+	}
+
+	private function loggedIn(string $uid, string $displayName): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$user->method('getDisplayName')->willReturn($displayName);
+		$this->userSession->method('getUser')->willReturn($user);
+	}
+
+	/** @return Person&MockObject */
+	private function actorWithAccount(string $account): Person {
+		$actor = $this->createMock(Person::class);
+		$actor->method('getAccount')->willReturn($account);
+
+		return $actor;
+	}
+
+	private function assertFailure(DataResponse $response, string $exceptionClass): void {
+		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		$this->assertSame(-1, $response->getData()['status']);
+		$this->assertSame($exceptionClass, $response->getData()['exception']);
+	}
+
+	public function testSubscribeRendersTheAppWithTargetAccountAndCurrentUser(): void {
+		$this->loggedIn('alice', 'Alice A.');
+		$this->cacheActorService->method('getFromAccount')->with('bob@remote.example')
+			->willReturn($this->actorWithAccount('bob@remote.example'));
+
+		$response = $this->controller->subscribe('bob@remote.example');
+
+		$this->assertInstanceOf(TemplateResponse::class, $response);
+		$this->assertSame('main', $response->getTemplateName());
+		$this->assertSame([
+			'account' => 'bob@remote.example',
+			'currentUser' => ['uid' => 'alice', 'displayName' => 'Alice A.'],
+		], $this->states['social']['serverData']);
+	}
+
+	public function testSubscribeFallsBackToActorIdWhenUriIsNotAnAccount(): void {
+		$this->loggedIn('alice', 'Alice');
+		$this->cacheActorService->method('getFromAccount')->willThrowException(new InvalidResourceException());
+		$this->cacheActorService->expects($this->once())->method('getFromId')->with('https://remote.example/users/bob')
+			->willReturn($this->actorWithAccount('bob@remote.example'));
+
+		$response = $this->controller->subscribe('https://remote.example/users/bob');
+
+		$this->assertInstanceOf(TemplateResponse::class, $response);
+		$this->assertSame('bob@remote.example', $this->states['social']['serverData']['account']);
+	}
+
+	public function testSubscribeFailsWithoutASessionUser(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+		$this->cacheActorService->method('getFromAccount')->willReturn($this->actorWithAccount('bob@remote.example'));
+
+		$response = $this->controller->subscribe('bob@remote.example');
+
+		$this->assertFailure($response, \Exception::class);
+		$this->assertSame('Failed to retrieve current user', $response->getData()['message']);
+	}
+
+	public function testSubscribeFailsForUnknownActor(): void {
+		$this->cacheActorService->method('getFromAccount')->willThrowException(new CacheActorDoesNotExistException());
+
+		$this->assertFailure($this->controller->subscribe('ghost@remote.example'), CacheActorDoesNotExistException::class);
+	}
+
+	public function testFollowRemoteRendersAGuestPageForTheLocalAccount(): void {
+		$this->accountService->method('getActor')->with('alice')->willReturn($this->actorWithAccount('alice@cloud.example'));
+
+		$response = $this->controller->followRemote('alice');
+
+		$this->assertInstanceOf(TemplateResponse::class, $response);
+		$this->assertSame('guest', $response->getRenderAs());
+		$this->assertSame(['local' => 'alice', 'account' => 'alice@cloud.example'], $this->states['social']['serverData']);
+	}
+
+	public function testFollowRemoteFailsForUnknownLocalAccount(): void {
+		$this->accountService->method('getActor')->willThrowException(new AccountDoesNotExistException());
+
+		$this->assertFailure($this->controller->followRemote('ghost'), AccountDoesNotExistException::class);
+	}
+
+	public function testGetLinkBuildsTheRemoteSubscribeUrlFromWebfinger(): void {
+		$this->accountService->method('getActor')->with('alice')->willReturn($this->actorWithAccount('alice@cloud.example'));
+		$this->curlService->method('webfingerAccount')->willReturn([
+			'links' => [
+				['rel' => 'self', 'href' => 'https://remote.example/users/bob'],
+				['rel' => 'http://ostatus.org/schema/1.0/subscribe', 'template' => 'https://remote.example/authorize_interaction?uri={uri}'],
+			],
+		]);
+
+		$response = $this->controller->getLink('alice', 'bob@remote.example');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(
+			['result' => ['url' => 'https://remote.example/authorize_interaction?uri=alice@cloud.example'], 'status' => 1],
+			$response->getData()
+		);
+	}
+
+	public function testGetLinkFailsWhenRemoteHasNoSubscribeTemplate(): void {
+		$this->accountService->method('getActor')->willReturn($this->actorWithAccount('alice@cloud.example'));
+		$this->curlService->method('webfingerAccount')->willReturn(['links' => [['rel' => 'self', 'href' => 'x']]]);
+
+		$this->assertFailure($this->controller->getLink('alice', 'bob@remote.example'), RetrieveAccountFormatException::class);
+	}
+
+	public function testGetLinkFailsWhenWebfingerFails(): void {
+		$this->accountService->method('getActor')->willReturn($this->actorWithAccount('alice@cloud.example'));
+		$this->curlService->method('webfingerAccount')->willThrowException(new \RuntimeException('unreachable'));
+
+		$this->assertFailure($this->controller->getLink('alice', 'bob@remote.example'), \RuntimeException::class);
+	}
+}

--- a/tests/Controller/QueueControllerTest.php
+++ b/tests/Controller/QueueControllerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Controller;
+
+use OCA\Social\Controller\QueueController;
+use OCA\Social\Service\ActivityService;
+use OCA\Social\Service\MiscService;
+use OCA\Social\Service\RequestQueueService;
+use OCP\IRequest;
+use PHPUnit\Framework\TestCase;
+
+class QueueControllerTest extends TestCase {
+	public function testAsyncForRequestCannotBeUnitTested(): void {
+		// The controller can at least be wired up with its dependencies.
+		new QueueController(
+			$this->createMock(IRequest::class),
+			$this->createMock(RequestQueueService::class),
+			$this->createMock(ActivityService::class),
+			$this->createMock(MiscService::class)
+		);
+
+		$this->markTestSkipped(
+			'QueueController::asyncForRequest() unconditionally calls exit() after detaching the HTTP '
+			. 'response (TAsync::async()), which terminates the PHPUnit process; it needs an end-to-end test.'
+		);
+	}
+}

--- a/tests/Controller/SocialPubControllerTest.php
+++ b/tests/Controller/SocialPubControllerTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Controller;
+
+use OCA\Social\Controller\NavigationController;
+use OCA\Social\Controller\SocialPubController;
+use OCA\Social\Exceptions\AccountDoesNotExistException;
+use OCA\Social\Exceptions\StreamNotFoundException;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Stream;
+use OCA\Social\Service\AccountService;
+use OCA\Social\Service\CacheActorService;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\StreamService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IInitialStateService;
+use OCP\IL10N;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class SocialPubControllerTest extends TestCase {
+	private const SOCIAL_URL = 'https://cloud.example/apps/social/';
+
+	/** @var IInitialStateService&MockObject */
+	private $initialStateService;
+	/** @var CacheActorService&MockObject */
+	private $cacheActorService;
+	/** @var AccountService&MockObject */
+	private $accountService;
+	/** @var StreamService&MockObject */
+	private $streamService;
+	private array $states = [];
+
+	protected function setUp(): void {
+		$this->initialStateService = $this->createMock(IInitialStateService::class);
+		$this->cacheActorService = $this->createMock(CacheActorService::class);
+		$this->accountService = $this->createMock(AccountService::class);
+		$this->streamService = $this->createMock(StreamService::class);
+
+		$this->initialStateService->method('provideInitialState')
+			->willReturnCallback(function (string $app, string $key, $data): void {
+				$this->states[$app][$key] = $data;
+			});
+	}
+
+	protected function tearDown(): void {
+		\OC::$server->reset();
+	}
+
+	private function controller(?string $userId): SocialPubController {
+		$configService = $this->createMock(ConfigService::class);
+		$configService->method('getSocialUrl')->willReturn(self::SOCIAL_URL);
+
+		return new SocialPubController(
+			$userId,
+			$this->initialStateService,
+			$this->createMock(IRequest::class),
+			$this->createMock(IL10N::class),
+			$this->createMock(NavigationController::class),
+			$this->cacheActorService,
+			$this->accountService,
+			$this->streamService,
+			$configService
+		);
+	}
+
+	/** @return Stream&MockObject */
+	private function streamBy(string $displayName, string $preferredUsername): Stream {
+		$author = $this->createMock(Person::class);
+		$author->method('getDisplayName')->willReturn($displayName);
+		$author->method('getPreferredUsername')->willReturn($preferredUsername);
+		$stream = $this->createMock(Stream::class);
+		$stream->method('getActor')->willReturn($author);
+
+		return $stream;
+	}
+
+	public function testDisplayPostRendersTheStreamForItsAuthor(): void {
+		$viewer = $this->createMock(Person::class);
+		$this->accountService->method('getCurrentViewer')->willReturn($viewer);
+		$this->streamService->expects($this->once())->method('setViewer')->with($viewer);
+		$stream = $this->streamBy('Alice', 'alice');
+		$this->streamService->method('getStreamById')->with(self::SOCIAL_URL . '@alice/abc', false)->willReturn($stream);
+		$stream->expects($this->once())->method('setCompleteDetails')->with(true);
+		$stream->expects($this->once())->method('setExportFormat')->with(ACore::FORMAT_LOCAL);
+
+		$response = $this->controller('alice')->displayPost('alice', 'abc');
+
+		$this->assertInstanceOf(TemplateResponse::class, $response);
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame('main', $response->getTemplateName());
+		$this->assertSame(['application' => 'Social'], $response->getParams());
+		$this->assertSame($stream, $this->states['social']['item']);
+		$this->assertSame(['public' => false], $this->states['social']['serverData']);
+	}
+
+	public function testDisplayPostIsPublicForAnonymousVisitors(): void {
+		$this->accountService->method('getCurrentViewer')->willThrowException(new AccountDoesNotExistException());
+		$this->streamService->expects($this->never())->method('setViewer');
+		$this->streamService->method('getStreamById')->willReturn($this->streamBy('Alice', 'alice'));
+
+		$this->controller(null)->displayPost('alice', 'abc');
+
+		$this->assertSame(['public' => true], $this->states['social']['serverData']);
+	}
+
+	public function testDisplayPostMatchesTheAuthorCaseInsensitively(): void {
+		$this->accountService->method('getCurrentViewer')->willThrowException(new AccountDoesNotExistException());
+		$this->streamService->method('getStreamById')->willReturn($this->streamBy('Alice Wonder', 'ALICE'));
+
+		$this->assertInstanceOf(TemplateResponse::class, $this->controller(null)->displayPost('alice', 'abc'));
+	}
+
+	public function testDisplayPostRefusesAStreamOfAnotherAuthor(): void {
+		$this->accountService->method('getCurrentViewer')->willThrowException(new AccountDoesNotExistException());
+		$this->streamService->method('getStreamById')->willReturn($this->streamBy('Bob', 'bob'));
+
+		$this->expectException(StreamNotFoundException::class);
+
+		$this->controller(null)->displayPost('alice', 'abc');
+	}
+
+	public function testDisplayPostPropagatesUnknownStreams(): void {
+		$this->accountService->method('getCurrentViewer')->willThrowException(new AccountDoesNotExistException());
+		$this->streamService->method('getStreamById')->willThrowException(new StreamNotFoundException());
+
+		$this->expectException(StreamNotFoundException::class);
+
+		$this->controller(null)->displayPost('alice', 'missing');
+	}
+
+	/** @return iterable<string, array{string}> */
+	public function publicPages(): iterable {
+		yield 'actor' => ['actor'];
+		yield 'followers' => ['followers'];
+		yield 'following' => ['following'];
+	}
+
+	/** @dataProvider publicPages */
+	public function testPublicPagesReportUnexpectedLookupFailures(string $page): void {
+		$this->cacheActorService->method('getFromAccount')->with('alice')->willThrowException(new \RuntimeException('db down'));
+
+		$response = $this->controller(null)->$page('alice');
+
+		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		$this->assertSame(-1, $response->getData()['status']);
+		$this->assertSame(\RuntimeException::class, $response->getData()['exception']);
+	}
+}

--- a/tests/Cron/CacheTest.php
+++ b/tests/Cron/CacheTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Cron;
+
+use OCA\Social\Cron\Cache;
+use OCA\Social\Db\CacheActorsRequest;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Service\AccountService;
+use OCA\Social\Service\CacheActorService;
+use OCA\Social\Service\DocumentService;
+use OCA\Social\Service\HashtagService;
+use OCA\Social\Service\StreamService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJobList;
+use OCP\BackgroundJob\TimedJob;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class CacheTest extends TestCase {
+	private const NOW = 1700000000;
+
+	/** @var AccountService&MockObject */
+	private $accountService;
+	/** @var CacheActorService&MockObject */
+	private $cacheActorService;
+	/** @var DocumentService&MockObject */
+	private $documentService;
+	/** @var HashtagService&MockObject */
+	private $hashtagService;
+	/** @var StreamService&MockObject */
+	private $streamService;
+	/** @var CacheActorsRequest&MockObject */
+	private $cacheActorsRequest;
+	/** @var IJobList&MockObject */
+	private $jobList;
+	private Cache $job;
+
+	protected function setUp(): void {
+		$time = $this->createMock(ITimeFactory::class);
+		$time->method('getTime')->willReturn(self::NOW);
+		$this->accountService = $this->createMock(AccountService::class);
+		$this->cacheActorService = $this->createMock(CacheActorService::class);
+		$this->documentService = $this->createMock(DocumentService::class);
+		$this->hashtagService = $this->createMock(HashtagService::class);
+		$this->streamService = $this->createMock(StreamService::class);
+		$this->cacheActorsRequest = $this->createMock(CacheActorsRequest::class);
+		$this->jobList = $this->createMock(IJobList::class);
+
+		$this->job = new Cache(
+			$time,
+			$this->accountService,
+			$this->cacheActorService,
+			$this->documentService,
+			$this->hashtagService,
+			$this->streamService,
+			$this->cacheActorsRequest
+		);
+	}
+
+	protected function tearDown(): void {
+		\OC::$server->reset();
+	}
+
+	public function testIsATimedJobRunningEveryTwelveMinutes(): void {
+		$this->assertInstanceOf(TimedJob::class, $this->job);
+
+		$interval = new \ReflectionProperty(TimedJob::class, 'interval');
+
+		$this->assertSame(12 * 60, $interval->getValue($this->job));
+	}
+
+	public function testRunRefreshesEveryCacheAndSyncsRemoteTimelines(): void {
+		$this->accountService->expects($this->once())->method('manageDeletedActors');
+		$this->accountService->expects($this->once())->method('manageCacheLocalActors');
+		$this->cacheActorService->expects($this->once())->method('manageCacheRemoteActors');
+		$this->cacheActorService->expects($this->once())->method('manageDetailsRemoteActors');
+		$this->documentService->expects($this->once())->method('manageCacheDocuments');
+		$this->hashtagService->expects($this->once())->method('manageHashtags');
+		$bob = $this->createMock(Person::class);
+		$carol = $this->createMock(Person::class);
+		$this->cacheActorsRequest->expects($this->once())->method('getRemoteActorsToUpdate')->with(false)->willReturn([$bob, $carol]);
+		$synced = [];
+		$this->streamService->expects($this->exactly(2))->method('syncRemoteTimeline')
+			->willReturnCallback(function (Person $actor) use (&$synced): int {
+				$synced[] = $actor;
+
+				return 0;
+			});
+		$this->jobList->expects($this->once())->method('setLastRun')->with($this->job);
+
+		$this->job->start($this->jobList);
+
+		$this->assertSame([$bob, $carol], $synced);
+	}
+
+	public function testAFailingStepDoesNotStopTheOthers(): void {
+		$this->accountService->method('manageDeletedActors')->willThrowException(new \RuntimeException('db'));
+		$this->cacheActorService->method('manageCacheRemoteActors')->willThrowException(new \RuntimeException('network'));
+		$this->accountService->expects($this->once())->method('manageCacheLocalActors');
+		$this->cacheActorService->expects($this->once())->method('manageDetailsRemoteActors');
+		$this->documentService->expects($this->once())->method('manageCacheDocuments');
+		$this->hashtagService->expects($this->once())->method('manageHashtags');
+		$this->cacheActorsRequest->expects($this->once())->method('getRemoteActorsToUpdate')->willReturn([]);
+
+		$this->job->start($this->jobList);
+	}
+
+	public function testOneUnreachableRemoteActorDoesNotStopTheTimelineSync(): void {
+		$gone = $this->createMock(Person::class);
+		$alive = $this->createMock(Person::class);
+		$this->cacheActorsRequest->method('getRemoteActorsToUpdate')->willReturn([$gone, $alive]);
+		$this->streamService->expects($this->exactly(2))->method('syncRemoteTimeline')
+			->willReturnCallback(function (Person $actor) use ($gone): int {
+				if ($actor === $gone) {
+					throw new \RuntimeException('410 Gone');
+				}
+
+				return 3;
+			});
+
+		$this->job->start($this->jobList);
+	}
+
+	public function testRunIsSkippedWhenTheLastRunIsTooRecent(): void {
+		$this->job->setLastRun(self::NOW - 60);
+		$this->accountService->expects($this->never())->method('manageDeletedActors');
+		$this->jobList->expects($this->never())->method('setLastRun');
+
+		$this->job->start($this->jobList);
+	}
+}

--- a/tests/Cron/QueueTest.php
+++ b/tests/Cron/QueueTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Cron;
+
+use OCA\Social\Cron\Queue;
+use OCA\Social\Exceptions\SocialAppConfigException;
+use OCA\Social\Model\RequestQueue;
+use OCA\Social\Model\StreamQueue;
+use OCA\Social\Service\ActivityService;
+use OCA\Social\Service\RequestQueueService;
+use OCA\Social\Service\StreamQueueService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJobList;
+use OCP\BackgroundJob\TimedJob;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class QueueTest extends TestCase {
+	private const NOW = 1700000000;
+
+	/** @var RequestQueueService&MockObject */
+	private $requestQueueService;
+	/** @var StreamQueueService&MockObject */
+	private $streamQueueService;
+	/** @var ActivityService&MockObject */
+	private $activityService;
+	/** @var IJobList&MockObject */
+	private $jobList;
+	private Queue $job;
+
+	protected function setUp(): void {
+		$time = $this->createMock(ITimeFactory::class);
+		$time->method('getTime')->willReturn(self::NOW);
+		$this->requestQueueService = $this->createMock(RequestQueueService::class);
+		$this->streamQueueService = $this->createMock(StreamQueueService::class);
+		$this->activityService = $this->createMock(ActivityService::class);
+		$this->jobList = $this->createMock(IJobList::class);
+
+		$this->job = new Queue($time, $this->requestQueueService, $this->streamQueueService, $this->activityService);
+	}
+
+	protected function tearDown(): void {
+		\OC::$server->reset();
+	}
+
+	public function testIsATimedJobRunningEveryTwelveMinutes(): void {
+		$this->assertInstanceOf(TimedJob::class, $this->job);
+
+		$interval = new \ReflectionProperty(TimedJob::class, 'interval');
+
+		$this->assertSame(12 * 60, $interval->getValue($this->job));
+	}
+
+	public function testStandbyRequestsAreSentWithTheServiceTimeout(): void {
+		$first = (new RequestQueue())->setToken('t1');
+		$second = (new RequestQueue())->setToken('t2');
+		$this->requestQueueService->method('getRequestStandby')->willReturn([$first, $second]);
+		$this->streamQueueService->method('getRequestStandby')->willReturn([]);
+		$this->activityService->expects($this->once())->method('manageInit');
+		$managed = [];
+		$this->activityService->expects($this->exactly(2))->method('manageRequest')
+			->willReturnCallback(function (RequestQueue $request) use (&$managed): void {
+				$this->assertSame(ActivityService::TIMEOUT_SERVICE, $request->getTimeout());
+				$managed[] = $request->getToken();
+			});
+
+		$this->job->start($this->jobList);
+
+		$this->assertSame(['t1', 't2'], $managed);
+	}
+
+	public function testAMisconfiguredRequestDoesNotStopTheQueue(): void {
+		$bad = (new RequestQueue())->setToken('bad');
+		$good = (new RequestQueue())->setToken('good');
+		$this->requestQueueService->method('getRequestStandby')->willReturn([$bad, $good]);
+		$this->streamQueueService->method('getRequestStandby')->willReturn([]);
+		$sent = [];
+		$this->activityService->expects($this->exactly(2))->method('manageRequest')
+			->willReturnCallback(function (RequestQueue $request) use (&$sent): void {
+				if ($request->getToken() === 'bad') {
+					throw new SocialAppConfigException();
+				}
+				$sent[] = $request->getToken();
+			});
+
+		$this->job->start($this->jobList);
+
+		$this->assertSame(['good'], $sent);
+	}
+
+	public function testStandbyStreamItemsAreProcessedAfterTheRequests(): void {
+		$this->requestQueueService->method('getRequestStandby')->willReturn([]);
+		$items = [$this->createMock(StreamQueue::class), $this->createMock(StreamQueue::class)];
+		$this->streamQueueService->method('getRequestStandby')->willReturn($items);
+		$processed = [];
+		$this->streamQueueService->expects($this->exactly(2))->method('manageStreamQueue')
+			->willReturnCallback(function (StreamQueue $item) use (&$processed): void {
+				$processed[] = $item;
+			});
+
+		$this->job->start($this->jobList);
+
+		$this->assertSame($items, $processed);
+	}
+
+	public function testRunIsSkippedWhenTheLastRunIsTooRecent(): void {
+		$this->job->setLastRun(self::NOW - 60);
+		$this->requestQueueService->expects($this->never())->method('getRequestStandby');
+		$this->streamQueueService->expects($this->never())->method('getRequestStandby');
+
+		$this->job->start($this->jobList);
+	}
+}

--- a/tests/Dashboard/SocialTimelineWidgetTest.php
+++ b/tests/Dashboard/SocialTimelineWidgetTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Dashboard;
+
+use OCA\Social\Dashboard\SocialTimelineWidget;
+use OCA\Social\Exceptions\AccountDoesNotExistException;
+use OCA\Social\Exceptions\CacheActorDoesNotExistException;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Announce;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Model\Client\Options\ProbeOptions;
+use OCA\Social\Service\AccountService;
+use OCA\Social\Service\CacheActorService;
+use OCA\Social\Service\StreamService;
+use OCP\Dashboard\IAPIWidgetV2;
+use OCP\Dashboard\IButtonWidget;
+use OCP\Dashboard\IIconWidget;
+use OCP\Dashboard\IReloadableWidget;
+use OCP\Dashboard\Model\WidgetButton;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class SocialTimelineWidgetTest extends TestCase {
+	/** @var IL10N&MockObject */
+	private $l10n;
+	/** @var IURLGenerator&MockObject */
+	private $urlGenerator;
+	/** @var AccountService&MockObject */
+	private $accountService;
+	/** @var CacheActorService&MockObject */
+	private $cacheActorService;
+	/** @var StreamService&MockObject */
+	private $streamService;
+	private SocialTimelineWidget $widget;
+
+	protected function setUp(): void {
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->l10n->method('t')->willReturnArgument(0);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->accountService = $this->createMock(AccountService::class);
+		$this->cacheActorService = $this->createMock(CacheActorService::class);
+		$this->streamService = $this->createMock(StreamService::class);
+
+		$this->widget = new SocialTimelineWidget(
+			$this->l10n,
+			$this->urlGenerator,
+			$this->accountService,
+			$this->cacheActorService,
+			$this->streamService,
+			new NullLogger()
+		);
+	}
+
+	/** @return Person&MockObject */
+	private function viewer(string $uid = 'alice'): Person {
+		$account = $this->createMock(Person::class);
+		$account->method('getPreferredUsername')->willReturn($uid);
+		$this->accountService->method('getActorFromUserId')->with($uid, false)->willReturn($account);
+		$viewer = $this->createMock(Person::class);
+		$this->cacheActorService->method('getFromLocalAccount')->with($uid)->willReturn($viewer);
+
+		return $viewer;
+	}
+
+	/** @return Note&MockObject */
+	private function note(string $content, string $attributedTo, int $published): Note {
+		$note = $this->createMock(Note::class);
+		$note->method('getContent')->willReturn($content);
+		$note->method('getAttributedTo')->willReturn($attributedTo);
+		$note->method('getPublishedTime')->willReturn($published);
+
+		return $note;
+	}
+
+	/** @return Person&MockObject */
+	private function author(string $name, string $username, string $avatar): Person {
+		$author = $this->createMock(Person::class);
+		$author->method('getName')->willReturn($name);
+		$author->method('getPreferredUsername')->willReturn($username);
+		$author->method('getAvatar')->willReturn($avatar);
+
+		return $author;
+	}
+
+	public function testIdentity(): void {
+		$this->assertInstanceOf(IAPIWidgetV2::class, $this->widget);
+		$this->assertInstanceOf(IIconWidget::class, $this->widget);
+		$this->assertInstanceOf(IButtonWidget::class, $this->widget);
+		$this->assertInstanceOf(IReloadableWidget::class, $this->widget);
+		$this->assertSame('social_timeline', $this->widget->getId());
+		$this->assertSame('Social timeline', $this->widget->getTitle());
+		$this->assertSame(11, $this->widget->getOrder());
+		$this->assertSame('icon-social', $this->widget->getIconClass());
+		$this->assertSame(300, $this->widget->getReloadInterval());
+	}
+
+	public function testIconAndUrlComeFromTheUrlGenerator(): void {
+		$this->urlGenerator->method('imagePath')->with('social', 'social-dark.svg')->willReturn('/apps/social/img/social-dark.svg');
+		$this->urlGenerator->method('linkToRoute')->with('social.Navigation.timeline')->willReturn('/apps/social/timeline');
+
+		$this->assertSame('/apps/social/img/social-dark.svg', $this->widget->getIconUrl());
+		$this->assertSame('/apps/social/timeline', $this->widget->getUrl());
+	}
+
+	public function testMoreButtonOpensTheTimeline(): void {
+		$this->urlGenerator->method('linkToRoute')->with('social.Navigation.timeline')->willReturn('/apps/social/timeline');
+
+		$buttons = $this->widget->getWidgetButtons('alice');
+
+		$this->assertCount(1, $buttons);
+		$this->assertSame(WidgetButton::TYPE_MORE, $buttons[0]->getType());
+		$this->assertSame('/apps/social/timeline', $buttons[0]->getLink());
+		$this->assertSame('Open timeline', $buttons[0]->getText());
+	}
+
+	public function testItemsAreBuiltFromTheViewersHomeTimeline(): void {
+		$viewer = $this->viewer();
+		$viewer->expects($this->once())->method('setExportFormat')->with(ACore::FORMAT_LOCAL);
+		$this->streamService->expects($this->once())->method('setViewer')->with($viewer);
+		$options = null;
+		$this->streamService->method('getTimeline')->willReturnCallback(function (ProbeOptions $o) use (&$options): array {
+			$options = $o;
+
+			return [
+				$this->note('<p>Hello <b>world</b>, this is a fairly long post that should be truncated at one hundred and twenty characters for the dashboard tile.</p>', 'https://remote.example/users/bob', 1700000001),
+				$this->createMock(Announce::class),
+				$this->note('', 'https://remote.example/users/carol', 1700000002),
+			];
+		});
+		$this->cacheActorService->method('getFromId')->willReturnMap([
+			['https://remote.example/users/bob', false, $this->author('Bob B.', 'bob', 'https://remote.example/bob.png')],
+			['https://remote.example/users/carol', false, $this->author('', 'carol', '')],
+		]);
+		$this->urlGenerator->method('linkToRoute')->with('social.Navigation.timeline', ['path' => 'home'])->willReturn('/apps/social/timeline/home');
+
+		$items = $this->widget->getItemsV2('alice', null, 5);
+
+		$this->assertSame(ProbeOptions::HOME, $options->getProbe());
+		$this->assertSame(5, $options->getLimit());
+		$this->assertSame('Follow some accounts to see their posts here', $items->getEmptyContentMessage());
+		$this->assertSame('No recent posts', $items->getHalfEmptyContentMessage());
+		$list = $items->getItems();
+		$this->assertCount(2, $list, 'non-Note stream items are skipped');
+		$this->assertSame(
+			'Hello world, this is a fairly long post that should be truncated at one hundred and twenty characters for the dashboard ',
+			$list[0]->getTitle(),
+			'markup is stripped before truncating'
+		);
+		$this->assertSame(120, mb_strlen($list[0]->getTitle()));
+		$this->assertSame('Bob B.', $list[0]->getSubtitle());
+		$this->assertSame('https://remote.example/bob.png', $list[0]->getIconUrl());
+		$this->assertSame('/apps/social/timeline/home', $list[0]->getLink());
+		$this->assertSame('1700000001', $list[0]->getSinceId());
+		$this->assertSame('(no content)', $list[1]->getTitle());
+		$this->assertSame('carol', $list[1]->getSubtitle(), 'falls back to the username without a display name');
+	}
+
+	public function testLimitIsCappedAtTwenty(): void {
+		$this->viewer();
+		$options = null;
+		$this->streamService->method('getTimeline')->willReturnCallback(function (ProbeOptions $o) use (&$options): array {
+			$options = $o;
+
+			return [];
+		});
+
+		$this->widget->getItemsV2('alice', null, 50);
+
+		$this->assertSame(20, $options->getLimit());
+	}
+
+	public function testUnresolvableAuthorFallsBackToTheActorId(): void {
+		$this->viewer();
+		$this->streamService->method('getTimeline')->willReturn([$this->note('hi', 'https://remote.example/users/gone', 1)]);
+		$this->cacheActorService->method('getFromId')->willThrowException(new CacheActorDoesNotExistException());
+
+		$items = $this->widget->getItemsV2('alice')->getItems();
+
+		$this->assertSame('https://remote.example/users/gone', $items[0]->getSubtitle());
+		$this->assertSame('', $items[0]->getIconUrl());
+	}
+
+	public function testFailuresYieldAnEmptyWidgetWithAnErrorMessage(): void {
+		$this->accountService->method('getActorFromUserId')->willThrowException(new AccountDoesNotExistException());
+		$this->streamService->expects($this->never())->method('getTimeline');
+
+		$items = $this->widget->getItemsV2('nobody');
+
+		$this->assertSame([], $items->getItems());
+		$this->assertSame('Could not load timeline', $items->getEmptyContentMessage());
+		$this->assertSame('Could not load timeline', $items->getHalfEmptyContentMessage());
+	}
+}

--- a/tests/Dashboard/SocialWidgetTest.php
+++ b/tests/Dashboard/SocialWidgetTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Dashboard;
+
+use OCA\Social\Dashboard\SocialWidget;
+use OCP\Dashboard\IWidget;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class SocialWidgetTest extends TestCase {
+	/** @var IL10N&MockObject */
+	private $l10n;
+	/** @var IURLGenerator&MockObject */
+	private $urlGenerator;
+	private SocialWidget $widget;
+
+	protected function setUp(): void {
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->widget = new SocialWidget($this->l10n, $this->urlGenerator);
+	}
+
+	public function testIsADashboardWidgetWithAStableId(): void {
+		$this->assertInstanceOf(IWidget::class, $this->widget);
+		$this->assertSame('social_notifications', $this->widget->getId());
+		$this->assertSame(10, $this->widget->getOrder());
+		$this->assertSame('icon-social', $this->widget->getIconClass());
+	}
+
+	public function testTitleIsTranslated(): void {
+		$this->l10n->method('t')->with('Social notifications')->willReturn('Soziale Benachrichtigungen');
+
+		$this->assertSame('Soziale Benachrichtigungen', $this->widget->getTitle());
+	}
+
+	public function testUrlPointsToTheNotificationStream(): void {
+		$this->urlGenerator->method('linkToRoute')->with('social.local.streamNotifications', [])
+			->willReturn('/apps/social/api/v1/stream/notifications');
+
+		$this->assertSame('/apps/social/api/v1/stream/notifications', $this->widget->getUrl());
+	}
+}

--- a/tests/Helper/NoUserException.php
+++ b/tests/Helper/NoUserException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Helper;
+
+/**
+ * Stand-in for the server's `OC\User\NoUserException`, which is private to the
+ * server and so absent from the OCP stubs the suite runs against.
+ *
+ * A user-defined class rather than an alias of `RuntimeException`, because
+ * `class_alias()` refuses an internal class as its first argument.
+ */
+class NoUserException extends \RuntimeException {
+}

--- a/tests/Helper/TestContainer.php
+++ b/tests/Helper/TestContainer.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Helper;
+
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Stand-in for `\OC::$server` in unit tests.
+ *
+ * A few code paths reach the container statically (`\OCP\Server::get()`,
+ * `\OC::$server->get()`) instead of taking their dependency through the
+ * constructor. Tests that hit such a path register what it should resolve
+ * to; anything unregistered is a NotFound exception naming the class, so a
+ * hidden dependency shows up as a clear failure rather than a fatal.
+ */
+class TestContainer implements ContainerInterface {
+	/** @var array<string, object> */
+	private array $services = [];
+
+	public function __construct() {
+		$this->reset();
+	}
+
+	public function register(string $id, object $service): void {
+		$this->services[$id] = $service;
+	}
+
+	/** Back to the defaults: only a silent logger is known. */
+	public function reset(): void {
+		$this->services = [LoggerInterface::class => new NullLogger()];
+	}
+
+	public function get(string $id): object {
+		if (!isset($this->services[$id])) {
+			throw new class('Service ' . $id . ' is not registered in the test container') extends \RuntimeException implements NotFoundExceptionInterface {
+			};
+		}
+
+		return $this->services[$id];
+	}
+
+	public function has(string $id): bool {
+		return isset($this->services[$id]);
+	}
+
+	/** Same as get(), for code calling the legacy `query()` name. */
+	public function query(string $id): object {
+		return $this->get($id);
+	}
+}

--- a/tests/Helper/TestContainerTest.php
+++ b/tests/Helper/TestContainerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Helper;
+
+use OCP\Server;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\NotFoundExceptionInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+class TestContainerTest extends TestCase {
+	protected function tearDown(): void {
+		\OC::$server->reset();
+	}
+
+	public function testStaticServerFacadeResolvesRegisteredService(): void {
+		$logger = $this->createMock(LoggerInterface::class);
+		\OC::$server->register(LoggerInterface::class, $logger);
+
+		$this->assertSame($logger, Server::get(LoggerInterface::class));
+	}
+
+	public function testUnknownServiceIsANotFoundError(): void {
+		$this->expectException(NotFoundExceptionInterface::class);
+		$this->expectExceptionMessage(\OCP\IConfig::class);
+
+		Server::get(\OCP\IConfig::class);
+	}
+
+	public function testResetRestoresTheSilentLogger(): void {
+		\OC::$server->register(LoggerInterface::class, $this->createMock(LoggerInterface::class));
+		\OC::$server->reset();
+
+		$this->assertInstanceOf(NullLogger::class, Server::get(LoggerInterface::class));
+	}
+}

--- a/tests/Interfaces/Activity/AbstractActivityPubInterfaceTest.php
+++ b/tests/Interfaces/Activity/AbstractActivityPubInterfaceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Interfaces\Activity;
+
+use OCA\Social\Exceptions\ItemNotFoundException;
+use OCA\Social\Interfaces\Activity\AbstractActivityPubInterface;
+use OCA\Social\Model\ActivityPub\Activity\Create;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use PHPUnit\Framework\TestCase;
+
+class AbstractActivityPubInterfaceTest extends TestCase {
+	private AbstractActivityPubInterface $handler;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->handler = new AbstractActivityPubInterface();
+	}
+
+	public function testGetItemIsNotSupportedByDefault(): void {
+		$this->expectException(ItemNotFoundException::class);
+
+		$this->handler->getItem(new Note());
+	}
+
+	public function testGetItemByIdIsNotSupportedByDefault(): void {
+		$this->expectException(ItemNotFoundException::class);
+
+		$this->handler->getItemById('https://remote.example/notes/1');
+	}
+
+	public function testEveryOtherHookIsANoOp(): void {
+		$this->expectNotToPerformAssertions();
+
+		$note = new Note();
+		$this->handler->processIncomingRequest($note);
+		$this->handler->processResult($note);
+		$this->handler->save($note);
+		$this->handler->update($note);
+		$this->handler->delete($note);
+		$this->handler->event($note, 'updateCache');
+		$this->handler->activity(new Create(), $note);
+	}
+}

--- a/tests/Interfaces/Activity/AcceptInterfaceTest.php
+++ b/tests/Interfaces/Activity/AcceptInterfaceTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Interfaces\Activity;
+
+use OCA\Social\Interfaces\Activity\AcceptInterface;
+use OCA\Social\Interfaces\IActivityPubInterface;
+use OCA\Social\Model\ActivityPub\Activity\Accept;
+use OCA\Social\Model\ActivityPub\Object\Note;
+
+require_once __DIR__ . '/DispatchingActivityTestCase.php';
+
+class AcceptInterfaceTest extends DispatchingActivityTestCase {
+	protected function createHandler(): IActivityPubInterface {
+		return new AcceptInterface();
+	}
+
+	protected function activityType(): string {
+		return Accept::TYPE;
+	}
+
+	public function testAcceptOfSomethingElseThanAFollowIsNotAFollowConfirmation(): void {
+		$note = new Note();
+		$note->setId(self::REMOTE_URL . '/notes/1');
+		$accept = $this->incoming(Accept::TYPE, self::REMOTE_URL . '/accepts/1', self::REMOTE_URL . '/users/bob', $note);
+
+		$this->followInterface->expects($this->never())->method('activity');
+		$this->noteInterface->expects($this->once())
+			->method('activity')
+			->with($this->identicalTo($accept), $this->identicalTo($note));
+
+		$this->createHandler()->processIncomingRequest($accept);
+	}
+}

--- a/tests/Interfaces/Activity/AddInterfaceTest.php
+++ b/tests/Interfaces/Activity/AddInterfaceTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Interfaces\Activity;
+
+use OCA\Social\Interfaces\Activity\AddInterface;
+use OCA\Social\Interfaces\IActivityPubInterface;
+use OCA\Social\Model\ActivityPub\Activity\Add;
+
+require_once __DIR__ . '/DispatchingActivityTestCase.php';
+
+class AddInterfaceTest extends DispatchingActivityTestCase {
+	protected function createHandler(): IActivityPubInterface {
+		return new AddInterface();
+	}
+
+	protected function activityType(): string {
+		return Add::TYPE;
+	}
+}

--- a/tests/Interfaces/Activity/BlockInterfaceTest.php
+++ b/tests/Interfaces/Activity/BlockInterfaceTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Interfaces\Activity;
+
+use OCA\Social\Interfaces\Activity\BlockInterface;
+use OCA\Social\Interfaces\IActivityPubInterface;
+use OCA\Social\Model\ActivityPub\Activity\Block;
+
+require_once __DIR__ . '/DispatchingActivityTestCase.php';
+
+class BlockInterfaceTest extends DispatchingActivityTestCase {
+	protected function createHandler(): IActivityPubInterface {
+		return new BlockInterface();
+	}
+
+	protected function activityType(): string {
+		return Block::TYPE;
+	}
+}

--- a/tests/Interfaces/Activity/CreateInterfaceTest.php
+++ b/tests/Interfaces/Activity/CreateInterfaceTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Interfaces\Activity;
+
+use OCA\Social\Interfaces\Activity\CreateInterface;
+use OCA\Social\Interfaces\IActivityPubInterface;
+use OCA\Social\Model\ActivityPub\Activity\Create;
+
+require_once __DIR__ . '/DispatchingActivityTestCase.php';
+
+class CreateInterfaceTest extends DispatchingActivityTestCase {
+	protected function createHandler(): IActivityPubInterface {
+		return new CreateInterface();
+	}
+
+	protected function activityType(): string {
+		return Create::TYPE;
+	}
+
+	public function testCreateOfANoteGoesToTheNoteInterface(): void {
+		$note = $this->note(self::REMOTE_URL . '/notes/1', self::REMOTE_URL . '/users/bob');
+		$create = $this->incoming(Create::TYPE, self::REMOTE_URL . '/notes/1/activity', self::REMOTE_URL . '/users/bob', $note);
+
+		$this->noteInterface->expects($this->once())
+			->method('activity')
+			->with($this->identicalTo($create), $this->identicalTo($note));
+
+		$this->createHandler()->processIncomingRequest($create);
+	}
+}

--- a/tests/Interfaces/Activity/DeleteInterfaceTest.php
+++ b/tests/Interfaces/Activity/DeleteInterfaceTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Interfaces\Activity;
+
+use OCA\Social\Exceptions\InvalidOriginException;
+use OCA\Social\Exceptions\ItemNotFoundException;
+use OCA\Social\Interfaces\Activity\DeleteInterface;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Activity\Delete;
+use OCA\Social\Tests\Interfaces\ActivityPubTestCase;
+
+require_once __DIR__ . '/../ActivityPubTestCase.php';
+
+class DeleteInterfaceTest extends ActivityPubTestCase {
+	private const BOB = self::REMOTE_URL . '/users/bob';
+	private const NOTE = self::REMOTE_URL . '/notes/1';
+
+	private DeleteInterface $handler;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->handler = new DeleteInterface();
+	}
+
+	/** A Delete from bob's server, either naming its target by id or embedding it. */
+	private function delete(string $objectId, ?ACore $object = null, ?string $origin = null): ACore {
+		$delete = $this->incoming(Delete::TYPE, self::BOB . '#delete/1', self::BOB, $object, $origin);
+		if ($object === null) {
+			$delete->setObjectId($objectId);
+		}
+
+		return $delete;
+	}
+
+	public function testDeleteNamingAKnownNoteRemovesTheNote(): void {
+		$note = $this->note(self::NOTE, self::BOB);
+		$this->noteInterface->method('getItemById')->with(self::NOTE)->willReturn($note);
+
+		$this->noteInterface->expects($this->once())->method('delete')->with($this->identicalTo($note));
+		$this->personInterface->expects($this->never())->method('getItemById');
+		$this->personInterface->expects($this->never())->method('delete');
+
+		$this->handler->processIncomingRequest($this->delete(self::NOTE));
+	}
+
+	public function testDeleteNamingAKnownActorRemovesTheActor(): void {
+		$bob = $this->person(self::BOB);
+		$this->noteInterface->method('getItemById')->willThrowException(new ItemNotFoundException());
+		$this->personInterface->method('getItemById')->with(self::BOB)->willReturn($bob);
+
+		$this->personInterface->expects($this->once())->method('delete')->with($this->identicalTo($bob));
+		$this->noteInterface->expects($this->never())->method('delete');
+
+		$this->handler->processIncomingRequest($this->delete(self::BOB));
+	}
+
+	public function testDeleteNamingSomethingUnknownDoesNothing(): void {
+		$this->noteInterface->method('getItemById')->willThrowException(new ItemNotFoundException());
+		$this->personInterface->method('getItemById')->willThrowException(new ItemNotFoundException());
+
+		$this->noteInterface->expects($this->never())->method('delete');
+		$this->personInterface->expects($this->never())->method('delete');
+
+		$this->handler->processIncomingRequest($this->delete(self::REMOTE_URL . '/whatever/1'));
+	}
+
+	public function testDeleteEmbeddingANoteIsHandedToTheNoteInterface(): void {
+		$note = $this->note(self::NOTE, self::BOB);
+		$delete = $this->delete(self::NOTE, $note);
+
+		$this->noteInterface->expects($this->once())
+			->method('activity')
+			->with($this->identicalTo($delete), $this->identicalTo($note));
+		$this->noteInterface->expects($this->never())->method('getItemById');
+
+		$this->handler->processIncomingRequest($delete);
+	}
+
+	public function testDeleteEmbeddingAnActorIsHandedToThePersonInterface(): void {
+		$bob = $this->person(self::BOB);
+		$delete = $this->delete(self::BOB, $bob);
+
+		$this->personInterface->expects($this->once())
+			->method('activity')
+			->with($this->identicalTo($delete), $this->identicalTo($bob));
+
+		$this->handler->processIncomingRequest($delete);
+	}
+
+	public function testDeleteOfSomethingHostedElsewhereIsRefused(): void {
+		$this->noteInterface->expects($this->never())->method('getItemById');
+		$this->personInterface->expects($this->never())->method('getItemById');
+
+		$this->expectException(InvalidOriginException::class);
+
+		// bob's server may only delete what lives on bob's server
+		$this->handler->processIncomingRequest($this->delete('https://other.example/notes/1'));
+	}
+
+	public function testDeleteNotComingFromItsOwnOriginIsRefused(): void {
+		$this->noteInterface->expects($this->never())->method('getItemById');
+
+		$this->expectException(InvalidOriginException::class);
+
+		$this->handler->processIncomingRequest($this->delete(self::NOTE, null, 'evil.example'));
+	}
+}

--- a/tests/Interfaces/Activity/DispatchingActivityTestCase.php
+++ b/tests/Interfaces/Activity/DispatchingActivityTestCase.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Interfaces\Activity;
+
+use OCA\Social\Interfaces\IActivityPubInterface;
+use OCA\Social\Model\ActivityPub\Object\Follow;
+use OCA\Social\Model\ActivityPub\Object\Tombstone;
+use OCA\Social\Tests\Interfaces\ActivityPubTestCase;
+
+require_once __DIR__ . '/../ActivityPubTestCase.php';
+
+/**
+ * Accept, Add, Block, Create, Reject, Remove, Undo and Update all do the same
+ * thing on arrival: look up the interface for the wrapped object and hand both
+ * items over. These are the rules they share; each concrete test adds the
+ * routing that matters for its own activity type.
+ */
+abstract class DispatchingActivityTestCase extends ActivityPubTestCase {
+	abstract protected function createHandler(): IActivityPubInterface;
+
+	abstract protected function activityType(): string;
+
+	public function testActivityCarryingOnlyAnObjectIdIsIgnored(): void {
+		$this->expectNoInterfaceReceivesActivity();
+
+		$activity = $this->incoming($this->activityType(), self::REMOTE_URL . '/activities/1', self::REMOTE_URL . '/users/bob');
+		$activity->setObjectId(self::REMOTE_URL . '/objects/1');
+
+		$this->createHandler()->processIncomingRequest($activity);
+	}
+
+	public function testActivityOnObjectWithoutInterfaceIsSwallowed(): void {
+		$this->expectNoInterfaceReceivesActivity();
+
+		// Tombstone is a known model but has no handler in the registry
+		$tombstone = new Tombstone();
+		$tombstone->setId(self::REMOTE_URL . '/objects/1');
+		$activity = $this->incoming($this->activityType(), self::REMOTE_URL . '/activities/1', self::REMOTE_URL . '/users/bob', $tombstone);
+
+		$this->createHandler()->processIncomingRequest($activity);
+	}
+
+	public function testActivityIsHandedToTheObjectsInterfaceTogetherWithTheObject(): void {
+		$follow = new Follow();
+		$follow->setId(self::REMOTE_URL . '/follows/1');
+		$activity = $this->incoming($this->activityType(), self::REMOTE_URL . '/activities/1', self::REMOTE_URL . '/users/bob', $follow);
+
+		$this->followInterface->expects($this->once())
+			->method('activity')
+			->with($this->identicalTo($activity), $this->identicalTo($follow));
+
+		$this->createHandler()->processIncomingRequest($activity);
+	}
+}

--- a/tests/Interfaces/Activity/MoveInterfaceTest.php
+++ b/tests/Interfaces/Activity/MoveInterfaceTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Interfaces\Activity;
+
+use OCA\Social\Db\ActionsRequest;
+use OCA\Social\Db\CacheDocumentsRequest;
+use OCA\Social\Db\FollowsRequest;
+use OCA\Social\Db\StreamDestRequest;
+use OCA\Social\Db\StreamRequest;
+use OCA\Social\Exceptions\CacheActorDoesNotExistException;
+use OCA\Social\Exceptions\InvalidOriginException;
+use OCA\Social\Exceptions\StreamNotFoundException;
+use OCA\Social\Interfaces\Activity\MoveInterface;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Activity\Move;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Model\ActivityPub\Stream;
+use OCA\Social\Model\StreamDest;
+use OCA\Social\Service\CacheActorService;
+use OCA\Social\Tests\Interfaces\ActivityPubTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+require_once __DIR__ . '/../ActivityPubTestCase.php';
+
+class MoveInterfaceTest extends ActivityPubTestCase {
+	private const CAROL = 'https://other.example/users/carol';
+
+	/** @var ActionsRequest&MockObject */
+	private $actionsRequest;
+	/** @var CacheDocumentsRequest&MockObject */
+	private $cacheDocumentsRequest;
+	/** @var FollowsRequest&MockObject */
+	private $followsRequest;
+	/** @var StreamRequest&MockObject */
+	private $streamRequest;
+	/** @var StreamDestRequest&MockObject */
+	private $streamDestRequest;
+	/** @var CacheActorService&MockObject */
+	private $cacheActorService;
+	private MoveInterface $handler;
+
+	private Person $old;
+	private Person $new;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->actionsRequest = $this->createMock(ActionsRequest::class);
+		$this->cacheDocumentsRequest = $this->createMock(CacheDocumentsRequest::class);
+		$this->followsRequest = $this->createMock(FollowsRequest::class);
+		$this->streamRequest = $this->createMock(StreamRequest::class);
+		$this->streamDestRequest = $this->createMock(StreamDestRequest::class);
+		$this->cacheActorService = $this->createMock(CacheActorService::class);
+
+		$this->handler = new MoveInterface(
+			$this->actionsRequest,
+			$this->cacheDocumentsRequest,
+			$this->followsRequest,
+			$this->streamRequest,
+			$this->streamDestRequest,
+			$this->cacheActorService,
+		);
+
+		$this->old = $this->person(self::REMOTE_URL . '/users/bob');
+		$this->new = $this->person('https://new.example/users/bob');
+	}
+
+	private function dest(string $streamId, string $type = 'recipient', string $subtype = 'to'): StreamDest {
+		$dest = new StreamDest();
+		$dest->setStreamId($streamId)
+			->setActorId($this->old->getId())
+			->setType($type)
+			->setSubtype($subtype);
+
+		return $dest;
+	}
+
+	/** A Move signed by bob's old server, pointing at the new account. */
+	private function move(?string $origin = null): ACore {
+		$move = $this->incoming(Move::TYPE, $this->old->getId() . '#moves/1', $this->old->getId(), null, $origin);
+		$move->setObjectId($this->old->getId());
+		$move->setTarget($this->new->getId());
+
+		return $move;
+	}
+
+	public function testMoveAccountRepointsActionsDocumentsAndFollowsToTheNewActor(): void {
+		$this->streamDestRequest->method('getRelatedToActor')->willReturn([]);
+
+		$this->actionsRequest->expects($this->once())
+			->method('moveAccount')->with($this->old->getId(), $this->new->getId());
+		$this->cacheDocumentsRequest->expects($this->once())
+			->method('moveAccount')->with($this->old->getId(), $this->new->getId());
+		$this->followsRequest->expects($this->once())
+			->method('moveAccountFollowers')->with($this->old->getId(), $this->identicalTo($this->new));
+		$this->followsRequest->expects($this->once())
+			->method('moveAccountFollowing')->with($this->old->getId(), $this->identicalTo($this->new));
+
+		$this->handler->moveAccount($this->old, $this->new);
+	}
+
+	public function testMoveAccountReattributesTheOldActorsPosts(): void {
+		$this->streamDestRequest->method('getRelatedToActor')->willReturn([]);
+
+		$this->streamRequest->expects($this->once())
+			->method('updateAuthor')->with($this->old->getId(), $this->new->getId());
+
+		$this->handler->moveAccount($this->old, $this->new);
+	}
+
+	public function testMoveAccountRepointsRecipientReferencesIncludingTheCollections(): void {
+		$this->streamDestRequest->method('getRelatedToActor')->willReturn([]);
+
+		$moved = [];
+		$this->streamDestRequest->method('moveActor')
+			->willReturnCallback(function (string $from, string $to) use (&$moved): void {
+				$moved[] = [$from, $to];
+			});
+
+		$this->handler->moveAccount($this->old, $this->new);
+
+		$this->assertEqualsCanonicalizing([
+			[$this->old->getId(), $this->new->getId()],
+			[$this->old->getFollowers(), $this->new->getFollowers()],
+			[$this->old->getFollowing(), $this->new->getFollowing()],
+		], $moved);
+	}
+
+	public function testMoveAccountRewritesRecipientsOfStreamsAddressedToTheOldActor(): void {
+		$direct = new Note();
+		$direct->setId(self::REMOTE_URL . '/notes/direct');
+		$direct->setTo($this->old->getId());
+
+		$toFollowers = new Note();
+		$toFollowers->setId(self::REMOTE_URL . '/notes/public');
+		$toFollowers->setToArray([$this->old->getFollowers(), self::CAROL]);
+
+		$ccActor = new Note();
+		$ccActor->setId(self::REMOTE_URL . '/notes/cc');
+		$ccActor->setCcArray([$this->old->getId(), self::CAROL]);
+
+		$unrelated = new Note();
+		$unrelated->setId(self::REMOTE_URL . '/notes/unrelated');
+		$unrelated->setToArray([self::CAROL]);
+
+		$streams = [];
+		foreach ([$direct, $toFollowers, $ccActor, $unrelated] as $stream) {
+			$streams[$stream->getId()] = $stream;
+		}
+		$this->streamRequest->method('getStream')->willReturnCallback(function (string $id) use ($streams): Stream {
+			if (!isset($streams[$id])) {
+				throw new StreamNotFoundException();
+			}
+
+			return $streams[$id];
+		});
+		$this->streamDestRequest->method('getRelatedToActor')->with($this->identicalTo($this->old))->willReturn([
+			$this->dest($direct->getId()),
+			$this->dest($toFollowers->getId()),
+			$this->dest($ccActor->getId(), 'recipient', 'cc'),
+			$this->dest($unrelated->getId()),
+			$this->dest(self::REMOTE_URL . '/notes/gone'),
+			$this->dest($toFollowers->getId(), 'hashtag', 'x'),
+		]);
+
+		$updated = [];
+		$this->streamRequest->method('update')->willReturnCallback(function (Stream $stream) use (&$updated): void {
+			$updated[] = $stream->getId();
+		});
+
+		$this->handler->moveAccount($this->old, $this->new);
+
+		$this->assertSame($this->new->getId(), $direct->getTo());
+		$this->assertEqualsCanonicalizing([self::CAROL, $this->new->getFollowers()], $toFollowers->getToArray());
+		$this->assertEqualsCanonicalizing([self::CAROL, $this->new->getId()], $ccActor->getCcArray());
+		$this->assertSame([self::CAROL], $unrelated->getToArray());
+		$this->assertEqualsCanonicalizing([$direct->getId(), $toFollowers->getId(), $ccActor->getId()], $updated);
+	}
+
+	public function testIncomingMoveOfAKnownActorIsAppliedToItsTarget(): void {
+		$this->cacheActorService->method('getFromAccount')
+			->willReturnCallback(function (string $account) {
+				return $account === $this->old->getId() ? $this->old : $this->new;
+			});
+		$this->streamDestRequest->method('getRelatedToActor')->willReturn([]);
+
+		$this->followsRequest->expects($this->once())
+			->method('moveAccountFollowers')->with($this->old->getId(), $this->identicalTo($this->new));
+
+		$this->handler->processIncomingRequest($this->move());
+	}
+
+	public function testIncomingMoveOfAnUnknownActorIsIgnored(): void {
+		$this->cacheActorService->method('getFromAccount')
+			->willThrowException(new CacheActorDoesNotExistException());
+
+		$this->actionsRequest->expects($this->never())->method('moveAccount');
+		$this->followsRequest->expects($this->never())->method('moveAccountFollowers');
+
+		$this->handler->processIncomingRequest($this->move());
+	}
+
+	public function testIncomingMoveNotComingFromTheActorsOriginIsRefused(): void {
+		$this->cacheActorService->expects($this->never())->method('getFromAccount');
+		$this->followsRequest->expects($this->never())->method('moveAccountFollowers');
+
+		$this->expectException(InvalidOriginException::class);
+
+		$this->handler->processIncomingRequest($this->move('evil.example'));
+	}
+
+	public function testIncomingMoveOfSomebodyElsesAccountIsRefused(): void {
+		$move = $this->move();
+		$move->setObjectId(self::CAROL);
+
+		$this->cacheActorService->expects($this->never())->method('getFromAccount');
+
+		$this->expectException(InvalidOriginException::class);
+
+		$this->handler->processIncomingRequest($move);
+	}
+}

--- a/tests/Interfaces/Activity/RejectInterfaceTest.php
+++ b/tests/Interfaces/Activity/RejectInterfaceTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Interfaces\Activity;
+
+use OCA\Social\Interfaces\Activity\RejectInterface;
+use OCA\Social\Interfaces\IActivityPubInterface;
+use OCA\Social\Model\ActivityPub\Activity\Reject;
+
+require_once __DIR__ . '/DispatchingActivityTestCase.php';
+
+class RejectInterfaceTest extends DispatchingActivityTestCase {
+	protected function createHandler(): IActivityPubInterface {
+		return new RejectInterface();
+	}
+
+	protected function activityType(): string {
+		return Reject::TYPE;
+	}
+}

--- a/tests/Interfaces/Activity/RemoveInterfaceTest.php
+++ b/tests/Interfaces/Activity/RemoveInterfaceTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Interfaces\Activity;
+
+use OCA\Social\Interfaces\Activity\RemoveInterface;
+use OCA\Social\Interfaces\IActivityPubInterface;
+use OCA\Social\Model\ActivityPub\Activity\Remove;
+
+require_once __DIR__ . '/DispatchingActivityTestCase.php';
+
+class RemoveInterfaceTest extends DispatchingActivityTestCase {
+	protected function createHandler(): IActivityPubInterface {
+		return new RemoveInterface();
+	}
+
+	protected function activityType(): string {
+		return Remove::TYPE;
+	}
+}

--- a/tests/Interfaces/Activity/UndoInterfaceTest.php
+++ b/tests/Interfaces/Activity/UndoInterfaceTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Interfaces\Activity;
+
+use OCA\Social\Interfaces\Activity\UndoInterface;
+use OCA\Social\Interfaces\IActivityPubInterface;
+use OCA\Social\Model\ActivityPub\Activity\Undo;
+use OCA\Social\Model\ActivityPub\Object\Announce;
+use OCA\Social\Model\ActivityPub\Object\Like;
+
+require_once __DIR__ . '/DispatchingActivityTestCase.php';
+
+class UndoInterfaceTest extends DispatchingActivityTestCase {
+	protected function createHandler(): IActivityPubInterface {
+		return new UndoInterface();
+	}
+
+	protected function activityType(): string {
+		return Undo::TYPE;
+	}
+
+	public function testUndoOfALikeGoesToTheLikeInterface(): void {
+		$like = new Like();
+		$like->setId(self::REMOTE_URL . '/likes/1');
+		$undo = $this->incoming(Undo::TYPE, self::REMOTE_URL . '/undo/1', self::REMOTE_URL . '/users/bob', $like);
+
+		$this->likeInterface->expects($this->once())
+			->method('activity')
+			->with($this->identicalTo($undo), $this->identicalTo($like));
+		$this->followInterface->expects($this->never())->method('activity');
+		$this->announceInterface->expects($this->never())->method('activity');
+
+		$this->createHandler()->processIncomingRequest($undo);
+	}
+
+	public function testUndoOfABoostGoesToTheAnnounceInterface(): void {
+		$announce = new Announce();
+		$announce->setId(self::REMOTE_URL . '/announces/1');
+		$undo = $this->incoming(Undo::TYPE, self::REMOTE_URL . '/undo/1', self::REMOTE_URL . '/users/bob', $announce);
+
+		$this->announceInterface->expects($this->once())
+			->method('activity')
+			->with($this->identicalTo($undo), $this->identicalTo($announce));
+		$this->likeInterface->expects($this->never())->method('activity');
+
+		$this->createHandler()->processIncomingRequest($undo);
+	}
+}

--- a/tests/Interfaces/Activity/UpdateInterfaceTest.php
+++ b/tests/Interfaces/Activity/UpdateInterfaceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Interfaces\Activity;
+
+use OCA\Social\Interfaces\Activity\UpdateInterface;
+use OCA\Social\Interfaces\IActivityPubInterface;
+use OCA\Social\Model\ActivityPub\Activity\Update;
+
+require_once __DIR__ . '/DispatchingActivityTestCase.php';
+
+class UpdateInterfaceTest extends DispatchingActivityTestCase {
+	protected function createHandler(): IActivityPubInterface {
+		return new UpdateInterface();
+	}
+
+	protected function activityType(): string {
+		return Update::TYPE;
+	}
+
+	public function testUpdateOfAnActorGoesToThePersonInterface(): void {
+		$bob = $this->person(self::REMOTE_URL . '/users/bob');
+		$update = $this->incoming(Update::TYPE, self::REMOTE_URL . '/users/bob#updates/1', $bob->getId(), $bob);
+
+		$this->personInterface->expects($this->once())
+			->method('activity')
+			->with($this->identicalTo($update), $this->identicalTo($bob));
+		$this->noteInterface->expects($this->never())->method('activity');
+
+		$this->createHandler()->processIncomingRequest($update);
+	}
+
+	public function testUpdateOfANoteGoesToTheNoteInterface(): void {
+		$note = $this->note(self::REMOTE_URL . '/notes/1', self::REMOTE_URL . '/users/bob');
+		$update = $this->incoming(Update::TYPE, self::REMOTE_URL . '/notes/1#updates/1', self::REMOTE_URL . '/users/bob', $note);
+
+		$this->noteInterface->expects($this->once())
+			->method('activity')
+			->with($this->identicalTo($update), $this->identicalTo($note));
+		$this->personInterface->expects($this->never())->method('activity');
+
+		$this->createHandler()->processIncomingRequest($update);
+	}
+}

--- a/tests/Interfaces/ActivityPubTestCase.php
+++ b/tests/Interfaces/ActivityPubTestCase.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Interfaces;
+
+use OCA\Social\AP;
+use OCA\Social\Interfaces\Activity\AcceptInterface;
+use OCA\Social\Interfaces\Activity\AddInterface;
+use OCA\Social\Interfaces\Activity\BlockInterface;
+use OCA\Social\Interfaces\Activity\CreateInterface;
+use OCA\Social\Interfaces\Activity\DeleteInterface;
+use OCA\Social\Interfaces\Activity\MoveInterface;
+use OCA\Social\Interfaces\Activity\RejectInterface;
+use OCA\Social\Interfaces\Activity\RemoveInterface;
+use OCA\Social\Interfaces\Activity\UndoInterface;
+use OCA\Social\Interfaces\Activity\UpdateInterface;
+use OCA\Social\Interfaces\Actor\ApplicationInterface;
+use OCA\Social\Interfaces\Actor\GroupInterface;
+use OCA\Social\Interfaces\Actor\OrganizationInterface;
+use OCA\Social\Interfaces\Actor\PersonInterface;
+use OCA\Social\Interfaces\Actor\ServiceInterface;
+use OCA\Social\Interfaces\IActivityPubInterface;
+use OCA\Social\Interfaces\Internal\SocialAppNotificationInterface;
+use OCA\Social\Interfaces\Object\AnnounceInterface;
+use OCA\Social\Interfaces\Object\DocumentInterface;
+use OCA\Social\Interfaces\Object\FollowInterface;
+use OCA\Social\Interfaces\Object\ImageInterface;
+use OCA\Social\Interfaces\Object\LikeInterface;
+use OCA\Social\Interfaces\Object\NoteInterface;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\SignatureService;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Shared fixture for the incoming-federation handlers.
+ *
+ * The handlers reach each other through the static `AP::$activityPub` registry,
+ * so every test gets a registry built from one mock per interface; the handler
+ * under test is then constructed for real with mocked collaborators. Nothing in
+ * here touches a database, the network or the filesystem.
+ */
+abstract class ActivityPubTestCase extends TestCase {
+	public const LOCAL_HOST = 'local.example';
+	public const LOCAL_URL = 'https://local.example';
+	public const REMOTE_HOST = 'remote.example';
+	public const REMOTE_URL = 'https://remote.example';
+
+	protected AP $ap;
+	/** @var ConfigService&MockObject */
+	protected $configService;
+
+	/** @var AcceptInterface&MockObject */
+	protected $acceptInterface;
+	/** @var AddInterface&MockObject */
+	protected $addInterface;
+	/** @var AnnounceInterface&MockObject */
+	protected $announceInterface;
+	/** @var BlockInterface&MockObject */
+	protected $blockInterface;
+	/** @var CreateInterface&MockObject */
+	protected $createInterface;
+	/** @var DeleteInterface&MockObject */
+	protected $deleteInterface;
+	/** @var DocumentInterface&MockObject */
+	protected $documentInterface;
+	/** @var FollowInterface&MockObject */
+	protected $followInterface;
+	/** @var ImageInterface&MockObject */
+	protected $imageInterface;
+	/** @var LikeInterface&MockObject */
+	protected $likeInterface;
+	/** @var MoveInterface&MockObject */
+	protected $moveInterface;
+	/** @var NoteInterface&MockObject */
+	protected $noteInterface;
+	/** @var SocialAppNotificationInterface&MockObject */
+	protected $notificationInterface;
+	/** @var PersonInterface&MockObject */
+	protected $personInterface;
+	/** @var ServiceInterface&MockObject */
+	protected $serviceInterface;
+	/** @var GroupInterface&MockObject */
+	protected $groupInterface;
+	/** @var OrganizationInterface&MockObject */
+	protected $organizationInterface;
+	/** @var ApplicationInterface&MockObject */
+	protected $applicationInterface;
+	/** @var RejectInterface&MockObject */
+	protected $rejectInterface;
+	/** @var RemoveInterface&MockObject */
+	protected $removeInterface;
+	/** @var UndoInterface&MockObject */
+	protected $undoInterface;
+	/** @var UpdateInterface&MockObject */
+	protected $updateInterface;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->acceptInterface = $this->createMock(AcceptInterface::class);
+		$this->addInterface = $this->createMock(AddInterface::class);
+		$this->announceInterface = $this->createMock(AnnounceInterface::class);
+		$this->blockInterface = $this->createMock(BlockInterface::class);
+		$this->createInterface = $this->createMock(CreateInterface::class);
+		$this->deleteInterface = $this->createMock(DeleteInterface::class);
+		$this->documentInterface = $this->createMock(DocumentInterface::class);
+		$this->followInterface = $this->createMock(FollowInterface::class);
+		$this->imageInterface = $this->createMock(ImageInterface::class);
+		$this->likeInterface = $this->createMock(LikeInterface::class);
+		$this->moveInterface = $this->createMock(MoveInterface::class);
+		$this->noteInterface = $this->createMock(NoteInterface::class);
+		$this->notificationInterface = $this->createMock(SocialAppNotificationInterface::class);
+		$this->personInterface = $this->createMock(PersonInterface::class);
+		$this->serviceInterface = $this->createMock(ServiceInterface::class);
+		$this->groupInterface = $this->createMock(GroupInterface::class);
+		$this->organizationInterface = $this->createMock(OrganizationInterface::class);
+		$this->applicationInterface = $this->createMock(ApplicationInterface::class);
+		$this->rejectInterface = $this->createMock(RejectInterface::class);
+		$this->removeInterface = $this->createMock(RemoveInterface::class);
+		$this->undoInterface = $this->createMock(UndoInterface::class);
+		$this->updateInterface = $this->createMock(UpdateInterface::class);
+
+		// Every model created through the registry gets the cloud URL; ids generated
+		// locally (the Accept answering a Follow, for instance) are built from it.
+		$this->configService = $this->createMock(ConfigService::class);
+		$this->configService->method('getCloudUrl')->willReturn(self::LOCAL_URL);
+
+		$this->ap = new AP(
+			$this->acceptInterface,
+			$this->addInterface,
+			$this->announceInterface,
+			$this->blockInterface,
+			$this->createInterface,
+			$this->deleteInterface,
+			$this->documentInterface,
+			$this->followInterface,
+			$this->imageInterface,
+			$this->likeInterface,
+			$this->moveInterface,
+			$this->noteInterface,
+			$this->notificationInterface,
+			$this->personInterface,
+			$this->serviceInterface,
+			$this->groupInterface,
+			$this->organizationInterface,
+			$this->applicationInterface,
+			$this->rejectInterface,
+			$this->removeInterface,
+			$this->undoInterface,
+			$this->updateInterface,
+			$this->configService,
+		);
+		AP::$activityPub = $this->ap;
+
+		// Stream::import() resolves the URL generator statically while importing attachments
+		\OC::$server->register(IURLGenerator::class, $this->createMock(IURLGenerator::class));
+	}
+
+	protected function tearDown(): void {
+		AP::$activityPub = null;
+		\OC::$server->reset();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @return array<int, IActivityPubInterface&MockObject>
+	 */
+	protected function allInterfaces(): array {
+		return [
+			$this->acceptInterface,
+			$this->addInterface,
+			$this->announceInterface,
+			$this->blockInterface,
+			$this->createInterface,
+			$this->deleteInterface,
+			$this->documentInterface,
+			$this->followInterface,
+			$this->imageInterface,
+			$this->likeInterface,
+			$this->moveInterface,
+			$this->noteInterface,
+			$this->notificationInterface,
+			$this->personInterface,
+			$this->serviceInterface,
+			$this->groupInterface,
+			$this->organizationInterface,
+			$this->applicationInterface,
+			$this->rejectInterface,
+			$this->removeInterface,
+			$this->undoInterface,
+			$this->updateInterface,
+		];
+	}
+
+	/** Nothing in the registry may be handed an activity. */
+	protected function expectNoInterfaceReceivesActivity(): void {
+		foreach ($this->allInterfaces() as $interface) {
+			$interface->expects($this->never())->method('activity');
+		}
+	}
+
+	/**
+	 * Records the first argument of the next call to a mocked method; use it to
+	 * assert on the object a handler passes on instead of matching it inline.
+	 *
+	 * @param mixed $into receives the argument
+	 * @param mixed $return what the mocked method should return (void methods: null)
+	 */
+	protected function capture(MockObject $mock, string $method, &$into, $return = null): void {
+		$mock->expects($this->once())
+			->method($method)
+			->willReturnCallback(function ($argument) use (&$into, $return) {
+				$into = $argument;
+
+				return $return;
+			});
+	}
+
+	/** An actor whose collection URLs hang off its id, the way Mastodon lays them out. */
+	protected function person(string $id, bool $local = false, string $account = ''): Person {
+		$person = new Person();
+		$person->setAccount($account !== '' ? $account : basename($id) . '@' . parse_url($id, PHP_URL_HOST))
+			->setInbox($id . '/inbox')
+			->setFollowers($id . '/followers')
+			->setFollowing($id . '/following');
+		$person->setId($id);
+		$person->setLocal($local);
+
+		return $person;
+	}
+
+	/** A Note as it arrives inside an activity: id plus author, nothing stored yet. */
+	protected function note(string $id, string $attributedTo, bool $local = false): Note {
+		$note = new Note();
+		$note->setId($id);
+		$note->setAttributedTo($attributedTo);
+		$note->setLocal($local);
+
+		return $note;
+	}
+
+	/**
+	 * An item the way the inbox hands it to a handler: built through the registry,
+	 * carrying the origin the request signature was verified against (the host of
+	 * its own id unless told otherwise) and, optionally, the wrapped object.
+	 */
+	protected function incoming(
+		string $type,
+		string $id,
+		string $actorId,
+		?ACore $object = null,
+		?string $origin = null,
+	): ACore {
+		$item = $this->ap->getItemFromType($type);
+		$item->setId($id);
+		$item->setActorId($actorId);
+		if ($object !== null) {
+			$item->setObject($object);
+		}
+		$item->setOrigin(
+			$origin ?? (string)parse_url($id, PHP_URL_HOST),
+			SignatureService::ORIGIN_HEADER,
+			time()
+		);
+
+		return $item;
+	}
+}

--- a/tests/Interfaces/Actor/ActorInterfaceTestCase.php
+++ b/tests/Interfaces/Actor/ActorInterfaceTestCase.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Interfaces\Actor;
+
+use OCA\Social\Db\ActionsRequest;
+use OCA\Social\Db\CacheActorsRequest;
+use OCA\Social\Db\CacheDocumentsRequest;
+use OCA\Social\Db\FollowsRequest;
+use OCA\Social\Db\RequestQueueRequest;
+use OCA\Social\Db\StreamDestRequest;
+use OCA\Social\Db\StreamRequest;
+use OCA\Social\Exceptions\CacheActorDoesNotExistException;
+use OCA\Social\Exceptions\ItemNotFoundException;
+use OCA\Social\Interfaces\Actor\PersonInterface;
+use OCA\Social\Model\ActivityPub\Activity\Delete;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Service\ActorService;
+use OCA\Social\Tests\Interfaces\ActivityPubTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+require_once __DIR__ . '/../ActivityPubTestCase.php';
+
+/**
+ * Service, Group, Organization and Application actors are handled by
+ * PersonInterface subclasses that add nothing of their own; these are the
+ * behaviours every actor kind must share.
+ */
+abstract class ActorInterfaceTestCase extends ActivityPubTestCase {
+	protected const BOB = self::REMOTE_URL . '/users/bob';
+
+	/** @var ActionsRequest&MockObject */
+	protected $actionsRequest;
+	/** @var CacheActorsRequest&MockObject */
+	protected $cacheActorsRequest;
+	/** @var CacheDocumentsRequest&MockObject */
+	protected $cacheDocumentsRequest;
+	/** @var FollowsRequest&MockObject */
+	protected $followsRequest;
+	/** @var RequestQueueRequest&MockObject */
+	protected $requestQueueRequest;
+	/** @var StreamRequest&MockObject */
+	protected $streamRequest;
+	/** @var StreamDestRequest&MockObject */
+	protected $streamDestRequest;
+	/** @var ActorService&MockObject */
+	protected $actorService;
+	protected PersonInterface $handler;
+
+	/** The handler under test, wired with the mocks above. */
+	abstract protected function createHandler(): PersonInterface;
+
+	/** An empty instance of the actor model this handler is registered for. */
+	abstract protected function createActor(): Person;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->actionsRequest = $this->createMock(ActionsRequest::class);
+		$this->cacheActorsRequest = $this->createMock(CacheActorsRequest::class);
+		$this->cacheDocumentsRequest = $this->createMock(CacheDocumentsRequest::class);
+		$this->followsRequest = $this->createMock(FollowsRequest::class);
+		$this->requestQueueRequest = $this->createMock(RequestQueueRequest::class);
+		$this->streamRequest = $this->createMock(StreamRequest::class);
+		$this->streamDestRequest = $this->createMock(StreamDestRequest::class);
+		$this->actorService = $this->createMock(ActorService::class);
+
+		$this->handler = $this->createHandler();
+	}
+
+	/** bob, a remote actor of the kind under test. */
+	protected function bob(): Person {
+		$bob = $this->createActor();
+		$bob->setAccount('bob@remote.example')
+			->setInbox(self::BOB . '/inbox')
+			->setFollowers(self::BOB . '/followers')
+			->setFollowing(self::BOB . '/following');
+		$bob->setId(self::BOB);
+
+		return $bob;
+	}
+
+	protected function nothingCached(): void {
+		$this->cacheActorsRequest->method('getFromId')->willThrowException(new CacheActorDoesNotExistException());
+	}
+
+	public function testGetItemByIdReturnsTheCachedActor(): void {
+		$bob = $this->bob();
+		$this->cacheActorsRequest->method('getFromId')->with(self::BOB)->willReturn($bob);
+
+		$this->assertSame($bob, $this->handler->getItemById(self::BOB));
+	}
+
+	public function testGetItemByIdThrowsWhenTheActorIsNotCached(): void {
+		$this->nothingCached();
+
+		$this->expectException(ItemNotFoundException::class);
+
+		$this->handler->getItemById(self::BOB);
+	}
+
+	public function testSaveOfAnUnknownActorCreatesIt(): void {
+		$this->nothingCached();
+		$bob = $this->bob();
+
+		$this->actorService->expects($this->once())->method('save')->with($this->identicalTo($bob));
+		$this->actorService->expects($this->never())->method('update');
+
+		$this->handler->save($bob);
+	}
+
+	public function testSaveOfACachedActorUpdatesIt(): void {
+		$bob = $this->bob();
+		$this->cacheActorsRequest->method('getFromId')->willReturn($bob);
+
+		$this->actorService->expects($this->once())->method('update')->with($this->identicalTo($bob));
+		$this->actorService->expects($this->never())->method('save');
+
+		$this->handler->save($bob);
+	}
+
+	public function testDeleteActivityWipesEverythingTheActorLeftBehind(): void {
+		$bob = $this->bob();
+		$delete = $this->incoming(Delete::TYPE, self::BOB . '#delete', self::BOB, $bob);
+		$this->streamDestRequest->method('getRelatedToActor')->willReturn([]);
+
+		$this->actionsRequest->expects($this->once())->method('deleteByActor')->with(self::BOB);
+		$this->cacheActorsRequest->expects($this->once())->method('deleteCacheById')->with(self::BOB);
+		$this->cacheDocumentsRequest->expects($this->once())->method('deleteByParent')->with(self::BOB);
+		$this->requestQueueRequest->expects($this->once())->method('deleteByAuthor')->with(self::BOB);
+		$this->followsRequest->expects($this->once())->method('deleteRelatedId')->with(self::BOB);
+		$this->streamRequest->expects($this->once())->method('deleteByAuthor')->with(self::BOB);
+		$this->streamDestRequest->expects($this->once())->method('deleteRelatedToActor')->with(self::BOB);
+
+		$this->handler->activity($delete, $bob);
+	}
+}

--- a/tests/Interfaces/Actor/ApplicationInterfaceTest.php
+++ b/tests/Interfaces/Actor/ApplicationInterfaceTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Interfaces\Actor;
+
+use OCA\Social\Interfaces\Actor\ApplicationInterface;
+use OCA\Social\Interfaces\Actor\PersonInterface;
+use OCA\Social\Model\ActivityPub\Actor\Application;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+
+require_once __DIR__ . '/ActorInterfaceTestCase.php';
+
+class ApplicationInterfaceTest extends ActorInterfaceTestCase {
+	protected function createHandler(): PersonInterface {
+		return new ApplicationInterface(
+			$this->actionsRequest,
+			$this->cacheActorsRequest,
+			$this->cacheDocumentsRequest,
+			$this->followsRequest,
+			$this->requestQueueRequest,
+			$this->streamRequest,
+			$this->streamDestRequest,
+			$this->actorService,
+			$this->configService,
+		);
+	}
+
+	protected function createActor(): Person {
+		return new Application();
+	}
+}

--- a/tests/Interfaces/Actor/GroupInterfaceTest.php
+++ b/tests/Interfaces/Actor/GroupInterfaceTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Interfaces\Actor;
+
+use OCA\Social\Interfaces\Actor\GroupInterface;
+use OCA\Social\Interfaces\Actor\PersonInterface;
+use OCA\Social\Model\ActivityPub\Actor\Group;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+
+require_once __DIR__ . '/ActorInterfaceTestCase.php';
+
+class GroupInterfaceTest extends ActorInterfaceTestCase {
+	protected function createHandler(): PersonInterface {
+		return new GroupInterface(
+			$this->actionsRequest,
+			$this->cacheActorsRequest,
+			$this->cacheDocumentsRequest,
+			$this->followsRequest,
+			$this->requestQueueRequest,
+			$this->streamRequest,
+			$this->streamDestRequest,
+			$this->actorService,
+			$this->configService,
+		);
+	}
+
+	protected function createActor(): Person {
+		return new Group();
+	}
+}

--- a/tests/Interfaces/Actor/OrganizationInterfaceTest.php
+++ b/tests/Interfaces/Actor/OrganizationInterfaceTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Interfaces\Actor;
+
+use OCA\Social\Interfaces\Actor\OrganizationInterface;
+use OCA\Social\Interfaces\Actor\PersonInterface;
+use OCA\Social\Model\ActivityPub\Actor\Organization;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+
+require_once __DIR__ . '/ActorInterfaceTestCase.php';
+
+class OrganizationInterfaceTest extends ActorInterfaceTestCase {
+	protected function createHandler(): PersonInterface {
+		return new OrganizationInterface(
+			$this->actionsRequest,
+			$this->cacheActorsRequest,
+			$this->cacheDocumentsRequest,
+			$this->followsRequest,
+			$this->requestQueueRequest,
+			$this->streamRequest,
+			$this->streamDestRequest,
+			$this->actorService,
+			$this->configService,
+		);
+	}
+
+	protected function createActor(): Person {
+		return new Organization();
+	}
+}

--- a/tests/Interfaces/Actor/PersonInterfaceTest.php
+++ b/tests/Interfaces/Actor/PersonInterfaceTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Interfaces\Actor;
+
+use OCA\Social\Exceptions\InvalidOriginException;
+use OCA\Social\Exceptions\ItemNotFoundException;
+use OCA\Social\Exceptions\StreamNotFoundException;
+use OCA\Social\Interfaces\Actor\PersonInterface;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Activity\Delete;
+use OCA\Social\Model\ActivityPub\Activity\Update;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Model\ActivityPub\Stream;
+use OCA\Social\Model\StreamDest;
+use OCA\Social\Service\SignatureService;
+
+require_once __DIR__ . '/ActorInterfaceTestCase.php';
+
+class PersonInterfaceTest extends ActorInterfaceTestCase {
+	private const CAROL = 'https://other.example/users/carol';
+
+	protected function createHandler(): PersonInterface {
+		return new PersonInterface(
+			$this->actionsRequest,
+			$this->cacheActorsRequest,
+			$this->cacheDocumentsRequest,
+			$this->followsRequest,
+			$this->requestQueueRequest,
+			$this->streamRequest,
+			$this->streamDestRequest,
+			$this->actorService,
+			$this->configService,
+		);
+	}
+
+	protected function createActor(): Person {
+		return new Person();
+	}
+
+	/** An Update of bob's profile, signed by bob's server at the given time. */
+	private function update(Person $bob, int $creationTime, string $origin = self::REMOTE_HOST): ACore {
+		$update = $this->incoming(Update::TYPE, self::BOB . '#updates/1', self::BOB, $bob);
+		$update->setOrigin($origin, SignatureService::ORIGIN_HEADER, $creationTime);
+
+		return $update;
+	}
+
+	private function cachedBob(int $creation): Person {
+		$cached = $this->bob();
+		$cached->setCreation($creation);
+
+		return $cached;
+	}
+
+	private function dest(string $streamId, string $subtype, string $type = 'recipient'): StreamDest {
+		$dest = new StreamDest();
+		$dest->setStreamId($streamId)
+			->setActorId(self::BOB)
+			->setType($type)
+			->setSubtype($subtype);
+
+		return $dest;
+	}
+
+	/** @param Stream[] $streams */
+	private function storedStreams(array $streams): void {
+		$byId = [];
+		foreach ($streams as $stream) {
+			$byId[$stream->getId()] = $stream;
+		}
+		$this->streamRequest->method('getStream')->willReturnCallback(function (string $id) use ($byId): Stream {
+			if (!isset($byId[$id])) {
+				throw new StreamNotFoundException();
+			}
+
+			return $byId[$id];
+		});
+	}
+
+	public function testGetItemIsNotSupported(): void {
+		$this->expectException(ItemNotFoundException::class);
+
+		$this->handler->getItem($this->bob());
+	}
+
+	public function testUpdateNewerThanTheCachedProfileRefreshesIt(): void {
+		$bob = $this->bob();
+		$this->cacheActorsRequest->method('getFromId')->with(self::BOB)->willReturn($this->cachedBob(1000));
+
+		$this->cacheActorsRequest->expects($this->once())->method('update')->with($this->identicalTo($bob));
+		$this->cacheActorsRequest->expects($this->never())->method('save');
+
+		$this->handler->activity($this->update($bob, 2000), $bob);
+
+		$this->assertSame(2000, $bob->getCreation());
+	}
+
+	public function testUpdateOlderThanTheCachedProfileIsIgnored(): void {
+		$bob = $this->bob();
+		$this->cacheActorsRequest->method('getFromId')->willReturn($this->cachedBob(3000));
+
+		$this->cacheActorsRequest->expects($this->never())->method('update');
+		$this->cacheActorsRequest->expects($this->never())->method('save');
+
+		$this->handler->activity($this->update($bob, 2000), $bob);
+	}
+
+	public function testUpdateOfAnActorNotCachedYetCachesIt(): void {
+		$this->nothingCached();
+		$bob = $this->bob();
+
+		$this->cacheActorsRequest->expects($this->once())->method('save')->with($this->identicalTo($bob));
+		$this->cacheActorsRequest->expects($this->never())->method('update');
+
+		$this->handler->activity($this->update($bob, 2000), $bob);
+	}
+
+	public function testUpdateNotComingFromTheActorsServerIsRefused(): void {
+		$bob = $this->bob();
+
+		$this->cacheActorsRequest->expects($this->never())->method('update');
+		$this->cacheActorsRequest->expects($this->never())->method('save');
+
+		$this->expectException(InvalidOriginException::class);
+
+		$this->handler->activity($this->update($bob, 2000, 'evil.example'), $bob);
+	}
+
+	public function testDeleteNotComingFromTheActorsServerIsRefused(): void {
+		$bob = $this->bob();
+		$delete = $this->incoming(Delete::TYPE, self::BOB . '#delete', self::BOB, $bob, 'evil.example');
+
+		$this->cacheActorsRequest->expects($this->never())->method('deleteCacheById');
+
+		$this->expectException(InvalidOriginException::class);
+
+		$this->handler->activity($delete, $bob);
+	}
+
+	public function testDeleteRemovesTheActorFromTheRecipientsOfRemainingStreams(): void {
+		$bob = $this->bob();
+
+		$addressed = new Note();
+		$addressed->setId(self::REMOTE_URL . '/notes/addressed');
+		$addressed->setToArray([self::BOB, self::CAROL]);
+
+		$copied = new Note();
+		$copied->setId(self::REMOTE_URL . '/notes/copied');
+		$copied->setCcArray([$bob->getFollowers(), self::CAROL]);
+
+		$unrelated = new Note();
+		$unrelated->setId(self::REMOTE_URL . '/notes/unrelated');
+		$unrelated->setToArray([self::CAROL]);
+
+		$this->storedStreams([$addressed, $copied, $unrelated]);
+		$this->streamDestRequest->method('getRelatedToActor')->with($this->identicalTo($bob))->willReturn([
+			$this->dest($addressed->getId(), 'to'),
+			$this->dest($copied->getId(), 'cc'),
+			$this->dest($unrelated->getId(), 'to'),
+			$this->dest(self::REMOTE_URL . '/notes/gone', 'to'),
+			$this->dest($addressed->getId(), 'x', 'hashtag'),
+		]);
+
+		$updated = [];
+		$this->streamRequest->method('update')->willReturnCallback(function (Stream $stream) use (&$updated): void {
+			$updated[] = $stream->getId();
+		});
+		$this->streamRequest->expects($this->never())->method('deleteById');
+
+		$this->handler->delete($bob);
+
+		$this->assertSame([self::CAROL], array_values($addressed->getToArray()));
+		$this->assertSame([self::CAROL], array_values($copied->getCcArray()));
+		$this->assertSame([self::CAROL], $unrelated->getToArray());
+		$this->assertEqualsCanonicalizing([$addressed->getId(), $copied->getId()], $updated);
+	}
+
+	public function testDeleteRemovesDirectMessagesSentToTheActor(): void {
+		$bob = $this->bob();
+		$direct = new Note();
+		$direct->setId(self::REMOTE_URL . '/notes/direct');
+		$direct->setTo(self::BOB);
+
+		$this->storedStreams([$direct]);
+		$this->streamDestRequest->method('getRelatedToActor')->willReturn([$this->dest($direct->getId(), 'to')]);
+
+		$this->streamRequest->expects($this->once())->method('deleteById')->with($direct->getId());
+		$this->streamRequest->expects($this->never())->method('update');
+
+		$this->handler->delete($bob);
+	}
+
+	public function testDeleteIgnoresItemsThatAreNotActors(): void {
+		$this->actionsRequest->expects($this->never())->method('deleteByActor');
+		$this->cacheActorsRequest->expects($this->never())->method('deleteCacheById');
+		$this->streamRequest->expects($this->never())->method('deleteByAuthor');
+
+		$this->handler->delete($this->note(self::REMOTE_URL . '/notes/1', self::BOB));
+	}
+}

--- a/tests/Interfaces/Actor/ServiceInterfaceTest.php
+++ b/tests/Interfaces/Actor/ServiceInterfaceTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Interfaces\Actor;
+
+use OCA\Social\Interfaces\Actor\PersonInterface;
+use OCA\Social\Interfaces\Actor\ServiceInterface;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Actor\Service;
+
+require_once __DIR__ . '/ActorInterfaceTestCase.php';
+
+class ServiceInterfaceTest extends ActorInterfaceTestCase {
+	protected function createHandler(): PersonInterface {
+		return new ServiceInterface(
+			$this->actionsRequest,
+			$this->cacheActorsRequest,
+			$this->cacheDocumentsRequest,
+			$this->followsRequest,
+			$this->requestQueueRequest,
+			$this->streamRequest,
+			$this->streamDestRequest,
+			$this->actorService,
+			$this->configService,
+		);
+	}
+
+	protected function createActor(): Person {
+		return new Service();
+	}
+}

--- a/tests/Interfaces/Internal/SocialAppNotificationInterfaceTest.php
+++ b/tests/Interfaces/Internal/SocialAppNotificationInterfaceTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Interfaces\Internal;
+
+use OCA\Social\Db\StreamRequest;
+use OCA\Social\Interfaces\Internal\SocialAppNotificationInterface;
+use OCA\Social\Model\ActivityPub\Internal\SocialAppNotification;
+use OCA\Social\Model\ActivityPub\Object\Follow;
+use OCA\Social\Service\MiscService;
+use OCA\Social\Tests\Interfaces\ActivityPubTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+require_once __DIR__ . '/../ActivityPubTestCase.php';
+
+class SocialAppNotificationInterfaceTest extends ActivityPubTestCase {
+	private const ID = self::REMOTE_URL . '/follows/1/notification';
+
+	/** @var StreamRequest&MockObject */
+	private $streamRequest;
+	/** @var MiscService&MockObject */
+	private $miscService;
+	private SocialAppNotificationInterface $handler;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->streamRequest = $this->createMock(StreamRequest::class);
+		$this->miscService = $this->createMock(MiscService::class);
+
+		$this->handler = new SocialAppNotificationInterface($this->streamRequest, $this->miscService);
+	}
+
+	private function notification(): SocialAppNotification {
+		$notification = new SocialAppNotification();
+		$notification->setId(self::ID);
+		$notification->setSubType(Follow::TYPE);
+		$notification->setTo(self::LOCAL_URL . '/users/alice');
+		$notification->setLocal(true);
+
+		return $notification;
+	}
+
+	public function testNotificationWithoutAnIdIsNotStored(): void {
+		$this->streamRequest->expects($this->never())->method('save');
+		$this->miscService->expects($this->never())->method('log');
+
+		$this->handler->save(new SocialAppNotification());
+	}
+
+	public function testSaveStampsThePublicationTimeAndStoresTheNotificationAsAStream(): void {
+		$notification = $this->notification();
+
+		$this->streamRequest->expects($this->once())->method('save')->with($this->identicalTo($notification));
+
+		$this->handler->save($notification);
+
+		$this->assertNotSame('', $notification->getPublished());
+		$this->assertEqualsWithDelta(time(), $notification->getPublishedTime(), 5);
+	}
+
+	public function testUpdateRewritesTheNotificationAndItsRecipients(): void {
+		$notification = $this->notification();
+
+		$this->streamRequest->expects($this->once())->method('update')->with($this->identicalTo($notification), true);
+		$this->streamRequest->expects($this->never())->method('save');
+
+		$this->handler->update($notification);
+	}
+
+	public function testDeleteRemovesOnlyTheNotificationRow(): void {
+		$this->streamRequest->expects($this->once())->method('deleteById')->with(self::ID, SocialAppNotification::TYPE);
+
+		$this->handler->delete($this->notification());
+	}
+}

--- a/tests/Interfaces/Object/AnnounceInterfaceTest.php
+++ b/tests/Interfaces/Object/AnnounceInterfaceTest.php
@@ -1,0 +1,356 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Interfaces\Object;
+
+use OCA\Social\Db\ActionsRequest;
+use OCA\Social\Db\StreamRequest;
+use OCA\Social\Exceptions\ActionDoesNotExistException;
+use OCA\Social\Exceptions\CacheActorDoesNotExistException;
+use OCA\Social\Exceptions\InvalidOriginException;
+use OCA\Social\Exceptions\ItemNotFoundException;
+use OCA\Social\Exceptions\StreamNotFoundException;
+use OCA\Social\Interfaces\Object\AnnounceInterface;
+use OCA\Social\Model\ActivityPub\Activity\Undo;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Internal\SocialAppNotification;
+use OCA\Social\Model\ActivityPub\Object\Announce;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Model\ActivityPub\Stream;
+use OCA\Social\Model\StreamQueue;
+use OCA\Social\Service\CacheActorService;
+use OCA\Social\Service\MiscService;
+use OCA\Social\Service\SignatureService;
+use OCA\Social\Service\StreamQueueService;
+use OCA\Social\Tests\Interfaces\ActivityPubTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+require_once __DIR__ . '/../ActivityPubTestCase.php';
+
+class AnnounceInterfaceTest extends ActivityPubTestCase {
+	private const POST = self::LOCAL_URL . '/notes/1';
+
+	/** @var StreamRequest&MockObject */
+	private $streamRequest;
+	/** @var ActionsRequest&MockObject */
+	private $actionsRequest;
+	/** @var StreamQueueService&MockObject */
+	private $streamQueueService;
+	/** @var CacheActorService&MockObject */
+	private $cacheActorService;
+	/** @var MiscService&MockObject */
+	private $miscService;
+	private AnnounceInterface $handler;
+
+	private Person $alice;
+	private Person $bob;
+	private Person $carol;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->streamRequest = $this->createMock(StreamRequest::class);
+		$this->actionsRequest = $this->createMock(ActionsRequest::class);
+		$this->streamQueueService = $this->createMock(StreamQueueService::class);
+		$this->cacheActorService = $this->createMock(CacheActorService::class);
+		$this->miscService = $this->createMock(MiscService::class);
+
+		$this->handler = new AnnounceInterface(
+			$this->streamRequest,
+			$this->actionsRequest,
+			$this->streamQueueService,
+			$this->cacheActorService,
+			$this->miscService,
+		);
+
+		$this->alice = $this->person(self::LOCAL_URL . '/users/alice', true);
+		$this->bob = $this->person(self::REMOTE_URL . '/users/bob');
+		$this->carol = $this->person('https://other.example/users/carol');
+		$this->cacheActorService->method('getFromId')->willReturnCallback(function (string $id): Person {
+			if ($id === $this->bob->getId()) {
+				return $this->bob;
+			}
+
+			throw new CacheActorDoesNotExistException();
+		});
+	}
+
+	/** bob (remote) boosts something, alice's local post unless told otherwise. */
+	private function incomingAnnounce(string $objectId = self::POST, string $origin = self::REMOTE_HOST): Announce {
+		$announce = new Announce();
+		$announce->setId(self::REMOTE_URL . '/announces/1');
+		$announce->setActorId($this->bob->getId());
+		$announce->setObjectId($objectId);
+		$announce->setRequestToken('token-1');
+		$announce->setOrigin($origin, SignatureService::ORIGIN_HEADER, time());
+
+		return $announce;
+	}
+
+	private function post(bool $local = true, int $remoteBoosts = 0): Note {
+		$post = $this->note(self::POST, $this->alice->getId(), $local);
+		$post->setDetailInt('remote_boosts', $remoteBoosts);
+
+		return $post;
+	}
+
+	/** The Announce stream already stored for the post, carrying the followers of earlier boosters. */
+	private function knownAnnounce(string ...$ccFollowers): Announce {
+		$known = new Announce();
+		$known->setId(self::REMOTE_URL . '/announces/0');
+		$known->setAttributedTo($this->carol->getId());
+		$known->setCcArray($ccFollowers);
+
+		return $known;
+	}
+
+	private function boostNotification(string ...$accounts): SocialAppNotification {
+		$notification = new SocialAppNotification();
+		$notification->setId(self::POST . '/notification+boost');
+		foreach ($accounts as $account) {
+			$notification->addDetail('accounts', $account);
+		}
+
+		return $notification;
+	}
+
+	/** getStreamByObjectId() answers by requested stream type; a type not listed is "not found". */
+	private function storedStreamsByType(array $byType): void {
+		$this->streamRequest->method('getStreamByObjectId')
+			->willReturnCallback(function (string $objectId, string $type) use ($byType): Stream {
+				if (!isset($byType[$type])) {
+					throw new StreamNotFoundException();
+				}
+
+				return $byType[$type];
+			});
+	}
+
+	private function noStoredAction(): void {
+		$this->actionsRequest->method('getActionFromItem')->willThrowException(new ActionDoesNotExistException());
+	}
+
+	public function testFirstBoostOfAnObjectIsStoredAsAnAnnounceAttributedToTheBooster(): void {
+		$this->storedStreamsByType([]);
+		$this->streamRequest->method('getStreamById')->willThrowException(new StreamNotFoundException());
+		$announce = $this->incomingAnnounce(self::REMOTE_URL . '/notes/9');
+
+		$saved = null;
+		$this->capture($this->streamRequest, 'save', $saved);
+
+		$this->handler->processIncomingRequest($announce);
+
+		$this->assertSame($announce, $saved);
+		$this->assertSame($this->bob->getId(), $announce->getAttributedTo());
+		$this->assertSame(
+			self::REMOTE_URL . '/notes/9',
+			$announce->getCache()->getItem(self::REMOTE_URL . '/notes/9')->getUrl()
+		);
+	}
+
+	public function testFirstBoostOfAnObjectWeDoNotHaveYetQueuesItForFetching(): void {
+		$this->storedStreamsByType([]);
+		$this->streamRequest->method('getStreamById')->willThrowException(new StreamNotFoundException());
+		$announce = $this->incomingAnnounce(self::REMOTE_URL . '/notes/9');
+
+		$this->streamQueueService->expects($this->once())
+			->method('generateStreamQueue')
+			->with('token-1', StreamQueue::TYPE_CACHE, $announce->getId());
+		$this->actionsRequest->expects($this->never())->method('save');
+		$this->notificationInterface->expects($this->never())->method('save');
+
+		$this->handler->processIncomingRequest($announce);
+	}
+
+	public function testBoostOfAnAlreadyBoostedObjectAddsTheBoostersFollowersAsRecipients(): void {
+		$known = $this->knownAnnounce($this->carol->getFollowers());
+		$this->storedStreamsByType([Announce::TYPE => $known]);
+		$this->streamRequest->method('getStreamById')->willThrowException(new StreamNotFoundException());
+
+		$this->streamRequest->expects($this->never())->method('save');
+		$this->streamRequest->expects($this->once())->method('update')->with($this->identicalTo($known), true);
+
+		$this->handler->processIncomingRequest($this->incomingAnnounce());
+
+		$this->assertEqualsCanonicalizing(
+			[$this->carol->getFollowers(), $this->bob->getFollowers()],
+			$known->getCcArray()
+		);
+		$this->assertSame($this->bob->getId(), $known->getAttributedTo());
+	}
+
+	public function testBoostAlreadyReachingTheBoostersFollowersIsNotRewritten(): void {
+		$known = $this->knownAnnounce($this->bob->getFollowers());
+		$this->storedStreamsByType([Announce::TYPE => $known]);
+		$this->streamRequest->method('getStreamById')->willThrowException(new StreamNotFoundException());
+
+		$this->streamRequest->expects($this->never())->method('update');
+		$this->streamRequest->expects($this->never())->method('save');
+
+		$this->handler->processIncomingRequest($this->incomingAnnounce());
+	}
+
+	public function testBoostOfALocalPostIsCountedOnThePost(): void {
+		$this->storedStreamsByType([]);
+		$this->noStoredAction();
+		$post = $this->post(true, 1);
+		$this->streamRequest->method('getStreamById')->willReturn($post);
+		$this->actionsRequest->method('countActions')->with(self::POST, Announce::TYPE)->willReturn(2);
+		$announce = $this->incomingAnnounce();
+
+		$this->actionsRequest->expects($this->once())->method('save')->with($this->identicalTo($announce));
+		$this->streamRequest->expects($this->once())->method('updateDetails')->with($this->identicalTo($post));
+
+		$this->handler->processIncomingRequest($announce);
+
+		$this->assertSame(3, $post->getDetailInt('boosts'));
+	}
+
+	public function testBoostOfALocalPostNotifiesItsAuthor(): void {
+		$this->storedStreamsByType([]);
+		$this->noStoredAction();
+		$this->streamRequest->method('getStreamById')->willReturn($this->post());
+
+		$notification = null;
+		$this->capture($this->notificationInterface, 'save', $notification);
+
+		$this->handler->processIncomingRequest($this->incomingAnnounce());
+
+		$this->assertInstanceOf(SocialAppNotification::class, $notification);
+		$this->assertSame(Announce::TYPE, $notification->getSubType());
+		$this->assertSame($this->alice->getId(), $notification->getTo());
+		$this->assertSame(self::POST, $notification->getObjectId());
+		$this->assertSame(self::POST . '/notification+boost', $notification->getId());
+		$this->assertSame(['bob@remote.example'], $notification->getDetails('accounts'));
+		$this->assertTrue($notification->isLocal());
+	}
+
+	public function testFurtherBoostsJoinTheExistingNotification(): void {
+		$existing = $this->boostNotification('carol@other.example');
+		$this->storedStreamsByType([SocialAppNotification::TYPE => $existing]);
+		$this->noStoredAction();
+		$this->streamRequest->method('getStreamById')->willReturn($this->post());
+
+		$this->notificationInterface->expects($this->never())->method('save');
+		$this->notificationInterface->expects($this->once())->method('update')->with($this->identicalTo($existing));
+
+		$this->handler->processIncomingRequest($this->incomingAnnounce());
+
+		$this->assertSame(['carol@other.example', 'bob@remote.example'], $existing->getDetails('accounts'));
+	}
+
+	public function testBoostOfARemotePostDoesNotNotifyAnyone(): void {
+		$this->storedStreamsByType([]);
+		$this->noStoredAction();
+		$this->streamRequest->method('getStreamById')->willReturn($this->post(false));
+
+		$this->streamRequest->expects($this->once())->method('updateDetails');
+		$this->notificationInterface->expects($this->never())->method('save');
+		$this->notificationInterface->expects($this->never())->method('update');
+
+		$this->handler->processIncomingRequest($this->incomingAnnounce());
+	}
+
+	public function testBoostAlreadyCountedIsNotCountedTwice(): void {
+		$this->storedStreamsByType([]);
+		$announce = $this->incomingAnnounce();
+		$this->actionsRequest->method('getActionFromItem')->willReturn($announce);
+		$this->streamRequest->method('getStreamById')->willReturn($this->post());
+
+		$this->actionsRequest->expects($this->never())->method('save');
+		$this->streamRequest->expects($this->once())->method('updateDetails');
+
+		$this->handler->processIncomingRequest($announce);
+	}
+
+	public function testBoostNotSignedByTheBoostersServerIsRefused(): void {
+		$this->streamRequest->expects($this->never())->method('save');
+		$this->actionsRequest->expects($this->never())->method('save');
+
+		$this->expectException(InvalidOriginException::class);
+
+		$this->handler->processIncomingRequest($this->incomingAnnounce(self::POST, 'evil.example'));
+	}
+
+	public function testUndoDropsTheAnnounceWhenTheLastBoosterLeaves(): void {
+		$announce = $this->incomingAnnounce();
+		$undo = $this->incoming(Undo::TYPE, self::REMOTE_URL . '/undo/1', $this->bob->getId(), $announce);
+		$known = $this->knownAnnounce($this->bob->getFollowers());
+		$notification = $this->boostNotification('bob@remote.example');
+		$this->storedStreamsByType([Announce::TYPE => $known, SocialAppNotification::TYPE => $notification]);
+		$this->actionsRequest->method('getActionFromItem')->willReturn($announce);
+		$this->streamRequest->method('getStreamById')->willReturn($this->post());
+
+		$this->streamRequest->expects($this->once())->method('deleteById')->with($known->getId(), Announce::TYPE);
+		$this->streamRequest->expects($this->never())->method('update');
+		$this->actionsRequest->expects($this->once())->method('delete')->with($this->identicalTo($announce));
+		$this->streamRequest->expects($this->once())->method('updateDetails');
+		$this->notificationInterface->expects($this->once())->method('delete')->with($this->identicalTo($notification));
+
+		$this->handler->activity($undo, $announce);
+	}
+
+	public function testUndoKeepsTheAnnounceWhileOtherBoostersRemain(): void {
+		$announce = $this->incomingAnnounce();
+		$undo = $this->incoming(Undo::TYPE, self::REMOTE_URL . '/undo/1', $this->bob->getId(), $announce);
+		$known = $this->knownAnnounce($this->bob->getFollowers(), $this->carol->getFollowers());
+		$notification = $this->boostNotification('bob@remote.example', 'carol@other.example');
+		$this->storedStreamsByType([Announce::TYPE => $known, SocialAppNotification::TYPE => $notification]);
+		$this->noStoredAction();
+		$this->streamRequest->method('getStreamById')->willReturn($this->post());
+
+		$this->streamRequest->expects($this->never())->method('deleteById');
+		$this->streamRequest->expects($this->once())->method('update')->with($this->identicalTo($known), true);
+		$this->notificationInterface->expects($this->never())->method('delete');
+		$this->notificationInterface->expects($this->once())->method('update')->with($this->identicalTo($notification));
+
+		$this->handler->activity($undo, $announce);
+
+		$this->assertSame([$this->carol->getFollowers()], array_values($known->getCcArray()));
+		$this->assertSame(['carol@other.example'], array_values($notification->getDetails('accounts')));
+	}
+
+	public function testUndoOfAnUnknownBoostIsHarmless(): void {
+		$announce = $this->incomingAnnounce();
+		$undo = $this->incoming(Undo::TYPE, self::REMOTE_URL . '/undo/1', $this->bob->getId(), $announce);
+		$this->storedStreamsByType([]);
+		$this->noStoredAction();
+		$this->streamRequest->method('getStreamById')->willThrowException(new StreamNotFoundException());
+
+		$this->streamRequest->expects($this->never())->method('deleteById');
+		$this->actionsRequest->expects($this->never())->method('delete');
+		$this->notificationInterface->expects($this->never())->method('delete');
+
+		$this->handler->activity($undo, $announce);
+	}
+
+	public function testUndoNotComingFromTheBoostersServerIsRefused(): void {
+		$announce = $this->incomingAnnounce();
+		$undo = $this->incoming(Undo::TYPE, self::REMOTE_URL . '/undo/1', $this->bob->getId(), $announce, 'evil.example');
+
+		$this->streamRequest->expects($this->never())->method('deleteById');
+		$this->actionsRequest->expects($this->never())->method('delete');
+
+		$this->expectException(InvalidOriginException::class);
+
+		$this->handler->activity($undo, $announce);
+	}
+
+	public function testAnnouncesCannotBeLookedUpByItem(): void {
+		$this->expectException(ItemNotFoundException::class);
+
+		$this->handler->getItem($this->incomingAnnounce());
+	}
+
+	public function testAnnouncesCannotBeLookedUpById(): void {
+		$this->expectException(ItemNotFoundException::class);
+
+		$this->handler->getItemById(self::REMOTE_URL . '/announces/1');
+	}
+}

--- a/tests/Interfaces/Object/DocumentInterfaceTest.php
+++ b/tests/Interfaces/Object/DocumentInterfaceTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Interfaces\Object;
+
+use OCA\Social\Db\CacheDocumentsRequest;
+use OCA\Social\Exceptions\CacheDocumentDoesNotExistException;
+use OCA\Social\Exceptions\InvalidOriginException;
+use OCA\Social\Interfaces\Object\DocumentInterface;
+use OCA\Social\Model\ActivityPub\Activity\Create;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Document;
+use OCA\Social\Model\ActivityPub\Object\Image;
+use OCA\Social\Service\CacheDocumentService;
+use OCA\Social\Tests\Interfaces\ActivityPubTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+require_once __DIR__ . '/../ActivityPubTestCase.php';
+
+class DocumentInterfaceTest extends ActivityPubTestCase {
+	private const DOCUMENT = self::REMOTE_URL . '/media/1';
+
+	/** @var CacheDocumentService&MockObject */
+	private $cacheDocumentService;
+	/** @var CacheDocumentsRequest&MockObject */
+	private $cacheDocumentsRequest;
+	private DocumentInterface $handler;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->cacheDocumentService = $this->createMock(CacheDocumentService::class);
+		$this->cacheDocumentsRequest = $this->createMock(CacheDocumentsRequest::class);
+
+		$this->handler = new DocumentInterface($this->cacheDocumentService, $this->cacheDocumentsRequest);
+	}
+
+	private function document(string $url = self::REMOTE_URL . '/media/1.png'): Document {
+		$document = new Document();
+		$document->setId(self::DOCUMENT);
+		$document->setUrl($url);
+
+		return $document;
+	}
+
+	private function nothingCached(): void {
+		$this->cacheDocumentsRequest->method('getById')->willThrowException(new CacheDocumentDoesNotExistException());
+	}
+
+	public function testKnownDocumentIsUpdatedInPlace(): void {
+		$document = $this->document();
+		$this->cacheDocumentsRequest->method('getById')->with(self::DOCUMENT)->willReturn($document);
+
+		$this->cacheDocumentsRequest->expects($this->once())->method('update')->with($this->identicalTo($document));
+		$this->cacheDocumentsRequest->expects($this->never())->method('save');
+		$this->cacheDocumentService->expects($this->never())->method('saveRemoteFileToCache');
+
+		$this->handler->save($document);
+	}
+
+	public function testNewRemoteDocumentIsFetchedIntoTheCacheAndStored(): void {
+		$this->nothingCached();
+		$this->cacheDocumentsRequest->method('isDuplicate')->willReturn(false);
+		$document = $this->document();
+
+		$this->cacheDocumentService->expects($this->once())
+			->method('saveRemoteFileToCache')->with($this->identicalTo($document));
+		$this->cacheDocumentsRequest->expects($this->once())->method('save')->with($this->identicalTo($document));
+		$this->cacheDocumentsRequest->expects($this->never())->method('update');
+
+		$this->handler->save($document);
+	}
+
+	public function testNewLocalDocumentIsNotFetchedFromAnywhere(): void {
+		$this->nothingCached();
+		$this->cacheDocumentsRequest->method('isDuplicate')->willReturn(false);
+		$document = $this->document();
+		$document->setLocal(true);
+
+		$this->cacheDocumentService->expects($this->never())->method('saveRemoteFileToCache');
+		$this->cacheDocumentsRequest->expects($this->once())->method('save')->with($this->identicalTo($document));
+
+		$this->handler->save($document);
+	}
+
+	public function testDocumentAlreadyCachedUnderItsUrlIsNotStoredAgain(): void {
+		$this->nothingCached();
+		$document = $this->document();
+		$this->cacheDocumentsRequest->method('isDuplicate')->with($this->identicalTo($document))->willReturn(true);
+
+		$this->cacheDocumentsRequest->expects($this->never())->method('save');
+
+		$this->handler->save($document);
+	}
+
+	public function testFreshUploadWithoutUrlIsStoredForItsOwnerWithoutDuplicateCheck(): void {
+		$this->nothingCached();
+		$upload = new Document();
+		$upload->setId(self::LOCAL_URL . '/documents/g/1');
+		$upload->setAccount('alice');
+		$upload->setLocal(true);
+
+		$this->cacheDocumentsRequest->expects($this->never())->method('isDuplicate');
+		$this->cacheDocumentsRequest->expects($this->once())->method('save')->with($this->identicalTo($upload));
+
+		$this->handler->save($upload);
+	}
+
+	public function testDocumentAttachedToAStreamRecordsItsParent(): void {
+		$this->nothingCached();
+		$this->cacheDocumentsRequest->method('isDuplicate')->willReturn(false);
+		$note = $this->note(self::REMOTE_URL . '/notes/1', self::REMOTE_URL . '/users/bob');
+		$attachment = new Document($note);
+		$attachment->setId(self::DOCUMENT);
+		$attachment->setUrl(self::REMOTE_URL . '/media/1.png');
+
+		$this->cacheDocumentsRequest->expects($this->once())->method('save')->with($this->identicalTo($attachment));
+
+		$this->handler->save($attachment);
+
+		$this->assertSame($note->getId(), $attachment->getParentId());
+	}
+
+	public function testIconOfAnActorMustBeHostedByTheActorsServer(): void {
+		$bob = $this->incoming(Person::TYPE, self::REMOTE_URL . '/users/bob', self::REMOTE_URL . '/users/bob');
+		$icon = new Image($bob);
+		$icon->setId('https://cdn.example/avatars/bob.png');
+
+		$this->expectException(InvalidOriginException::class);
+
+		$this->handler->activity($bob, $icon);
+	}
+
+	public function testIconHostedByTheActorsServerIsAccepted(): void {
+		$this->expectNotToPerformAssertions();
+
+		$bob = $this->incoming(Person::TYPE, self::REMOTE_URL . '/users/bob', self::REMOTE_URL . '/users/bob');
+		$icon = new Image($bob);
+		$icon->setId(self::REMOTE_URL . '/avatars/bob.png');
+
+		$this->handler->activity($bob, $icon);
+	}
+
+	public function testAttachmentsOfOtherActivitiesAreNotOriginChecked(): void {
+		$this->expectNotToPerformAssertions();
+
+		$create = $this->incoming(Create::TYPE, self::REMOTE_URL . '/notes/1/activity', self::REMOTE_URL . '/users/bob');
+		$attachment = new Document($create);
+		$attachment->setId('https://cdn.example/media/1.png');
+
+		$this->handler->activity($create, $attachment);
+	}
+}

--- a/tests/Interfaces/Object/FollowInterfaceTest.php
+++ b/tests/Interfaces/Object/FollowInterfaceTest.php
@@ -1,0 +1,301 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Interfaces\Object;
+
+use OCA\Social\Db\FollowsRequest;
+use OCA\Social\Exceptions\CacheActorDoesNotExistException;
+use OCA\Social\Exceptions\FollowNotFoundException;
+use OCA\Social\Exceptions\InvalidOriginException;
+use OCA\Social\Interfaces\Object\FollowInterface;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Activity\Accept;
+use OCA\Social\Model\ActivityPub\Activity\Create;
+use OCA\Social\Model\ActivityPub\Activity\Reject;
+use OCA\Social\Model\ActivityPub\Activity\Undo;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Internal\SocialAppNotification;
+use OCA\Social\Model\ActivityPub\Object\Follow;
+use OCA\Social\Model\InstancePath;
+use OCA\Social\Service\AccountService;
+use OCA\Social\Service\ActivityService;
+use OCA\Social\Service\CacheActorService;
+use OCA\Social\Service\MiscService;
+use OCA\Social\Service\SignatureService;
+use OCA\Social\Tests\Interfaces\ActivityPubTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+require_once __DIR__ . '/../ActivityPubTestCase.php';
+
+class FollowInterfaceTest extends ActivityPubTestCase {
+	/** @var FollowsRequest&MockObject */
+	private $followsRequest;
+	/** @var CacheActorService&MockObject */
+	private $cacheActorService;
+	/** @var AccountService&MockObject */
+	private $accountService;
+	/** @var ActivityService&MockObject */
+	private $activityService;
+	/** @var MiscService&MockObject */
+	private $miscService;
+	private FollowInterface $handler;
+
+	private Person $alice;
+	private Person $bob;
+	private Person $carol;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->followsRequest = $this->createMock(FollowsRequest::class);
+		$this->cacheActorService = $this->createMock(CacheActorService::class);
+		$this->accountService = $this->createMock(AccountService::class);
+		$this->activityService = $this->createMock(ActivityService::class);
+		$this->miscService = $this->createMock(MiscService::class);
+
+		$this->handler = new FollowInterface(
+			$this->followsRequest,
+			$this->cacheActorService,
+			$this->accountService,
+			$this->activityService,
+			$this->miscService,
+		);
+
+		$this->alice = $this->person(self::LOCAL_URL . '/users/alice', true);
+		$this->bob = $this->person(self::REMOTE_URL . '/users/bob');
+		$this->carol = $this->person('https://other.example/users/carol');
+
+		$known = [$this->alice, $this->bob, $this->carol];
+		$this->cacheActorService->method('getFromId')->willReturnCallback(function (string $id) use ($known): Person {
+			foreach ($known as $actor) {
+				if ($actor->getId() === $id) {
+					return $actor;
+				}
+			}
+
+			throw new CacheActorDoesNotExistException();
+		});
+	}
+
+	/** bob (remote) asks to follow a target, alice (local) unless told otherwise. */
+	private function incomingFollow(?string $target = null, string $origin = self::REMOTE_HOST): Follow {
+		$follow = new Follow();
+		$follow->setId(self::REMOTE_URL . '/follows/1');
+		$follow->setActorId($this->bob->getId());
+		$follow->setObjectId($target ?? $this->alice->getId());
+		$follow->setOrigin($origin, SignatureService::ORIGIN_HEADER, time());
+
+		return $follow;
+	}
+
+	/** alice's own follow request towards bob, as stored on our side. */
+	private function ourFollowOfBob(): Follow {
+		$follow = new Follow();
+		$follow->setId(self::LOCAL_URL . '/follows/7');
+		$follow->setActorId($this->alice->getId());
+		$follow->setObjectId($this->bob->getId());
+
+		return $follow;
+	}
+
+	private function noKnownFollow(): void {
+		$this->followsRequest->method('getByPersons')->willThrowException(new FollowNotFoundException());
+	}
+
+	public function testNewFollowOfALocalActorIsStoredAgainstTheirFollowersCollection(): void {
+		$this->noKnownFollow();
+		$follow = $this->incomingFollow();
+
+		$this->followsRequest->expects($this->once())->method('save')->with($this->identicalTo($follow));
+
+		$this->handler->processIncomingRequest($follow);
+
+		$this->assertSame($this->alice->getFollowers(), $follow->getFollowId());
+	}
+
+	public function testNewFollowIsAnsweredWithAnAcceptDeliveredToTheFollowersInbox(): void {
+		$this->noKnownFollow();
+		$follow = $this->incomingFollow();
+
+		$sent = null;
+		$this->capture($this->activityService, 'request', $sent, '');
+
+		$this->handler->processIncomingRequest($follow);
+
+		$this->assertInstanceOf(Accept::class, $sent);
+		$this->assertSame($this->alice->getId(), $sent->getActorId());
+		$this->assertSame($follow, $sent->getObject());
+		$this->assertStringStartsWith(self::LOCAL_URL . '/', $sent->getId());
+
+		$paths = $sent->getInstancePaths();
+		$this->assertCount(1, $paths);
+		$this->assertSame($this->bob->getInbox(), $paths[0]->getUri());
+		$this->assertSame(InstancePath::TYPE_INBOX, $paths[0]->getType());
+	}
+
+	public function testNewFollowIsMarkedAcceptedAndRefreshesTheLocalCounters(): void {
+		$this->noKnownFollow();
+		$follow = $this->incomingFollow();
+
+		$this->followsRequest->expects($this->once())->method('accepted')->with($this->identicalTo($follow));
+		$this->accountService->expects($this->once())
+			->method('cacheLocalActorDetailCount')->with($this->identicalTo($this->alice));
+
+		$this->handler->processIncomingRequest($follow);
+	}
+
+	public function testNewFollowNotifiesTheFollowedLocalActor(): void {
+		$this->noKnownFollow();
+		$follow = $this->incomingFollow();
+
+		$notification = null;
+		$this->capture($this->notificationInterface, 'save', $notification);
+
+		$this->handler->processIncomingRequest($follow);
+
+		$this->assertInstanceOf(SocialAppNotification::class, $notification);
+		$this->assertSame(Follow::TYPE, $notification->getSubType());
+		$this->assertSame($this->alice->getId(), $notification->getTo());
+		$this->assertSame($this->bob->getId(), $notification->getActorId());
+		$this->assertSame($follow->getId() . '/notification', $notification->getId());
+		$this->assertSame('bob@remote.example', $notification->getDetailsAll()['account']);
+		$this->assertTrue($notification->isLocal());
+	}
+
+	public function testFollowOfARemoteActorIsRefused(): void {
+		$this->noKnownFollow();
+
+		$this->followsRequest->expects($this->never())->method('save');
+		$this->followsRequest->expects($this->never())->method('accepted');
+		$this->activityService->expects($this->never())->method('request');
+
+		$this->handler->processIncomingRequest($this->incomingFollow($this->carol->getId()));
+	}
+
+	public function testFollowOfAnUnknownActorIsRefused(): void {
+		$this->noKnownFollow();
+
+		$this->followsRequest->expects($this->never())->method('save');
+		$this->activityService->expects($this->never())->method('request');
+
+		$this->expectException(CacheActorDoesNotExistException::class);
+
+		$this->handler->processIncomingRequest($this->incomingFollow(self::LOCAL_URL . '/users/nobody'));
+	}
+
+	public function testFollowNotSignedByTheFollowersServerIsRefused(): void {
+		$this->followsRequest->expects($this->never())->method('getByPersons');
+		$this->followsRequest->expects($this->never())->method('save');
+
+		$this->expectException(InvalidOriginException::class);
+
+		$this->handler->processIncomingRequest($this->incomingFollow(null, 'evil.example'));
+	}
+
+	public function testFollowAlreadyAcceptedIsIgnored(): void {
+		$known = new Follow();
+		$known->setAccepted(true);
+		$this->followsRequest->method('getByPersons')
+			->with($this->bob->getId(), $this->alice->getId())
+			->willReturn($known);
+
+		$this->followsRequest->expects($this->never())->method('save');
+		$this->followsRequest->expects($this->never())->method('accepted');
+		$this->activityService->expects($this->never())->method('request');
+
+		$this->handler->processIncomingRequest($this->incomingFollow());
+	}
+
+	public function testFollowStillPendingGetsTheAcceptAgainWithoutBeingStoredTwice(): void {
+		$this->followsRequest->method('getByPersons')->willReturn(new Follow());
+		$follow = $this->incomingFollow();
+
+		$this->followsRequest->expects($this->never())->method('save');
+		$this->activityService->expects($this->once())->method('request')->with($this->isInstanceOf(Accept::class));
+		$this->followsRequest->expects($this->once())->method('accepted')->with($this->identicalTo($follow));
+
+		$this->handler->processIncomingRequest($follow);
+	}
+
+	public function testFailedAcceptDeliveryIsLoggedAndLeavesTheFollowPending(): void {
+		$this->noKnownFollow();
+		$this->activityService->method('request')->willThrowException(new \RuntimeException('inbox unreachable'));
+
+		$this->followsRequest->expects($this->once())->method('save');
+		$this->followsRequest->expects($this->never())->method('accepted');
+		$this->notificationInterface->expects($this->never())->method('save');
+		$this->miscService->expects($this->once())
+			->method('log')->with($this->stringContains('confirmFollowRequest'));
+
+		$this->handler->processIncomingRequest($this->incomingFollow());
+	}
+
+	public function testUndoRemovesTheFollow(): void {
+		$follow = $this->incomingFollow();
+		$undo = $this->incoming(Undo::TYPE, self::REMOTE_URL . '/undo/1', $this->bob->getId(), $follow);
+
+		$this->followsRequest->expects($this->once())->method('delete')->with($this->identicalTo($follow));
+		$this->followsRequest->expects($this->never())->method('accepted');
+
+		$this->handler->activity($undo, $follow);
+	}
+
+	public function testUndoNotComingFromTheFollowersServerIsRefused(): void {
+		$follow = $this->incomingFollow();
+		$undo = $this->incoming(Undo::TYPE, self::REMOTE_URL . '/undo/1', $this->bob->getId(), $follow, 'evil.example');
+
+		$this->followsRequest->expects($this->never())->method('delete');
+
+		$this->expectException(InvalidOriginException::class);
+
+		$this->handler->activity($undo, $follow);
+	}
+
+	public function testAcceptMarksOurFollowRequestAccepted(): void {
+		$follow = $this->ourFollowOfBob();
+		$accept = $this->incoming(Accept::TYPE, self::REMOTE_URL . '/accepts/1', $this->bob->getId(), $follow);
+
+		$this->followsRequest->expects($this->once())->method('accepted')->with($this->identicalTo($follow));
+		$this->followsRequest->expects($this->never())->method('delete');
+
+		$this->handler->activity($accept, $follow);
+	}
+
+	public function testAcceptNotComingFromTheFollowedActorsServerIsRefused(): void {
+		$follow = $this->ourFollowOfBob();
+		$accept = $this->incoming(Accept::TYPE, 'https://evil.example/accepts/1', $this->bob->getId(), $follow);
+
+		$this->followsRequest->expects($this->never())->method('accepted');
+
+		$this->expectException(InvalidOriginException::class);
+
+		$this->handler->activity($accept, $follow);
+	}
+
+	public function testRejectRemovesOurPendingFollowRequest(): void {
+		$follow = $this->ourFollowOfBob();
+		$reject = $this->incoming(Reject::TYPE, self::REMOTE_URL . '/rejects/1', $this->bob->getId(), $follow);
+
+		$this->followsRequest->expects($this->once())->method('delete')->with($this->identicalTo($follow));
+		$this->followsRequest->expects($this->never())->method('accepted');
+
+		$this->handler->activity($reject, $follow);
+	}
+
+	public function testOtherActivitiesLeaveTheFollowUntouched(): void {
+		$follow = $this->ourFollowOfBob();
+		/** @var ACore $create */
+		$create = $this->incoming(Create::TYPE, self::REMOTE_URL . '/creates/1', $this->bob->getId(), $follow);
+
+		$this->followsRequest->expects($this->never())->method('delete');
+		$this->followsRequest->expects($this->never())->method('accepted');
+
+		$this->handler->activity($create, $follow);
+	}
+}

--- a/tests/Interfaces/Object/ImageInterfaceTest.php
+++ b/tests/Interfaces/Object/ImageInterfaceTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Interfaces\Object;
+
+use OCA\Social\Db\CacheDocumentsRequest;
+use OCA\Social\Exceptions\CacheDocumentDoesNotExistException;
+use OCA\Social\Interfaces\Object\DocumentInterface;
+use OCA\Social\Interfaces\Object\ImageInterface;
+use OCA\Social\Model\ActivityPub\Object\Image;
+use OCA\Social\Service\CacheDocumentService;
+use OCA\Social\Tests\Interfaces\ActivityPubTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+require_once __DIR__ . '/../ActivityPubTestCase.php';
+
+class ImageInterfaceTest extends ActivityPubTestCase {
+	/** @var CacheDocumentService&MockObject */
+	private $cacheDocumentService;
+	/** @var CacheDocumentsRequest&MockObject */
+	private $cacheDocumentsRequest;
+	private ImageInterface $handler;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->cacheDocumentService = $this->createMock(CacheDocumentService::class);
+		$this->cacheDocumentsRequest = $this->createMock(CacheDocumentsRequest::class);
+
+		// note the constructor takes its collaborators the other way round than DocumentInterface
+		$this->handler = new ImageInterface($this->cacheDocumentsRequest, $this->cacheDocumentService);
+	}
+
+	private function image(): Image {
+		$image = new Image();
+		$image->setId(self::REMOTE_URL . '/media/1');
+		$image->setUrl(self::REMOTE_URL . '/media/1.png');
+
+		return $image;
+	}
+
+	public function testImagesAreDocuments(): void {
+		$this->assertInstanceOf(DocumentInterface::class, $this->handler);
+	}
+
+	public function testNewRemoteImageIsFetchedIntoTheCacheAndStored(): void {
+		$this->cacheDocumentsRequest->method('getById')->willThrowException(new CacheDocumentDoesNotExistException());
+		$this->cacheDocumentsRequest->method('isDuplicate')->willReturn(false);
+		$image = $this->image();
+
+		$this->cacheDocumentService->expects($this->once())
+			->method('saveRemoteFileToCache')->with($this->identicalTo($image));
+		$this->cacheDocumentsRequest->expects($this->once())->method('save')->with($this->identicalTo($image));
+
+		$this->handler->save($image);
+	}
+
+	public function testKnownImageIsUpdatedInPlace(): void {
+		$image = $this->image();
+		$this->cacheDocumentsRequest->method('getById')->willReturn($image);
+
+		$this->cacheDocumentsRequest->expects($this->once())->method('update')->with($this->identicalTo($image));
+		$this->cacheDocumentsRequest->expects($this->never())->method('save');
+		$this->cacheDocumentService->expects($this->never())->method('saveRemoteFileToCache');
+
+		$this->handler->save($image);
+	}
+}

--- a/tests/Interfaces/Object/LikeInterfaceTest.php
+++ b/tests/Interfaces/Object/LikeInterfaceTest.php
@@ -1,0 +1,297 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Interfaces\Object;
+
+use OCA\Social\Db\ActionsRequest;
+use OCA\Social\Db\StreamRequest;
+use OCA\Social\Exceptions\ActionDoesNotExistException;
+use OCA\Social\Exceptions\CacheActorDoesNotExistException;
+use OCA\Social\Exceptions\InvalidOriginException;
+use OCA\Social\Exceptions\ItemAlreadyExistsException;
+use OCA\Social\Exceptions\ItemNotFoundException;
+use OCA\Social\Exceptions\StreamNotFoundException;
+use OCA\Social\Interfaces\Object\LikeInterface;
+use OCA\Social\Model\ActivityPub\Activity\Create;
+use OCA\Social\Model\ActivityPub\Activity\Undo;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Internal\SocialAppNotification;
+use OCA\Social\Model\ActivityPub\Object\Like;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Service\CacheActorService;
+use OCA\Social\Service\SignatureService;
+use OCA\Social\Tests\Interfaces\ActivityPubTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+require_once __DIR__ . '/../ActivityPubTestCase.php';
+
+class LikeInterfaceTest extends ActivityPubTestCase {
+	private const POST = self::LOCAL_URL . '/notes/1';
+
+	/** @var ActionsRequest&MockObject */
+	private $actionsRequest;
+	/** @var StreamRequest&MockObject */
+	private $streamRequest;
+	/** @var CacheActorService&MockObject */
+	private $cacheActorService;
+	private LikeInterface $handler;
+
+	private Person $alice;
+	private Person $bob;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->actionsRequest = $this->createMock(ActionsRequest::class);
+		$this->streamRequest = $this->createMock(StreamRequest::class);
+		$this->cacheActorService = $this->createMock(CacheActorService::class);
+
+		$this->handler = new LikeInterface($this->actionsRequest, $this->streamRequest, $this->cacheActorService);
+
+		$this->alice = $this->person(self::LOCAL_URL . '/users/alice', true);
+		$this->bob = $this->person(self::REMOTE_URL . '/users/bob');
+		$this->cacheActorService->method('getFromId')->willReturnCallback(function (string $id): Person {
+			if ($id === $this->bob->getId()) {
+				return $this->bob;
+			}
+
+			throw new CacheActorDoesNotExistException();
+		});
+	}
+
+	/** bob (remote) likes alice's post. */
+	private function incomingLike(string $origin = self::REMOTE_HOST): Like {
+		$like = new Like();
+		$like->setId(self::REMOTE_URL . '/likes/1');
+		$like->setActorId($this->bob->getId());
+		$like->setObjectId(self::POST);
+		$like->setOrigin($origin, SignatureService::ORIGIN_HEADER, time());
+
+		return $like;
+	}
+
+	private function post(bool $local = true, int $remoteLikes = 0): Note {
+		$post = $this->note(self::POST, $this->alice->getId(), $local);
+		$post->setDetailInt('remote_likes', $remoteLikes);
+
+		return $post;
+	}
+
+	private function likeNotification(string ...$accounts): SocialAppNotification {
+		$notification = new SocialAppNotification();
+		$notification->setId(self::POST . '/notification+like');
+		foreach ($accounts as $account) {
+			$notification->addDetail('accounts', $account);
+		}
+
+		return $notification;
+	}
+
+	private function noStoredLike(): void {
+		$this->actionsRequest->method('getActionFromItem')->willThrowException(new ActionDoesNotExistException());
+	}
+
+	private function noNotificationYet(): void {
+		$this->streamRequest->method('getStreamByObjectId')->willThrowException(new StreamNotFoundException());
+	}
+
+	public function testNewLikeIsStored(): void {
+		$this->noStoredLike();
+		$this->noNotificationYet();
+		$this->streamRequest->method('getStreamById')->willReturn($this->post());
+		$like = $this->incomingLike();
+
+		$this->actionsRequest->expects($this->once())->method('save')->with($this->identicalTo($like));
+
+		$this->handler->processIncomingRequest($like);
+	}
+
+	public function testLikeAddsToTheLikeCounterOfThePost(): void {
+		$this->noStoredLike();
+		$this->noNotificationYet();
+		$post = $this->post(true, 2);
+		$this->streamRequest->method('getStreamById')->willReturn($post);
+		$this->actionsRequest->method('countActions')->with(self::POST, Like::TYPE)->willReturn(3);
+
+		$updated = null;
+		$this->capture($this->streamRequest, 'updateDetails', $updated);
+
+		$this->handler->processIncomingRequest($this->incomingLike());
+
+		$this->assertSame($post, $updated);
+		$this->assertSame(5, $post->getDetailInt('likes'));
+	}
+
+	public function testLikeOnALocalPostNotifiesItsAuthor(): void {
+		$this->noStoredLike();
+		$this->noNotificationYet();
+		$this->streamRequest->method('getStreamById')->willReturn($this->post());
+
+		$notification = null;
+		$this->capture($this->notificationInterface, 'save', $notification);
+		$this->notificationInterface->expects($this->never())->method('update');
+
+		$this->handler->processIncomingRequest($this->incomingLike());
+
+		$this->assertInstanceOf(SocialAppNotification::class, $notification);
+		$this->assertSame(Like::TYPE, $notification->getSubType());
+		$this->assertSame($this->alice->getId(), $notification->getTo());
+		$this->assertSame(self::POST, $notification->getObjectId());
+		$this->assertSame(self::POST . '/notification+like', $notification->getId());
+		$this->assertSame(['bob@remote.example'], $notification->getDetails('accounts'));
+		$this->assertTrue($notification->isLocal());
+	}
+
+	public function testFurtherLikesJoinTheExistingNotification(): void {
+		$this->noStoredLike();
+		$this->streamRequest->method('getStreamById')->willReturn($this->post());
+		$existing = $this->likeNotification('carol@other.example');
+		$this->streamRequest->method('getStreamByObjectId')
+			->with(self::POST, SocialAppNotification::TYPE, Like::TYPE)
+			->willReturn($existing);
+
+		$this->notificationInterface->expects($this->never())->method('save');
+		$this->notificationInterface->expects($this->once())->method('update')->with($this->identicalTo($existing));
+
+		$this->handler->processIncomingRequest($this->incomingLike());
+
+		$this->assertSame(['carol@other.example', 'bob@remote.example'], $existing->getDetails('accounts'));
+	}
+
+	public function testLikeOnARemotePostDoesNotNotifyAnyone(): void {
+		$this->noStoredLike();
+		$this->streamRequest->method('getStreamById')->willReturn($this->post(false));
+
+		$this->streamRequest->expects($this->once())->method('updateDetails');
+		$this->notificationInterface->expects($this->never())->method('save');
+		$this->notificationInterface->expects($this->never())->method('update');
+
+		$this->handler->processIncomingRequest($this->incomingLike());
+	}
+
+	public function testLikeAlreadyKnownIsNotStoredTwice(): void {
+		$like = $this->incomingLike();
+		$this->actionsRequest->method('getActionFromItem')->willReturn($like);
+
+		$this->actionsRequest->expects($this->never())->method('save');
+		$this->streamRequest->expects($this->never())->method('updateDetails');
+
+		$this->handler->processIncomingRequest($like);
+	}
+
+	public function testSavingAKnownLikeIsReportedToTheCaller(): void {
+		$like = $this->incomingLike();
+		$this->actionsRequest->method('getActionFromItem')->willReturn($like);
+
+		$this->expectException(ItemAlreadyExistsException::class);
+
+		$this->handler->save($like);
+	}
+
+	public function testLikeOfAnUnknownPostIsStoredWithoutCounterOrNotification(): void {
+		$this->noStoredLike();
+		$this->streamRequest->method('getStreamById')->willThrowException(new StreamNotFoundException());
+
+		$this->actionsRequest->expects($this->once())->method('save');
+		$this->streamRequest->expects($this->never())->method('updateDetails');
+		$this->notificationInterface->expects($this->never())->method('save');
+
+		$this->handler->processIncomingRequest($this->incomingLike());
+	}
+
+	public function testLikeNotSignedByTheLikersServerIsRefused(): void {
+		$this->actionsRequest->expects($this->never())->method('save');
+
+		$this->expectException(InvalidOriginException::class);
+
+		$this->handler->processIncomingRequest($this->incomingLike('evil.example'));
+	}
+
+	public function testUndoDeletesTheLikeAndRecomputesTheCounter(): void {
+		$like = $this->incomingLike();
+		$undo = $this->incoming(Undo::TYPE, self::REMOTE_URL . '/undo/1', $this->bob->getId(), $like);
+		$post = $this->post(true, 1);
+		$this->streamRequest->method('getStreamById')->willReturn($post);
+		$this->actionsRequest->method('countActions')->willReturn(0);
+		$this->noNotificationYet();
+
+		$this->actionsRequest->expects($this->once())->method('delete')->with($this->identicalTo($like));
+		$this->streamRequest->expects($this->once())->method('updateDetails')->with($this->identicalTo($post));
+
+		$this->handler->activity($undo, $like);
+
+		$this->assertSame(1, $post->getDetailInt('likes'));
+	}
+
+	public function testUndoRemovesTheLikerFromTheNotificationAndDropsItWhenNobodyIsLeft(): void {
+		$like = $this->incomingLike();
+		$undo = $this->incoming(Undo::TYPE, self::REMOTE_URL . '/undo/1', $this->bob->getId(), $like);
+		$this->streamRequest->method('getStreamById')->willReturn($this->post());
+		$notification = $this->likeNotification('bob@remote.example');
+		$this->streamRequest->method('getStreamByObjectId')->willReturn($notification);
+
+		$this->notificationInterface->expects($this->once())->method('delete')->with($this->identicalTo($notification));
+		$this->notificationInterface->expects($this->never())->method('update');
+
+		$this->handler->activity($undo, $like);
+	}
+
+	public function testUndoKeepsTheNotificationWhileOtherLikersRemain(): void {
+		$like = $this->incomingLike();
+		$undo = $this->incoming(Undo::TYPE, self::REMOTE_URL . '/undo/1', $this->bob->getId(), $like);
+		$this->streamRequest->method('getStreamById')->willReturn($this->post());
+		$notification = $this->likeNotification('bob@remote.example', 'carol@other.example');
+		$this->streamRequest->method('getStreamByObjectId')->willReturn($notification);
+
+		$this->notificationInterface->expects($this->once())->method('update')->with($this->identicalTo($notification));
+		$this->notificationInterface->expects($this->never())->method('delete');
+
+		$this->handler->activity($undo, $like);
+
+		$this->assertSame(['carol@other.example'], array_values($notification->getDetails('accounts')));
+	}
+
+	public function testUndoNotComingFromTheLikersServerIsRefused(): void {
+		$like = $this->incomingLike();
+		$undo = $this->incoming(Undo::TYPE, self::REMOTE_URL . '/undo/1', $this->bob->getId(), $like, 'evil.example');
+
+		$this->actionsRequest->expects($this->never())->method('delete');
+
+		$this->expectException(InvalidOriginException::class);
+
+		$this->handler->activity($undo, $like);
+	}
+
+	public function testOtherActivitiesAreIgnored(): void {
+		$like = $this->incomingLike();
+		$create = $this->incoming(Create::TYPE, self::REMOTE_URL . '/creates/1', $this->bob->getId(), $like);
+
+		$this->actionsRequest->expects($this->never())->method('delete');
+		$this->actionsRequest->expects($this->never())->method('save');
+
+		$this->handler->activity($create, $like);
+	}
+
+	public function testGetItemReturnsTheStoredLike(): void {
+		$stored = new Like();
+		$this->actionsRequest->method('getAction')
+			->with($this->bob->getId(), self::POST, Like::TYPE)
+			->willReturn($stored);
+
+		$this->assertSame($stored, $this->handler->getItem($this->incomingLike()));
+	}
+
+	public function testGetItemThrowsWhenTheLikeIsUnknown(): void {
+		$this->actionsRequest->method('getAction')->willThrowException(new ActionDoesNotExistException());
+
+		$this->expectException(ItemNotFoundException::class);
+
+		$this->handler->getItem($this->incomingLike());
+	}
+}

--- a/tests/Interfaces/Object/NoteInterfaceTest.php
+++ b/tests/Interfaces/Object/NoteInterfaceTest.php
@@ -1,0 +1,340 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Interfaces\Object;
+
+use OCA\Social\Db\CacheActorsRequest;
+use OCA\Social\Db\StreamRequest;
+use OCA\Social\Exceptions\CacheActorDoesNotExistException;
+use OCA\Social\Exceptions\InvalidOriginException;
+use OCA\Social\Exceptions\ItemNotFoundException;
+use OCA\Social\Exceptions\StreamNotFoundException;
+use OCA\Social\Interfaces\Object\NoteInterface;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Activity\Accept;
+use OCA\Social\Model\ActivityPub\Activity\Create;
+use OCA\Social\Model\ActivityPub\Activity\Delete;
+use OCA\Social\Model\ActivityPub\Activity\Update;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Internal\SocialAppNotification;
+use OCA\Social\Model\ActivityPub\Object\Mention;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Model\ActivityPub\Stream;
+use OCA\Social\Service\PushService;
+use OCA\Social\Service\SignatureService;
+use OCA\Social\Tests\Interfaces\ActivityPubTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+require_once __DIR__ . '/../ActivityPubTestCase.php';
+
+class NoteInterfaceTest extends ActivityPubTestCase {
+	private const NOTE = self::REMOTE_URL . '/notes/1';
+	private const PARENT = self::LOCAL_URL . '/notes/parent';
+
+	/** @var StreamRequest&MockObject */
+	private $streamRequest;
+	/** @var CacheActorsRequest&MockObject */
+	private $cacheActorsRequest;
+	/** @var PushService&MockObject */
+	private $pushService;
+	private NoteInterface $handler;
+
+	private Person $alice;
+	private Person $bob;
+	private Person $carol;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->streamRequest = $this->createMock(StreamRequest::class);
+		$this->cacheActorsRequest = $this->createMock(CacheActorsRequest::class);
+		$this->pushService = $this->createMock(PushService::class);
+
+		$this->handler = new NoteInterface($this->streamRequest, $this->cacheActorsRequest, $this->pushService);
+
+		$this->alice = $this->person(self::LOCAL_URL . '/users/alice', true);
+		$this->bob = $this->person(self::REMOTE_URL . '/users/bob');
+		$this->carol = $this->person('https://other.example/users/carol');
+	}
+
+	/** A note written by bob (remote). */
+	private function incomingNote(): Note {
+		return $this->note(self::NOTE, $this->bob->getId());
+	}
+
+	/** The activity from bob's server wrapping the note. */
+	private function wrap(string $type, Note $note, string $origin = self::REMOTE_HOST): ACore {
+		return $this->incoming($type, self::NOTE . '/activity', $this->bob->getId(), $note, $origin);
+	}
+
+	/** The note as it comes back from storage in local format: with its author attached. */
+	private function storedCopy(): Note {
+		$post = $this->note(self::NOTE, $this->bob->getId());
+		$post->setActor($this->bob);
+
+		return $post;
+	}
+
+	private function nothingStored(): void {
+		$this->streamRequest->method('getStreamById')->willThrowException(new StreamNotFoundException());
+	}
+
+	/** Nothing is stored under the note's id yet, but its stored copy is available once saved. */
+	private function storedAfterSave(): void {
+		$this->streamRequest->method('getStreamById')
+			->willReturnCallback(function (string $id, bool $asViewer = false, int $format = ACore::FORMAT_ACTIVITYPUB): Stream {
+				if ($id === self::NOTE && $format === ACore::FORMAT_LOCAL) {
+					return $this->storedCopy();
+				}
+
+				throw new StreamNotFoundException();
+			});
+	}
+
+	private function knownActors(Person ...$actors): void {
+		$this->cacheActorsRequest->method('getFromId')->willReturnCallback(function (string $id) use ($actors): Person {
+			foreach ($actors as $actor) {
+				if ($actor->getId() === $id) {
+					return $actor;
+				}
+			}
+
+			throw new CacheActorDoesNotExistException();
+		});
+	}
+
+	public function testCreateStoresTheNoteTaggedWithItsActivity(): void {
+		$this->nothingStored();
+		$note = $this->incomingNote();
+		$create = $this->wrap(Create::TYPE, $note);
+
+		$this->streamRequest->expects($this->once())->method('save')->with($this->identicalTo($note));
+
+		$this->handler->activity($create, $note);
+
+		$this->assertSame($create->getId(), $note->getActivityId());
+	}
+
+	public function testCreateOfAStoredNoteIsPushedToConnectedClients(): void {
+		$this->nothingStored();
+		$note = $this->incomingNote();
+
+		$this->pushService->expects($this->once())->method('onNewStream')->with(self::NOTE);
+
+		$this->handler->activity($this->wrap(Create::TYPE, $note), $note);
+	}
+
+	public function testCreateOfAnAlreadyKnownNoteIsNotStoredTwice(): void {
+		$note = $this->incomingNote();
+		$this->streamRequest->method('getStreamById')->with(self::NOTE)->willReturn($this->storedCopy());
+
+		$this->streamRequest->expects($this->never())->method('save');
+		$this->pushService->expects($this->never())->method('onNewStream');
+
+		$this->handler->activity($this->wrap(Create::TYPE, $note), $note);
+	}
+
+	public function testCreateOfANoteClaimingAnAuthorFromAnotherServerIsRefused(): void {
+		$note = $this->note(self::NOTE, $this->carol->getId());
+
+		$this->streamRequest->expects($this->never())->method('save');
+
+		$this->expectException(InvalidOriginException::class);
+
+		$this->handler->activity($this->wrap(Create::TYPE, $note), $note);
+	}
+
+	public function testCreateNotComingFromTheNotesServerIsRefused(): void {
+		$note = $this->incomingNote();
+
+		$this->streamRequest->expects($this->never())->method('save');
+
+		$this->expectException(InvalidOriginException::class);
+
+		$this->handler->activity($this->wrap(Create::TYPE, $note, 'evil.example'), $note);
+	}
+
+	public function testCreateKeepsTheHashtagsAndMentionsOfTheNote(): void {
+		// nobody mentioned is known locally, so mentions fall back to the tag data
+		$this->personInterface->method('getItemById')->willThrowException(new ItemNotFoundException());
+		$this->storedAfterSave();
+		$this->knownActors();
+
+		$create = $this->ap->getItemFromData([
+			'type' => 'Create',
+			'id' => self::NOTE . '/activity',
+			'actor' => $this->bob->getId(),
+			'object' => [
+				'type' => 'Note',
+				'id' => self::NOTE,
+				'attributedTo' => $this->bob->getId(),
+				'content' => '<p>Hello #Nextcloud and @alice</p>',
+				'tag' => [
+					['type' => 'Hashtag', 'href' => self::REMOTE_URL . '/tags/nextcloud', 'name' => '#Nextcloud'],
+					['type' => 'Mention', 'href' => $this->alice->getId(), 'name' => '@alice@local.example'],
+				],
+			],
+		]);
+		$create->setOrigin(self::REMOTE_HOST, SignatureService::ORIGIN_HEADER, time());
+		$note = $create->getObject();
+
+		$saved = null;
+		$this->capture($this->streamRequest, 'save', $saved);
+
+		$this->handler->activity($create, $note);
+
+		$this->assertInstanceOf(Note::class, $saved);
+		$this->assertSame(['Nextcloud'], $saved->getHashtags());
+		$mentions = $saved->getDetailsAll()['mentions'];
+		$this->assertCount(1, $mentions);
+		$this->assertSame($this->alice->getId(), $mentions[0]['url']);
+		$this->assertSame('alice@local.example', $mentions[0]['acct']);
+	}
+
+	public function testReplyBumpsTheRepliesCounterOfItsParent(): void {
+		$parent = $this->note(self::PARENT, $this->alice->getId(), true);
+		$parent->setDetailInt('remote_replies', 1);
+		$this->streamRequest->method('getStreamById')->willReturnCallback(function (string $id) use ($parent): Stream {
+			if ($id === self::PARENT) {
+				return $parent;
+			}
+
+			throw new StreamNotFoundException();
+		});
+		$this->streamRequest->method('countRepliesTo')->with(self::PARENT)->willReturn(2);
+		$note = $this->incomingNote();
+		$note->setInReplyTo(self::PARENT);
+
+		$this->streamRequest->expects($this->once())->method('updateDetails')->with($this->identicalTo($parent));
+
+		$this->handler->activity($this->wrap(Create::TYPE, $note), $note);
+
+		$this->assertSame(3, $parent->getDetailInt('replies'));
+	}
+
+	public function testReplyToAnUnknownParentIsStillStored(): void {
+		$this->nothingStored();
+		$note = $this->incomingNote();
+		$note->setInReplyTo(self::PARENT);
+
+		$this->streamRequest->expects($this->once())->method('save')->with($this->identicalTo($note));
+		$this->streamRequest->expects($this->never())->method('updateDetails');
+
+		$this->handler->activity($this->wrap(Create::TYPE, $note), $note);
+	}
+
+	public function testMentioningALocalActorNotifiesThem(): void {
+		$this->storedAfterSave();
+		$this->knownActors($this->alice);
+		$note = $this->incomingNote();
+		$note->addTag(['type' => 'Mention', 'href' => $this->alice->getId(), 'name' => '@alice']);
+
+		$notification = null;
+		$this->capture($this->notificationInterface, 'save', $notification);
+
+		$this->handler->activity($this->wrap(Create::TYPE, $note), $note);
+
+		$this->assertInstanceOf(SocialAppNotification::class, $notification);
+		$this->assertSame(Mention::TYPE, $notification->getSubType());
+		$this->assertSame($this->alice->getId(), $notification->getTo());
+		$this->assertSame(self::NOTE, $notification->getObjectId());
+		$this->assertSame(self::NOTE . '/notification+mention', $notification->getId());
+		$this->assertSame(['bob@remote.example'], $notification->getDetails('account'));
+		$this->assertTrue($notification->isLocal());
+	}
+
+	public function testMentioningARemoteActorDoesNotNotifyAnyone(): void {
+		$this->storedAfterSave();
+		$this->knownActors($this->carol);
+		$note = $this->incomingNote();
+		$note->addTag(['type' => 'Mention', 'href' => $this->carol->getId(), 'name' => '@carol']);
+
+		$this->notificationInterface->expects($this->never())->method('save');
+
+		$this->handler->activity($this->wrap(Create::TYPE, $note), $note);
+	}
+
+	public function testMentioningAnUnknownActorDoesNotNotifyAnyone(): void {
+		$this->storedAfterSave();
+		$this->knownActors();
+		$note = $this->incomingNote();
+		$note->addTag(['type' => 'Mention', 'href' => self::LOCAL_URL . '/users/nobody', 'name' => '@nobody']);
+
+		$this->notificationInterface->expects($this->never())->method('save');
+		$this->streamRequest->expects($this->once())->method('save');
+
+		$this->handler->activity($this->wrap(Create::TYPE, $note), $note);
+	}
+
+	public function testDeleteRemovesTheNote(): void {
+		$note = $this->incomingNote();
+
+		$this->streamRequest->expects($this->once())->method('deleteById')->with(self::NOTE, Note::TYPE);
+
+		$this->handler->activity($this->wrap(Delete::TYPE, $note), $note);
+	}
+
+	public function testDeleteNotComingFromTheNotesServerIsRefused(): void {
+		$note = $this->incomingNote();
+
+		$this->streamRequest->expects($this->never())->method('deleteById');
+
+		$this->expectException(InvalidOriginException::class);
+
+		$this->handler->activity($this->wrap(Delete::TYPE, $note, 'evil.example'), $note);
+	}
+
+	public function testUpdateRewritesTheStoredNote(): void {
+		$note = $this->incomingNote();
+		$note->setContent('<p>edited</p>');
+		$update = $this->wrap(Update::TYPE, $note);
+
+		$this->streamRequest->expects($this->once())->method('update')->with($this->identicalTo($note));
+		$this->streamRequest->expects($this->never())->method('save');
+
+		$this->handler->activity($update, $note);
+
+		$this->assertSame($update->getId(), $note->getActivityId());
+	}
+
+	public function testUpdateOfANoteClaimingAnAuthorFromAnotherServerIsRefused(): void {
+		$note = $this->note(self::NOTE, $this->carol->getId());
+
+		$this->streamRequest->expects($this->never())->method('update');
+
+		$this->expectException(InvalidOriginException::class);
+
+		$this->handler->activity($this->wrap(Update::TYPE, $note), $note);
+	}
+
+	public function testOtherActivitiesLeaveTheNoteAlone(): void {
+		$note = $this->incomingNote();
+
+		$this->streamRequest->expects($this->never())->method('save');
+		$this->streamRequest->expects($this->never())->method('update');
+		$this->streamRequest->expects($this->never())->method('deleteById');
+
+		$this->handler->activity($this->wrap(Accept::TYPE, $note), $note);
+	}
+
+	public function testGetItemByIdReturnsTheStoredNote(): void {
+		$stored = $this->storedCopy();
+		$this->streamRequest->method('getStreamById')->with(self::NOTE)->willReturn($stored);
+
+		$this->assertSame($stored, $this->handler->getItemById(self::NOTE));
+	}
+
+	public function testGetItemByIdThrowsWhenTheNoteIsUnknown(): void {
+		$this->nothingStored();
+
+		$this->expectException(ItemNotFoundException::class);
+
+		$this->handler->getItemById(self::NOTE);
+	}
+}

--- a/tests/Listeners/ProfileSectionListenerTest.php
+++ b/tests/Listeners/ProfileSectionListenerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Listeners;
+
+use OCA\Social\Listeners\ProfileSectionListener;
+use OCP\Accounts\UserUpdatedEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\IUser;
+use PHPUnit\Framework\TestCase;
+
+class ProfileSectionListenerTest extends TestCase {
+	public function testIsAnEventListener(): void {
+		$this->assertInstanceOf(IEventListener::class, new ProfileSectionListener());
+	}
+
+	/** @return iterable<string, array{Event}> */
+	public function unrelatedEvents(): iterable {
+		yield 'generic event' => [new Event()];
+		yield 'account update' => [new UserUpdatedEvent($this->createMock(IUser::class), [])];
+	}
+
+	/**
+	 * Registering the profile script needs the server's script registry, so an
+	 * unrelated event must return before reaching it.
+	 *
+	 * @dataProvider unrelatedEvents
+	 */
+	public function testUnrelatedEventsAreIgnored(Event $event): void {
+		(new ProfileSectionListener())->handle($event);
+
+		$this->addToAssertionCount(1);
+	}
+}

--- a/tests/Listeners/UserAccountListenerTest.php
+++ b/tests/Listeners/UserAccountListenerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Listeners;
+
+use OCA\Social\Exceptions\AccountDoesNotExistException;
+use OCA\Social\Listeners\UserAccountListener;
+use OCA\Social\Service\AccountService;
+use OCP\Accounts\UserUpdatedEvent;
+use OCP\EventDispatcher\Event;
+use OCP\IUser;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class UserAccountListenerTest extends TestCase {
+	/** @var AccountService&MockObject */
+	private $accountService;
+	/** @var LoggerInterface&MockObject */
+	private $logger;
+	private UserAccountListener $listener;
+
+	protected function setUp(): void {
+		$this->accountService = $this->createMock(AccountService::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->listener = new UserAccountListener($this->accountService, $this->logger);
+	}
+
+	private function userUpdated(string $uid): UserUpdatedEvent {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+
+		return new UserUpdatedEvent($user, ['displayname' => 'New Name']);
+	}
+
+	public function testAccountUpdateRefreshesTheCachedLocalActor(): void {
+		$this->accountService->expects($this->once())->method('cacheLocalActorByUsername')->with('alice');
+		$this->logger->expects($this->never())->method('warning');
+
+		$this->listener->handle($this->userUpdated('alice'));
+	}
+
+	public function testOtherEventsAreIgnored(): void {
+		$this->accountService->expects($this->never())->method('cacheLocalActorByUsername');
+
+		$this->listener->handle(new Event());
+	}
+
+	public function testRefreshFailuresAreLoggedNotThrown(): void {
+		$exception = new AccountDoesNotExistException('no social account');
+		$this->accountService->method('cacheLocalActorByUsername')->willThrowException($exception);
+		$this->logger->expects($this->once())->method('warning')
+			->with('issue while updating user account', ['exception' => $exception]);
+
+		$this->listener->handle($this->userUpdated('bob'));
+	}
+}

--- a/tests/Model/ActivityPub/ACoreTest.php
+++ b/tests/Model/ActivityPub/ACoreTest.php
@@ -1,0 +1,460 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model\ActivityPub;
+
+use OCA\Social\Exceptions\ActivityCantBeVerifiedException;
+use OCA\Social\Exceptions\InvalidOriginException;
+use OCA\Social\Exceptions\InvalidResourceEntryException;
+use OCA\Social\Exceptions\UrlCloudException;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Document;
+use OCA\Social\Model\ActivityPub\Object\Like;
+use OCA\Social\Model\ActivityPub\Object\Tombstone;
+use OCA\Social\Model\LinkedDataSignature;
+use PHPUnit\Framework\TestCase;
+
+class ACoreTest extends TestCase {
+	private const UUID_PATTERN = '[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}';
+
+	public function testConstructorAttachesToParentAndRootIsTheTopOfTheChain(): void {
+		$root = new ACore();
+		$middle = new ACore($root);
+		$leaf = new ACore($middle);
+
+		$this->assertTrue($root->isRoot());
+		$this->assertFalse($leaf->isRoot());
+		$this->assertSame($middle, $leaf->getParent());
+		$this->assertSame($root, $leaf->getRoot());
+
+		$chain = [];
+		$leaf->getRoot($chain);
+		$this->assertSame([$leaf, $middle, $root], $chain);
+	}
+
+	public function testRequestTokenIsReadFromTheRoot(): void {
+		$root = new ACore();
+		$root->setRequestToken('tok-123');
+		$child = new ACore($root);
+		$child->setRequestToken('ignored');
+
+		$this->assertSame('tok-123', $child->getRequestToken());
+	}
+
+	public function testSetObjectAdoptsTheObjectAndItsIdWins(): void {
+		$activity = new Like();
+		$activity->setObjectId('https://a.example/old');
+		$note = new ACore();
+		$note->setId('https://a.example/note/1');
+
+		$activity->setObject($note);
+
+		$this->assertTrue($activity->hasObject());
+		$this->assertSame($activity, $note->getParent());
+		$this->assertSame('https://a.example/note/1', $activity->getObjectId());
+	}
+
+	public function testRecipientsMergeToAndCcAndCanDropThePublicCollection(): void {
+		$item = new ACore();
+		$item->setToArray([ACore::CONTEXT_PUBLIC, 'https://a.example/users/alice']);
+		$item->setCcArray(['https://a.example/users/alice/followers']);
+
+		$all = $item->getRecipients();
+		$this->assertContains(ACore::CONTEXT_PUBLIC, $all);
+		$this->assertContains('https://a.example/users/alice', $all);
+		$this->assertContains('https://a.example/users/alice/followers', $all);
+
+		$filtered = $item->getRecipients(true);
+		$this->assertNotContains(ACore::CONTEXT_PUBLIC, $filtered);
+		$this->assertContains('https://a.example/users/alice', $filtered);
+		$this->assertContains('https://a.example/users/alice/followers', $filtered);
+	}
+
+	public function publicAudienceProvider(): array {
+		$followers = 'https://a.example/users/alice/followers';
+
+		return [
+			'public in to' => [[ACore::CONTEXT_PUBLIC], [$followers], true],
+			'public in cc (unlisted)' => [[$followers], [ACore::CONTEXT_PUBLIC], true],
+			'followers only' => [[$followers], [], false],
+			'direct message' => [['https://b.example/users/bob'], [], false],
+		];
+	}
+
+	/**
+	 * @dataProvider publicAudienceProvider
+	 */
+	public function testIsPublicLooksForThePublicCollectionInToOrCc(array $to, array $cc, bool $expected): void {
+		$item = new ACore();
+		$item->setToArray($to);
+		$item->setCcArray($cc);
+
+		$this->assertSame($expected, $item->isPublic());
+	}
+
+	public function testGenerateUniqueIdNeedsTheCloudUrl(): void {
+		$this->expectException(UrlCloudException::class);
+
+		(new ACore())->generateUniqueId('/documents');
+	}
+
+	public function testGenerateUniqueIdBuildsAnAbsoluteIdUnderTheBase(): void {
+		$item = new ACore();
+		$item->setUrlCloud('https://cloud.example.org');
+
+		$item->generateUniqueId('documents/g/');
+
+		$this->assertMatchesRegularExpression(
+			'#^https://cloud\.example\.org/documents/g/' . self::UUID_PATTERN . '$#',
+			$item->getId()
+		);
+	}
+
+	public function testGenerateUniqueIdWithoutRootSkipsTheCloudUrl(): void {
+		$item = new ACore();
+
+		$item->generateUniqueId('/x', false);
+
+		$this->assertMatchesRegularExpression('#^/x/' . self::UUID_PATTERN . '$#', $item->getId());
+	}
+
+	public function testCheckOriginAcceptsIdsFromTheRootOrigin(): void {
+		$root = new ACore();
+		$root->setOrigin('mastodon.social', 1, 0);
+		$child = new Like($root);
+
+		$child->checkOrigin('https://mastodon.social/users/alice/statuses/1');
+		$this->assertSame('mastodon.social', $child->getRoot()->getOrigin());
+	}
+
+	public function invalidOriginProvider(): array {
+		return [
+			'other host' => ['https://evil.example/users/alice'],
+			'no host' => ['not-a-url'],
+			'empty' => [''],
+		];
+	}
+
+	/**
+	 * @dataProvider invalidOriginProvider
+	 */
+	public function testCheckOriginRejectsForeignIds(string $id): void {
+		$item = new ACore();
+		$item->setOrigin('mastodon.social', 1, 0);
+
+		$this->expectException(InvalidOriginException::class);
+
+		$item->checkOrigin($id);
+	}
+
+	public function testVerifyAcceptsSameSchemeHostAndPort(): void {
+		$item = new ACore();
+		$item->setId('https://mastodon.social:8443/users/alice');
+
+		$item->verify('https://mastodon.social:8443/inbox');
+		$this->assertSame('https://mastodon.social:8443/users/alice', $item->getId());
+	}
+
+	public function mismatchingUrlProvider(): array {
+		return [
+			'host' => ['https://evil.example/inbox'],
+			'scheme' => ['http://mastodon.social/inbox'],
+			'port' => ['https://mastodon.social:8443/inbox'],
+		];
+	}
+
+	/**
+	 * @dataProvider mismatchingUrlProvider
+	 */
+	public function testVerifyRejectsMismatchingUrls(string $url): void {
+		$item = new ACore();
+		$item->setId('https://mastodon.social/users/alice');
+
+		$this->expectException(ActivityCantBeVerifiedException::class);
+
+		$item->verify($url);
+	}
+
+	public function validEntryProvider(): array {
+		return [
+			'id is kept' => [ACore::AS_ID, 'https://a.example/x', 'https://a.example/x'],
+			'type is kept' => [ACore::AS_TYPE, 'Note', 'Note'],
+			'url is kept' => [ACore::AS_URL, 'https://a.example/@x', 'https://a.example/@x'],
+			'date is kept' => [ACore::AS_DATE, '2024-05-01T12:00:00Z', '2024-05-01T12:00:00Z'],
+			'string decodes entities before stripping tags' => [ACore::AS_STRING, '&lt;b&gt;bold&lt;/b&gt; text', 'bold text'],
+			'content is sanitized not stripped' => [ACore::AS_CONTENT, '<p onclick="x">hi <b>there</b></p>', '<p>hi <b>there</b></p>'],
+			'username drops tags' => [ACore::AS_USERNAME, '<b>alice</b>', 'alice'],
+			'account drops tags' => [ACore::AS_ACCOUNT, 'alice@<i>a.example</i>', 'alice@a.example'],
+		];
+	}
+
+	/**
+	 * @dataProvider validEntryProvider
+	 */
+	public function testValidateEntryStringNormalisesByKind(int $as, string $value, string $expected): void {
+		$this->assertSame($expected, (new ACore())->validateEntryString($as, $value));
+	}
+
+	public function testValidateEntryStringRejectsUnparsableIds(): void {
+		$this->expectException(InvalidResourceEntryException::class);
+
+		(new ACore())->validateEntryString(ACore::AS_ID, 'http:///broken');
+	}
+
+	public function testValidateEntryStringCanReturnEmptyInsteadOfThrowing(): void {
+		$this->assertSame('', (new ACore())->validateEntryString(ACore::AS_ID, 'http:///broken', false));
+		$this->assertSame('', (new ACore())->validateEntryString(99, 'anything', false));
+	}
+
+	public function testValidateFallsBackToTheDefault(): void {
+		$item = new ACore();
+
+		$this->assertSame('fallback', $item->validate(ACore::AS_ID, 'id', ['id' => 'http:///broken'], 'fallback'));
+		$this->assertSame('fallback', $item->validate(ACore::AS_ID, 'id', [], 'fallback'));
+		$this->assertSame('https://a.example/1', $item->validate(ACore::AS_ID, 'id', ['id' => 'https://a.example/1'], 'fallback'));
+	}
+
+	public function testValidateArrayKeepsOnlyValidEntries(): void {
+		$item = new ACore();
+
+		$result = $item->validateArray(ACore::AS_ID, 'to', [
+			'to' => ['https://a.example/1', 'http:///broken', 'https://a.example/2'],
+		]);
+
+		$this->assertSame(['https://a.example/1', 'https://a.example/2'], $result);
+		$this->assertSame(['dflt'], $item->validateArray(ACore::AS_ID, 'to', [], ['dflt']));
+	}
+
+	public function testValidateArrayNormalisesTagsToTypeHrefAndName(): void {
+		$result = (new ACore())->validateArray(ACore::AS_TAGS, 'tag', [
+			'tag' => [
+				['type' => 'Mention', 'href' => 'https://a.example/users/bob', 'name' => '@bob', 'extra' => 'dropped'],
+				['type' => 'Hashtag', 'name' => '#cats'],
+			],
+		]);
+
+		$this->assertSame([
+			['type' => 'Mention', 'href' => 'https://a.example/users/bob', 'name' => '@bob'],
+			['type' => 'Hashtag', 'href' => '', 'name' => '#cats'],
+		], $result);
+	}
+
+	public function testValidateEntryArrayOnlyKnowsTags(): void {
+		$this->expectException(InvalidResourceEntryException::class);
+
+		(new ACore())->validateEntryArray(ACore::AS_ID, ['id' => 'x']);
+	}
+
+	public function testImportReadsTheCoreActivityStreamsFields(): void {
+		$item = new ACore();
+
+		$item->import([
+			'id' => 'https://mastodon.social/users/alice#likes/1',
+			'type' => 'Like',
+			'url' => 'https://mastodon.social/@alice/1',
+			'summary' => 'a summary',
+			'to' => ['https://www.w3.org/ns/activitystreams#Public'],
+			'cc' => ['https://mastodon.social/users/alice/followers'],
+			'published' => '2024-05-01T12:00:00Z',
+			'actor' => 'https://mastodon.social/users/alice',
+			'object' => 'https://cloud.example.org/@bob/1',
+			'tag' => [['type' => 'Hashtag', 'href' => 'https://mastodon.social/tags/x', 'name' => '#x']],
+		]);
+
+		$this->assertSame('https://mastodon.social/users/alice#likes/1', $item->getId());
+		$this->assertSame('Like', $item->getType());
+		$this->assertSame('https://mastodon.social/@alice/1', $item->getUrl());
+		$this->assertSame('a summary', $item->getSummary());
+		$this->assertSame(['https://www.w3.org/ns/activitystreams#Public'], $item->getToArray());
+		$this->assertSame(['https://mastodon.social/users/alice/followers'], $item->getCcArray());
+		$this->assertSame('2024-05-01T12:00:00Z', $item->getPublished());
+		$this->assertSame('https://mastodon.social/users/alice', $item->getActorId());
+		$this->assertSame('https://cloud.example.org/@bob/1', $item->getObjectId());
+		$this->assertSame([['type' => 'Hashtag', 'href' => 'https://mastodon.social/tags/x', 'name' => '#x']], $item->getTags());
+	}
+
+	public function testImportIgnoresAnEmbeddedObjectForTheObjectId(): void {
+		$item = new ACore();
+
+		$item->import(['type' => 'Create', 'object' => ['type' => 'Note', 'id' => 'https://a.example/n/1']]);
+
+		$this->assertSame('', $item->getObjectId());
+	}
+
+	public function testImportFromDatabaseReadsARowIncludingJsonColumns(): void {
+		$item = new ACore();
+
+		$item->importFromDatabase([
+			'nid' => '42',
+			'id' => 'https://a.example/n/1',
+			'type' => 'Note',
+			'subtype' => 'Mention',
+			'url' => 'https://a.example/@alice/1',
+			'summary' => '<b>cw</b>',
+			'to' => 'https://a.example/users/bob',
+			'to_array' => '["https://www.w3.org/ns/activitystreams#Public"]',
+			'cc' => '["https://a.example/users/alice/followers"]',
+			'bcc' => '[]',
+			'published' => '2024-05-01T12:00:00Z',
+			'actor_id' => 'https://a.example/users/alice',
+			'object_id' => 'https://a.example/n/0',
+			'source' => '{"raw":true}',
+			'local' => 1,
+		]);
+
+		$this->assertSame(42, $item->getNid());
+		$this->assertSame('Mention', $item->getSubType());
+		$this->assertSame('cw', $item->getSummary());
+		$this->assertSame('https://a.example/users/bob', $item->getTo());
+		$this->assertSame(['https://www.w3.org/ns/activitystreams#Public'], $item->getToArray());
+		$this->assertSame(['https://a.example/users/alice/followers'], $item->getCcArray());
+		$this->assertSame([], $item->getBccArray());
+		$this->assertSame('https://a.example/users/alice', $item->getActorId());
+		$this->assertSame('https://a.example/n/0', $item->getObjectId());
+		$this->assertSame('{"raw":true}', $item->getSource());
+		$this->assertTrue($item->isLocal());
+	}
+
+	public function testImportFromLocalReadsTheNumericId(): void {
+		$item = new ACore();
+
+		$item->importFromLocal(['id' => '17']);
+
+		$this->assertSame(17, $item->getNid());
+	}
+
+	public function testExportAsActivityPubAddsTheContextOnlyOnTheRoot(): void {
+		$root = new Like();
+		$root->setId('https://a.example/l/1');
+		$child = new Tombstone($root);
+		$child->setId('https://a.example/n/1');
+
+		$this->assertSame([ACore::CONTEXT_ACTIVITYSTREAMS], $root->exportAsActivityPub()['@context']);
+		$this->assertArrayNotHasKey('@context', $child->exportAsActivityPub());
+	}
+
+	public function testExportAsActivityPubAddsTheSecurityContextWhenAsked(): void {
+		$item = new Like();
+		$item->setDisplayW3ContextSecurity(true);
+
+		$this->assertSame(
+			[ACore::CONTEXT_ACTIVITYSTREAMS, ACore::CONTEXT_SECURITY],
+			$item->exportAsActivityPub()['@context']
+		);
+	}
+
+	public function testExportAsActivityPubEmbedsTheSignatureAndSecurityContext(): void {
+		$item = new Like();
+		$signature = new LinkedDataSignature();
+		$item->setSignature($signature);
+
+		$export = $item->exportAsActivityPub();
+
+		$this->assertTrue($item->hasSignature());
+		$this->assertSame($signature, $export['signature']);
+		$this->assertContains(ACore::CONTEXT_SECURITY, $export['@context']);
+	}
+
+	public function testExportAsActivityPubUsesEmbeddedActorAndObjectAndDropsEmptyEntries(): void {
+		$item = new Like();
+		$item->setId('https://a.example/l/1');
+		$actor = new Person();
+		$actor->setId('https://a.example/users/alice');
+		$item->setActor($actor);
+		$note = new Tombstone();
+		$note->setId('https://a.example/n/1');
+		$item->setObject($note);
+		$item->setToArray([ACore::CONTEXT_PUBLIC]);
+
+		$export = $item->exportAsActivityPub();
+
+		$this->assertSame('https://a.example/l/1', $export['id']);
+		$this->assertSame('Like', $export['type']);
+		$this->assertSame('https://a.example/users/alice', $export['actor']);
+		$this->assertSame($note, $export['object']);
+		$this->assertSame([ACore::CONTEXT_PUBLIC], $export['to']);
+		foreach (['url', 'cc', 'summary', 'published', 'tag', 'actor_info', 'source', 'local', 'icon'] as $absent) {
+			$this->assertArrayNotHasKey($absent, $export, $absent . ' should be dropped when empty');
+		}
+	}
+
+	public function testExportAsActivityPubAddsDetailsOnlyWhenComplete(): void {
+		$item = new Like();
+		$item->setId('https://a.example/l/1');
+		$actor = new Person();
+		$actor->setId('https://a.example/users/alice');
+		$item->setActor($actor);
+		$item->setSource('{"raw":1}');
+		$item->setLocal(true);
+		$item->setCompleteDetails(true);
+
+		$export = $item->exportAsActivityPub();
+
+		$this->assertSame($actor, $export['actor_info']);
+		$this->assertSame('{"raw":1}', $export['source']);
+		$this->assertTrue($export['local']);
+	}
+
+	public function testExportAsActivityPubFallsBackToActorIdAndObjectId(): void {
+		$item = new Like();
+		$item->setActorId('https://a.example/users/alice');
+		$item->setObjectId('https://a.example/n/1');
+
+		$export = $item->exportAsActivityPub();
+
+		$this->assertSame('https://a.example/users/alice', $export['actor']);
+		$this->assertSame('https://a.example/n/1', $export['object']);
+	}
+
+	public function testIconBecomesAChildEntry(): void {
+		$item = new ACore();
+		$icon = new Document();
+		$icon->setUrl('https://a.example/avatar.png');
+
+		$item->setIcon($icon);
+
+		$this->assertTrue($item->hasIcon());
+		$this->assertSame($item, $icon->getParent());
+		$this->assertSame($icon, $item->exportAsActivityPub()['icon']);
+	}
+
+	public function testJsonSerializeFollowsTheExportFormat(): void {
+		$item = new Like();
+		$item->setId('https://a.example/l/1');
+
+		$this->assertSame(ACore::FORMAT_ACTIVITYPUB, $item->getExportFormat());
+		$this->assertSame('Like', $item->jsonSerialize()['type']);
+
+		$item->setExportFormat(ACore::FORMAT_LOCAL);
+		$this->assertSame(['id' => 'https://a.example/l/1', 'nid' => 0], $item->jsonSerialize());
+
+		$item->setNid(12);
+		$this->assertSame(['id' => '12', 'nid' => 12], $item->jsonSerialize());
+
+		$item->setExportFormat(ACore::FORMAT_NOTIFICATION);
+		$this->assertSame(['id' => '12'], $item->jsonSerialize());
+
+		$item->setExportFormat(0);
+		$this->assertSame(ACore::FORMAT_NOTIFICATION, $item->getExportFormat());
+	}
+
+	public function testEntryHelpersSkipEmptyValues(): void {
+		$item = new ACore();
+
+		$item->addEntry('empty', '')
+			->addEntryInt('zero', 0)
+			->addEntryArray('none', [])
+			->addEntry('str', 'value')
+			->addEntryInt('int', 3)
+			->addEntryArray('arr', ['a']);
+
+		$this->assertSame(['str' => 'value', 'int' => 3, 'arr' => ['a']], $item->getEntries());
+	}
+}

--- a/tests/Model/ActivityPub/Activity/ActivitiesTest.php
+++ b/tests/Model/ActivityPub/Activity/ActivitiesTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model\ActivityPub\Activity;
+
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Activity\Accept;
+use OCA\Social\Model\ActivityPub\Activity\Add;
+use OCA\Social\Model\ActivityPub\Activity\Block;
+use OCA\Social\Model\ActivityPub\Activity\Create;
+use OCA\Social\Model\ActivityPub\Activity\Delete;
+use OCA\Social\Model\ActivityPub\Activity\Move;
+use OCA\Social\Model\ActivityPub\Activity\Reject;
+use OCA\Social\Model\ActivityPub\Activity\Remove;
+use OCA\Social\Model\ActivityPub\Activity\Undo;
+use OCA\Social\Model\ActivityPub\Activity\Update;
+use OCA\Social\Model\ActivityPub\Object\Follow;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The ten activity models share the ACore import/export; this checks each one
+ * is wired to it and carries its own type.
+ */
+class ActivitiesTest extends TestCase {
+	public function activityProvider(): array {
+		return [
+			'Accept' => [Accept::class, 'Accept'],
+			'Add' => [Add::class, 'Add'],
+			'Block' => [Block::class, 'Block'],
+			'Create' => [Create::class, 'Create'],
+			'Delete' => [Delete::class, 'Delete'],
+			'Move' => [Move::class, 'Move'],
+			'Reject' => [Reject::class, 'Reject'],
+			'Remove' => [Remove::class, 'Remove'],
+			'Undo' => [Undo::class, 'Undo'],
+			'Update' => [Update::class, 'Update'],
+		];
+	}
+
+	/**
+	 * @dataProvider activityProvider
+	 */
+	public function testConstructorSetsTheTypeAndAttachesAParent(string $class, string $type): void {
+		$parent = new Create();
+		/** @var ACore $activity */
+		$activity = new $class($parent);
+
+		$this->assertSame($type, $activity->getType());
+		$this->assertSame($type, $class::TYPE);
+		$this->assertSame($parent, $activity->getParent());
+		$this->assertTrue((new $class())->isRoot());
+	}
+
+	/**
+	 * @dataProvider activityProvider
+	 */
+	public function testImportReadsActorAndObjectAndExportsThemBack(string $class, string $type): void {
+		/** @var ACore $activity */
+		$activity = new $class();
+
+		$activity->import([
+			'id' => 'https://mastodon.social/users/alice#' . strtolower($type) . '/1',
+			'type' => $type,
+			'actor' => 'https://mastodon.social/users/alice',
+			'object' => 'https://cloud.example.org/apps/social/@bob/1',
+			'to' => [ACore::CONTEXT_PUBLIC],
+		]);
+
+		$this->assertSame('https://mastodon.social/users/alice', $activity->getActorId());
+		$this->assertSame('https://cloud.example.org/apps/social/@bob/1', $activity->getObjectId());
+		$this->assertTrue($activity->isPublic());
+
+		$export = $activity->jsonSerialize();
+		$this->assertSame([ACore::CONTEXT_ACTIVITYSTREAMS], $export['@context']);
+		$this->assertSame($type, $export['type']);
+		$this->assertSame('https://mastodon.social/users/alice', $export['actor']);
+		$this->assertSame('https://cloud.example.org/apps/social/@bob/1', $export['object']);
+	}
+
+	public function testMoveImportsTheTargetAccount(): void {
+		$move = new Move();
+
+		$move->import([
+			'id' => 'https://mastodon.social/users/alice#moves/1',
+			'type' => 'Move',
+			'actor' => 'https://mastodon.social/users/alice',
+			'object' => 'https://mastodon.social/users/alice',
+			'target' => 'https://other.example/users/alice',
+		]);
+
+		$this->assertSame('https://mastodon.social/users/alice', $move->getActorId());
+		$this->assertSame('https://mastodon.social/users/alice', $move->getObjectId());
+		$this->assertSame('https://other.example/users/alice', $move->getTarget());
+	}
+
+	public function testUndoWithAnEmbeddedFollowExportsTheObjectInline(): void {
+		$undo = new Undo();
+		$undo->setId('https://mastodon.social/users/alice#follows/1/undo')
+			->setActorId('https://mastodon.social/users/alice');
+		$follow = new Follow();
+		$follow->setId('https://mastodon.social/users/alice#follows/1')
+			->setActorId('https://mastodon.social/users/alice')
+			->setObjectId('https://cloud.example.org/apps/social/@bob');
+		$undo->setObject($follow);
+
+		$export = $undo->jsonSerialize();
+
+		$this->assertSame($follow, $export['object']);
+		$this->assertSame('https://mastodon.social/users/alice#follows/1', $undo->getObjectId());
+		$this->assertArrayNotHasKey('@context', $follow->jsonSerialize(), 'the embedded object is not a root');
+	}
+}

--- a/tests/Model/ActivityPub/Actor/ActorSubtypesTest.php
+++ b/tests/Model/ActivityPub/Actor/ActorSubtypesTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model\ActivityPub\Actor;
+
+use OCA\Social\AP;
+use OCA\Social\Model\ActivityPub\Actor\Application;
+use OCA\Social\Model\ActivityPub\Actor\Group;
+use OCA\Social\Model\ActivityPub\Actor\Organization;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Actor\Service;
+use OCA\Social\Tests\Model\TActivityPubMocks;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../TActivityPubMocks.php';
+
+/**
+ * Service, Group, Organization and Application are Persons with another type.
+ */
+class ActorSubtypesTest extends TestCase {
+	use TActivityPubMocks;
+
+	protected function setUp(): void {
+		$this->installActivityPub();
+	}
+
+	protected function tearDown(): void {
+		AP::$activityPub = null;
+	}
+
+	public function subtypeProvider(): array {
+		return [
+			'Service' => [Service::class, 'Service'],
+			'Group' => [Group::class, 'Group'],
+			'Organization' => [Organization::class, 'Organization'],
+			'Application' => [Application::class, 'Application'],
+		];
+	}
+
+	/**
+	 * @dataProvider subtypeProvider
+	 */
+	public function testIsAPersonWithItsOwnTypeConstant(string $class, string $type): void {
+		$actor = new $class();
+
+		$this->assertInstanceOf(Person::class, $actor);
+		$this->assertSame($type, $class::TYPE);
+	}
+
+	/**
+	 * @dataProvider subtypeProvider
+	 */
+	public function testImportKeepsTheTypeAndReadsActorFields(string $class, string $type): void {
+		/** @var Person $actor */
+		$actor = new $class();
+
+		$actor->import([
+			'id' => 'https://bots.example/actor',
+			'type' => $type,
+			'preferredUsername' => 'relay',
+			'inbox' => 'https://bots.example/inbox',
+			'publicKey' => ['publicKeyPem' => 'PEM'],
+		]);
+
+		$this->assertSame($type, $actor->getType());
+		$this->assertSame('relay', $actor->getPreferredUsername());
+		$this->assertSame('https://bots.example/inbox', $actor->getInbox());
+		$this->assertSame('PEM', $actor->getPublicKey());
+		$this->assertSame($type, $actor->exportAsActivityPub()['type']);
+	}
+}

--- a/tests/Model/ActivityPub/Actor/PersonTest.php
+++ b/tests/Model/ActivityPub/Actor/PersonTest.php
@@ -1,0 +1,370 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model\ActivityPub\Actor;
+
+use OCA\Social\AP;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Document;
+use OCA\Social\Model\ActivityPub\Object\Image;
+use OCA\Social\Tests\Model\TActivityPubMocks;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../TActivityPubMocks.php';
+
+class PersonTest extends TestCase {
+	use TActivityPubMocks;
+
+	private const PEM = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0\n-----END PUBLIC KEY-----\n";
+
+	private string $timezone;
+	/** @var IURLGenerator&MockObject */
+	private $urlGenerator;
+
+	protected function setUp(): void {
+		$this->timezone = date_default_timezone_get();
+		date_default_timezone_set('UTC');
+
+		$this->installActivityPub();
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		\OC::$server->register(IURLGenerator::class, $this->urlGenerator);
+	}
+
+	protected function tearDown(): void {
+		date_default_timezone_set($this->timezone);
+		AP::$activityPub = null;
+		\OC::$server->reset();
+	}
+
+	/** An actor document as served by Mastodon. */
+	private function mastodonActor(): array {
+		return [
+			'@context' => [ACore::CONTEXT_ACTIVITYSTREAMS, ACore::CONTEXT_SECURITY],
+			'id' => 'https://mastodon.social/users/alice',
+			'type' => 'Person',
+			'following' => 'https://mastodon.social/users/alice/following',
+			'followers' => 'https://mastodon.social/users/alice/followers',
+			'inbox' => 'https://mastodon.social/users/alice/inbox',
+			'outbox' => 'https://mastodon.social/users/alice/outbox',
+			'featured' => 'https://mastodon.social/users/alice/collections/featured',
+			'preferredUsername' => 'alice',
+			'name' => 'Alice <b>W.</b>',
+			'summary' => '<p>Hello <script>alert(1)</script>world</p>',
+			'url' => 'https://mastodon.social/@alice',
+			'manuallyApprovesFollowers' => true,
+			'discoverable' => true,
+			'published' => '2019-01-01T00:00:00Z',
+			'publicKey' => [
+				'id' => 'https://mastodon.social/users/alice#main-key',
+				'owner' => 'https://mastodon.social/users/alice',
+				'publicKeyPem' => self::PEM,
+			],
+			'endpoints' => ['sharedInbox' => 'https://mastodon.social/inbox'],
+			'icon' => ['type' => 'Image', 'mediaType' => 'image/png', 'url' => 'https://files.mastodon.social/accounts/avatars/001/original/avatar.png'],
+			'image' => ['type' => 'Image', 'mediaType' => 'image/jpeg', 'url' => 'https://files.mastodon.social/accounts/headers/001/original/header.jpg'],
+		];
+	}
+
+	public function testConstructorSetsTheType(): void {
+		$this->assertSame('Person', (new Person())->getType());
+	}
+
+	public function testImportReadsAMastodonActorDocument(): void {
+		$person = new Person();
+
+		$person->import($this->mastodonActor());
+
+		$this->assertSame('https://mastodon.social/users/alice', $person->getId());
+		$this->assertSame('https://mastodon.social/@alice', $person->getUrl());
+		$this->assertSame('alice', $person->getPreferredUsername());
+		$this->assertSame('Alice W.', $person->getName(), 'name is stripped of tags');
+		$this->assertSame('<p>Hello world</p>', $person->getDescription(), 'summary is sanitized');
+		$this->assertSame('https://mastodon.social/users/alice/inbox', $person->getInbox());
+		$this->assertSame('https://mastodon.social/users/alice/outbox', $person->getOutbox());
+		$this->assertSame('https://mastodon.social/users/alice/followers', $person->getFollowers());
+		$this->assertSame('https://mastodon.social/users/alice/following', $person->getFollowing());
+		$this->assertSame('https://mastodon.social/users/alice/collections/featured', $person->getFeatured());
+		$this->assertSame('https://mastodon.social/inbox', $person->getSharedInbox());
+		$this->assertSame(self::PEM, $person->getPublicKey());
+		$this->assertSame('2019-01-01T00:00:00Z', $person->getPublished());
+
+		$this->assertTrue($person->hasIcon());
+		$this->assertInstanceOf(Image::class, $person->getIcon());
+		$this->assertSame($person, $person->getIcon()->getParent());
+		$this->assertSame('image/png', $person->getIcon()->getMediaType());
+		$this->assertSame('https://files.mastodon.social/accounts/avatars/001/original/avatar.png', $person->getAvatar());
+		$this->assertSame('https://files.mastodon.social/accounts/headers/001/original/header.jpg', $person->getHeader());
+	}
+
+	public function testImportWithoutIconOrImageLeavesAvatarAndHeaderEmpty(): void {
+		$person = new Person();
+		$actor = $this->mastodonActor();
+		unset($actor['icon'], $actor['image']);
+
+		$person->import($actor);
+
+		$this->assertFalse($person->hasIcon());
+		$this->assertSame('', $person->getAvatar());
+		$this->assertSame('', $person->getHeader());
+	}
+
+	public function testHeaderFallsBackToTheAvatar(): void {
+		$person = new Person();
+		$person->setAvatar('https://a.example/avatar.png');
+
+		$this->assertSame('https://a.example/avatar.png', $person->getHeader());
+
+		$person->setHeader('https://a.example/header.jpg');
+		$this->assertSame('https://a.example/header.jpg', $person->getHeader());
+	}
+
+	public function testNameAndDisplayNameFallBackToThePreferredUsername(): void {
+		$person = new Person();
+		$person->setPreferredUsername('alice');
+
+		$this->assertSame('alice', $person->getName());
+		$this->assertSame('alice', $person->getDisplayName());
+
+		$person->setName('Alice');
+		$person->setDisplayName('Alice W.');
+		$this->assertSame('Alice', $person->getName());
+		$this->assertSame('Alice W.', $person->getDisplayName());
+	}
+
+	public function testSetAccountStripsTheLeadingAt(): void {
+		$person = new Person();
+
+		$person->setAccount('@alice@mastodon.social');
+		$this->assertSame('alice@mastodon.social', $person->getAccount());
+
+		$person->setAccount('bob@mastodon.social');
+		$this->assertSame('bob@mastodon.social', $person->getAccount());
+	}
+
+	private function localActor(): Person {
+		$person = new Person();
+		$person->setId('https://cloud.example.org/apps/social/@alice')
+			->setPreferredUsername('alice')
+			->setName('Alice')
+			->setInbox('https://cloud.example.org/apps/social/@alice/inbox')
+			->setOutbox('https://cloud.example.org/apps/social/@alice/outbox')
+			->setFollowers('https://cloud.example.org/apps/social/@alice/followers')
+			->setFollowing('https://cloud.example.org/apps/social/@alice/following')
+			->setSharedInbox('https://cloud.example.org/apps/social/inbox')
+			->setPublicKey(self::PEM)
+			->setUrlSocial('https://cloud.example.org/apps/social/');
+
+		return $person;
+	}
+
+	public function testExportAsActivityPubProducesTheKeyAndEndpointBlocks(): void {
+		$export = $this->localActor()->exportAsActivityPub();
+
+		$this->assertSame([ACore::CONTEXT_ACTIVITYSTREAMS, ACore::CONTEXT_SECURITY], $export['@context']);
+		$this->assertSame('Person', $export['type']);
+		$this->assertSame('alice', $export['preferredUsername']);
+		$this->assertSame('Alice', $export['name']);
+		$this->assertSame('https://cloud.example.org/apps/social/@alice/inbox', $export['inbox']);
+		$this->assertSame('https://cloud.example.org/apps/social/@alice/outbox', $export['outbox']);
+		$this->assertSame('https://cloud.example.org/apps/social/@alice/followers', $export['followers']);
+		$this->assertSame('https://cloud.example.org/apps/social/@alice/following', $export['following']);
+		$this->assertSame(['sharedInbox' => 'https://cloud.example.org/apps/social/inbox'], $export['endpoints']);
+		$this->assertSame([
+			'id' => 'https://cloud.example.org/apps/social/@alice#main-key',
+			'owner' => 'https://cloud.example.org/apps/social/@alice',
+			'publicKeyPem' => self::PEM,
+		], $export['publicKey']);
+		$this->assertSame([
+			'https://cloud.example.org/apps/social/@alice',
+			'https://cloud.example.org/apps/social/users/alice',
+		], $export['aliases']);
+		$this->assertArrayNotHasKey('icon', $export);
+		$this->assertArrayNotHasKey('image', $export);
+		$this->assertArrayNotHasKey('details', $export);
+	}
+
+	public function testExportAsActivityPubWithoutPublicKeyKeepsThePlainContext(): void {
+		$person = $this->localActor();
+		$person->setPublicKey('');
+
+		$this->assertSame([ACore::CONTEXT_ACTIVITYSTREAMS], $person->exportAsActivityPub()['@context']);
+	}
+
+	public function testExportAsActivityPubDescribesIconAndHeaderImages(): void {
+		$person = $this->localActor();
+		$icon = new Image();
+		$icon->setMediaType('image/png')
+			->setUrl('https://cloud.example.org/avatar.png');
+		$person->setIcon($icon);
+		$person->setHeader('https://cloud.example.org/header.jpg');
+		$person->setCompleteDetails(true);
+		$person->setViewerLink(Person::LINK_LOCAL);
+		$person->setDetailInt('followers', 3);
+
+		$export = $person->exportAsActivityPub();
+
+		$this->assertSame(['type' => 'Image', 'mediaType' => 'image/png', 'url' => 'https://cloud.example.org/avatar.png'], $export['icon']);
+		$this->assertSame(['type' => 'Image', 'mediaType' => 'image/jpeg', 'url' => 'https://cloud.example.org/header.jpg'], $export['image']);
+		$this->assertSame(['followers' => 3], $export['details']);
+		$this->assertSame('local', $export['viewerLink']);
+	}
+
+	public function testExportAsLocalProducesAMastodonAccount(): void {
+		$person = new Person();
+		$person->setNid(3)
+			->setId('https://mastodon.social/users/alice')
+			->setPreferredUsername('alice')
+			->setAccount('alice@mastodon.social')
+			->setName('Alice')
+			->setLocked(true)
+			->setBot(false)
+			->setDiscoverable(true)
+			->setDescription('<p>bio</p>')
+			->setAvatar('https://files.mastodon.social/avatars/alice.png')
+			->setHeader('https://files.mastodon.social/headers/alice.jpg')
+			->setCreation(1546300800)
+			->setPrivacy('unlisted')
+			->setSensitive(true)
+			->setLanguage('fr');
+		$person->setDetailArray('count', ['followers' => 10, 'following' => 5, 'post' => 42]);
+
+		$account = $person->exportAsLocal();
+
+		$this->assertSame('3', $account['id']);
+		$this->assertSame('alice', $account['username']);
+		$this->assertSame('alice@mastodon.social', $account['acct']);
+		$this->assertSame('Alice', $account['display_name']);
+		$this->assertTrue($account['locked']);
+		$this->assertFalse($account['bot']);
+		$this->assertTrue($account['discoverable']);
+		$this->assertFalse($account['group']);
+		$this->assertSame('2019-01-01T00:00:00.000Z', $account['created_at']);
+		$this->assertSame('<p>bio</p>', $account['note']);
+		$this->assertSame('https://mastodon.social/users/alice', $account['url']);
+		$this->assertSame('https://files.mastodon.social/avatars/alice.png', $account['avatar']);
+		$this->assertSame('https://files.mastodon.social/avatars/alice.png', $account['avatar_static']);
+		$this->assertSame('https://files.mastodon.social/headers/alice.jpg', $account['header']);
+		$this->assertSame('https://files.mastodon.social/headers/alice.jpg', $account['header_static']);
+		$this->assertSame(10, $account['followers_count']);
+		$this->assertSame(5, $account['following_count']);
+		$this->assertSame(42, $account['statuses_count']);
+		$this->assertSame(['privacy' => 'unlisted', 'sensitive' => true, 'language' => 'fr', 'note' => '<p>bio</p>', 'fields' => [], 'follow_requests_count' => 0], $account['source']);
+		$this->assertSame([], $account['emojis']);
+		$this->assertSame([], $account['fields']);
+	}
+
+	public function testExportAsLocalUsesTheUsernameAsAcctForLocalAccounts(): void {
+		$person = new Person();
+		$person->setPreferredUsername('alice')
+			->setAccount('alice@cloud.example.org')
+			->setLocal(true);
+
+		$this->assertSame('alice', $person->exportAsLocal()['acct']);
+	}
+
+	public function testExportAsLocalServesTheCachedIconThroughTheMediaRoute(): void {
+		$this->urlGenerator->expects($this->once())->method('linkToRouteAbsolute')
+			->with('social.Api.mediaOpen', ['uuid' => 'abc123'])
+			->willReturn('https://cloud.example.org/apps/social/media/abc123');
+		$person = new Person();
+		$icon = new Document();
+		$icon->setLocalCopy('abc123')
+			->setUrl('https://files.mastodon.social/avatars/alice.png');
+		$person->setIcon($icon);
+
+		$account = $person->exportAsLocal();
+
+		$this->assertSame('https://cloud.example.org/apps/social/media/abc123', $account['avatar']);
+		$this->assertSame('https://cloud.example.org/apps/social/media/abc123', $account['avatar_static']);
+	}
+
+	public function testImportFromLocalReadsAMastodonAccount(): void {
+		$person = new Person();
+
+		$person->importFromLocal([
+			'id' => '31',
+			'username' => 'alice',
+			'acct' => '@alice@mastodon.social',
+			'display_name' => 'Alice W.',
+			'locked' => 'true',
+			'bot' => false,
+			'discoverable' => true,
+			'note' => '<p>bio</p>',
+			'url' => 'https://mastodon.social/@alice',
+			'avatar' => 'https://files.mastodon.social/avatars/alice.png',
+			'header' => 'https://files.mastodon.social/headers/alice.jpg',
+			'followers_count' => 10,
+			'following_count' => 5,
+			'statuses_count' => 42,
+			'last_status_at' => '2024-05-01',
+			'created_at' => '2019-01-01T00:00:00.000Z',
+			'source' => ['privacy' => 'private', 'sensitive' => false, 'language' => 'de'],
+		]);
+
+		$this->assertSame(31, $person->getNid());
+		$this->assertSame('https://mastodon.social/@alice', $person->getId());
+		$this->assertSame('alice', $person->getPreferredUsername());
+		$this->assertSame('alice@mastodon.social', $person->getAccount());
+		$this->assertSame('Alice W.', $person->getDisplayName());
+		$this->assertTrue($person->isLocked());
+		$this->assertFalse($person->isBot());
+		$this->assertTrue($person->isDiscoverable());
+		$this->assertSame('<p>bio</p>', $person->getDescription());
+		$this->assertSame('private', $person->getPrivacy());
+		$this->assertFalse($person->isSensitive());
+		$this->assertSame('de', $person->getLanguage());
+		$this->assertSame(1546300800, $person->getCreation());
+		$this->assertSame(
+			['followers' => 10, 'following' => 5, 'post' => 42, 'last_post_creation' => '2024-05-01'],
+			$person->getDetails('count')
+		);
+	}
+
+	public function testImportFromDatabaseReadsTheActorRow(): void {
+		$person = new Person();
+
+		$person->importFromDatabase([
+			'nid' => 3,
+			'id' => 'https://mastodon.social/users/alice',
+			'type' => 'Person',
+			'preferred_username' => 'alice',
+			'user_id' => '',
+			'name' => 'Alice',
+			'summary' => '<p onclick="x()">bio</p>',
+			'account' => 'alice@mastodon.social',
+			'public_key' => self::PEM,
+			'private_key' => '',
+			'inbox' => 'https://mastodon.social/users/alice/inbox',
+			'outbox' => 'https://mastodon.social/users/alice/outbox',
+			'followers' => 'https://mastodon.social/users/alice/followers',
+			'following' => 'https://mastodon.social/users/alice/following',
+			'shared_inbox' => 'https://mastodon.social/inbox',
+			'featured' => '',
+			'details' => '{"count":{"followers":10}}',
+			'creation' => '2019-01-01 00:00:00',
+			'deleted' => '',
+			'source' => '{"image":{"url":"https://files.mastodon.social/headers/alice.jpg"}}',
+		]);
+
+		$this->assertSame(3, $person->getNid());
+		$this->assertSame('alice', $person->getPreferredUsername());
+		$this->assertSame('Alice', $person->getName());
+		$this->assertSame('<p>bio</p>', $person->getDescription());
+		$this->assertSame('alice@mastodon.social', $person->getAccount());
+		$this->assertSame(self::PEM, $person->getPublicKey());
+		$this->assertSame('https://mastodon.social/inbox', $person->getSharedInbox());
+		$this->assertSame(10, $person->getDetails('count')['followers']);
+		$this->assertSame(1546300800, $person->getCreation());
+		$this->assertSame(0, $person->getDeleted());
+		$this->assertSame('https://files.mastodon.social/headers/alice.jpg', $person->getHeader(), 'header comes from the stored source');
+	}
+}

--- a/tests/Model/ActivityPub/ItemTest.php
+++ b/tests/Model/ActivityPub/ItemTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model\ActivityPub;
+
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Item;
+use OCA\Social\Model\InstancePath;
+use PHPUnit\Framework\TestCase;
+
+class ItemTest extends TestCase {
+	public function testAddToArrayIgnoresDuplicatesAndToAllIncludesTheSingleTo(): void {
+		$item = new Item();
+		$item->setTo('https://a.example/users/bob');
+
+		$item->addToArray('https://a.example/users/alice')
+			->addToArray('https://a.example/users/alice')
+			->addToArray('https://a.example/users/carol');
+
+		$this->assertSame(['https://a.example/users/alice', 'https://a.example/users/carol'], $item->getToArray());
+		$this->assertSame(
+			['https://a.example/users/alice', 'https://a.example/users/carol', 'https://a.example/users/bob'],
+			$item->getToAll()
+		);
+	}
+
+	public function testCcCanBeAddedOnceAndRemoved(): void {
+		$item = new Item();
+
+		$item->addCc('https://a.example/users/alice')
+			->addCc('https://a.example/users/alice')
+			->addCc('https://a.example/users/bob');
+
+		$this->assertCount(2, $item->getCcArray());
+		$this->assertTrue($item->hasCc('https://a.example/users/alice'));
+
+		$item->removeCc('https://a.example/users/bob');
+		$item->removeCc('https://nobody.example/');
+
+		$this->assertFalse($item->hasCc('https://a.example/users/bob'));
+		$this->assertSame(['https://a.example/users/alice'], $item->getCcArray());
+	}
+
+	public function testGetTagsCanFilterByType(): void {
+		$item = new Item();
+		$mention = ['type' => 'Mention', 'href' => 'https://a.example/users/bob', 'name' => '@bob'];
+		$hashtag = ['type' => 'Hashtag', 'href' => 'https://a.example/tags/cats', 'name' => '#cats'];
+
+		$item->addTag($mention)->addTag($hashtag);
+
+		$this->assertSame([$mention, $hashtag], $item->getTags());
+		$this->assertSame([$mention], $item->getTags('Mention'));
+		$this->assertSame([$hashtag], $item->getTags('Hashtag'));
+		$this->assertSame([], $item->getTags('Emoji'));
+	}
+
+	public function testActorObjectWinsOverTheActorId(): void {
+		$item = new Item();
+		$item->setActorId('https://a.example/users/old');
+
+		$this->assertFalse($item->hasActor());
+		$this->assertSame('https://a.example/users/old', $item->getActorId());
+
+		$actor = new Person();
+		$actor->setId('https://a.example/users/alice');
+		$item->setActor($actor);
+
+		$this->assertTrue($item->hasActor());
+		$this->assertSame($actor, $item->getActor());
+		$this->assertSame('https://a.example/users/alice', $item->getActorId());
+	}
+
+	public function testInstancePathsSkipEmptyUrisAndMerge(): void {
+		$item = new Item();
+		$inbox = new InstancePath('https://a.example/inbox', InstancePath::TYPE_INBOX);
+		$shared = new InstancePath('https://b.example/inbox', InstancePath::TYPE_GLOBAL);
+
+		$item->addInstancePath(new InstancePath(''));
+		$item->addInstancePath($inbox);
+		$item->addInstancePaths([$shared]);
+
+		$this->assertSame([$inbox, $shared], $item->getInstancePaths());
+
+		$item->setInstancePaths([$shared]);
+		$this->assertSame([$shared], $item->getInstancePaths());
+	}
+
+	public function testOriginStoresHostSourceAndCreationTime(): void {
+		$item = new Item();
+
+		$item->setOrigin('mastodon.social', 2, 1714564800);
+
+		$this->assertSame('mastodon.social', $item->getOrigin());
+		$this->assertSame(2, $item->getOriginSource());
+		$this->assertSame(1714564800, $item->getOriginCreationTime());
+	}
+
+	public function testScalarAccessorsRoundTrip(): void {
+		$item = new Item();
+
+		$item->setId('https://a.example/n/1')
+			->setNid(5)
+			->setType('Note')
+			->setSubType('Mention')
+			->setUrl('https://a.example/@alice/1')
+			->setSummary('cw')
+			->setPublished('2024-05-01T12:00:00Z')
+			->setObjectId('https://a.example/n/0')
+			->setTarget('https://b.example/users/alice')
+			->setIconId('https://a.example/icon.png')
+			->setSource('{}')
+			->setUrlSocial('https://cloud.example.org/apps/social/')
+			->setUrlCloud('https://cloud.example.org')
+			->setAddress('cloud.example.org')
+			->setLocal(true)
+			->setCompleteDetails(true)
+			->setBccArray(['https://a.example/users/bob']);
+
+		$this->assertSame('https://a.example/n/1', $item->getId());
+		$this->assertSame(5, $item->getNid());
+		$this->assertSame('Note', $item->getType());
+		$this->assertSame('Mention', $item->getSubType());
+		$this->assertSame('https://a.example/@alice/1', $item->getUrl());
+		$this->assertSame('cw', $item->getSummary());
+		$this->assertSame('2024-05-01T12:00:00Z', $item->getPublished());
+		$this->assertSame('https://a.example/n/0', $item->getObjectId());
+		$this->assertSame('https://b.example/users/alice', $item->getTarget());
+		$this->assertSame('https://a.example/icon.png', $item->getIconId());
+		$this->assertSame('{}', $item->getSource());
+		$this->assertSame('https://cloud.example.org/apps/social/', $item->getUrlSocial());
+		$this->assertSame('https://cloud.example.org', $item->getUrlCloud());
+		$this->assertSame('cloud.example.org', $item->getAddress());
+		$this->assertTrue($item->isLocal());
+		$this->assertTrue($item->isCompleteDetails());
+		$this->assertSame(['https://a.example/users/bob'], $item->getBccArray());
+	}
+}

--- a/tests/Model/ActivityPub/Object/AnnounceTest.php
+++ b/tests/Model/ActivityPub/Object/AnnounceTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model\ActivityPub\Object;
+
+use OCA\Social\AP;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Object\Announce;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Model\ActivityPub\Stream;
+use OCA\Social\Tests\Model\TActivityPubMocks;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../TActivityPubMocks.php';
+
+class AnnounceTest extends TestCase {
+	use TActivityPubMocks;
+
+	protected function setUp(): void {
+		$this->installActivityPub();
+		\OC::$server->register(IURLGenerator::class, $this->createMock(IURLGenerator::class));
+	}
+
+	protected function tearDown(): void {
+		AP::$activityPub = null;
+		\OC::$server->reset();
+	}
+
+	public function testIsAStreamOfTypeAnnounce(): void {
+		$announce = new Announce();
+
+		$this->assertInstanceOf(Stream::class, $announce);
+		$this->assertSame('Announce', $announce->getType());
+	}
+
+	public function testImportReadsAMastodonBoost(): void {
+		$announce = new Announce();
+
+		$announce->import([
+			'id' => 'https://mastodon.social/users/alice/statuses/2/activity',
+			'type' => 'Announce',
+			'actor' => 'https://mastodon.social/users/alice',
+			'published' => '2024-05-01T12:00:00Z',
+			'to' => ['https://mastodon.social/users/alice/followers'],
+			'cc' => ['https://remote.example/users/bob', ACore::CONTEXT_PUBLIC],
+			'object' => 'https://remote.example/users/bob/statuses/1',
+		]);
+
+		$this->assertSame('https://mastodon.social/users/alice', $announce->getActorId());
+		$this->assertSame('https://remote.example/users/bob/statuses/1', $announce->getObjectId());
+		$this->assertTrue($announce->isPublic());
+		$this->assertSame(1714564800, $announce->getPublishedTime());
+	}
+
+	public function testExportAsLocalEmbedsTheBoostedStatusAsReblog(): void {
+		$boosted = new Note();
+		$boosted->setId('https://remote.example/users/bob/statuses/1')
+			->setNid(5)
+			->setContent('<p>original</p>');
+		$announce = new Announce();
+		$announce->setId('https://mastodon.social/users/alice/statuses/2/activity');
+
+		$this->assertNull($announce->exportAsLocal()['reblog']);
+
+		$announce->setObject($boosted);
+		$reblog = $announce->exportAsLocal()['reblog'];
+
+		$this->assertSame('5', $reblog['id']);
+		$this->assertSame('<p>original</p>', $reblog['content']);
+		$this->assertSame('https://remote.example/users/bob/statuses/1', $reblog['uri']);
+	}
+}

--- a/tests/Model/ActivityPub/Object/DocumentTest.php
+++ b/tests/Model/ActivityPub/Object/DocumentTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model\ActivityPub\Object;
+
+use OCA\Social\Exceptions\UrlCloudException;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Object\Document;
+use OCA\Social\Model\Client\AttachmentMeta;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class DocumentTest extends TestCase {
+	/** @var IURLGenerator&MockObject */
+	private $urlGenerator;
+
+	protected function setUp(): void {
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->urlGenerator->method('linkToRouteAbsolute')->willReturnCallback(
+			fn (string $route, array $args): string => 'https://cloud.example.org/' . $route . '/' . $args['uuid']
+		);
+	}
+
+	public function testConstructorSetsTheType(): void {
+		$this->assertSame('Document', (new Document())->getType());
+	}
+
+	public function testImportReadsTheMediaTypeAndKeepsAGivenId(): void {
+		$document = new Document();
+
+		$document->import([
+			'id' => 'https://files.mastodon.social/media/1',
+			'type' => 'Document',
+			'mediaType' => 'image/jpeg',
+			'url' => 'https://files.mastodon.social/media/cat.jpg',
+		]);
+
+		$this->assertSame('https://files.mastodon.social/media/1', $document->getId());
+		$this->assertSame('image/jpeg', $document->getMediaType());
+		$this->assertSame('https://files.mastodon.social/media/cat.jpg', $document->getUrl());
+	}
+
+	public function testImportGeneratesAnIdUnderTheCloudUrlWhenMissing(): void {
+		$document = new Document();
+		$document->setUrlCloud('https://cloud.example.org');
+
+		$document->import(['type' => 'Document', 'mediaType' => 'image/png', 'url' => 'https://a.example/x.png']);
+
+		$this->assertMatchesRegularExpression('#^https://cloud\.example\.org/documents/g/[0-9a-f-]{36}$#', $document->getId());
+	}
+
+	public function testImportWithoutIdNeedsTheCloudUrl(): void {
+		$this->expectException(UrlCloudException::class);
+
+		(new Document())->import(['type' => 'Document', 'url' => 'https://a.example/x.png']);
+	}
+
+	public function testImportFromDatabaseReadsTheCacheRow(): void {
+		$document = new Document();
+
+		$document->importFromDatabase([
+			'nid' => 8,
+			'id' => 'https://files.mastodon.social/media/1',
+			'type' => 'Document',
+			'url' => 'https://files.mastodon.social/media/cat.jpg',
+			'account' => 'alice@mastodon.social',
+			'public' => 1,
+			'error' => 0,
+			'local_copy' => 'abc',
+			'resized_copy' => 'abc_s',
+			'blurhash' => 'UBL_:rOp',
+			'description' => 'A cat',
+			'media_type' => 'image/jpeg',
+			'mime_type' => 'image/jpeg',
+			'parent_id' => 'https://mastodon.social/users/alice/statuses/1',
+			'caching' => '2024-05-01 12:00:00',
+			'meta' => '{"original":{"width":1200,"height":800},"focus":{"x":0,"y":0}}',
+		]);
+
+		$this->assertSame(8, $document->getNid());
+		$this->assertSame('alice@mastodon.social', $document->getAccount());
+		$this->assertTrue($document->isPublic());
+		$this->assertSame(0, $document->getError());
+		$this->assertSame('abc', $document->getLocalCopy());
+		$this->assertSame('abc_s', $document->getResizedCopy());
+		$this->assertSame('UBL_:rOp', $document->getBlurHash());
+		$this->assertSame('A cat', $document->getDescription());
+		$this->assertSame('image/jpeg', $document->getMediaType());
+		$this->assertSame('image/jpeg', $document->getMimeType());
+		$this->assertSame('https://mastodon.social/users/alice/statuses/1', $document->getParentId());
+		$this->assertSame((new \DateTime('2024-05-01 12:00:00'))->getTimestamp(), $document->getCaching());
+		$this->assertInstanceOf(AttachmentMeta::class, $document->getMeta());
+		$this->assertSame(1200, $document->getMeta()->getOriginal()->getWidth());
+	}
+
+	public function testImportFromDatabaseWithoutCachingDateOrMeta(): void {
+		$document = new Document();
+
+		$document->importFromDatabase(['id' => 'https://a.example/1', 'type' => 'Document', 'caching' => '', 'public' => 0]);
+
+		$this->assertSame(0, $document->getCaching());
+		$this->assertFalse($document->isPublic());
+		$this->assertNull($document->getMeta());
+	}
+
+	public function testMediaUrlsPointToTheMediaRouteWithTheMimeExtension(): void {
+		$document = new Document();
+		$document->setLocalCopy('abc')
+			->setResizedCopy('abc_s');
+
+		$this->assertSame('https://cloud.example.org/social.Api.mediaOpen/abc.jpeg', $document->getMediaUrl($this->urlGenerator, 'image/jpeg'));
+		$this->assertSame('https://cloud.example.org/social.Api.mediaOpen/abc', $document->getMediaUrl($this->urlGenerator));
+		$this->assertSame('https://cloud.example.org/social.Api.mediaOpen/abc_s.png', $document->getResizedMediaUrl($this->urlGenerator, 'image/png'));
+	}
+
+	public function testConvertToMediaAttachmentBuildsTheMastodonEntity(): void {
+		$document = new Document();
+		$document->setNid(8)
+			->setMediaType('image/jpeg')
+			->setUrl('https://files.mastodon.social/media/cat.jpg')
+			->setLocalCopy('abc')
+			->setResizedCopy('abc_s')
+			->setDescription('A cat')
+			->setBlurHash('UBL_:rOp')
+			->setLocalCopySize(1200, 800);
+		$document->setResizedCopySize(600, 400);
+
+		$media = $document->convertToMediaAttachment($this->urlGenerator);
+
+		$this->assertSame('8', $media->getId());
+		$this->assertSame('image', $media->getType());
+		$this->assertSame('https://cloud.example.org/social.Api.mediaOpen/abc.jpeg', $media->getUrl());
+		$this->assertSame('https://cloud.example.org/social.Api.mediaOpen/abc_s.jpeg', $media->getPreviewUrl());
+		$this->assertSame('https://files.mastodon.social/media/cat.jpg', $media->getRemoteUrl());
+		$this->assertSame('A cat', $media->getDescription());
+		$this->assertSame('UBL_:rOp', $media->getBlurHash());
+		$this->assertSame(ACore::FORMAT_LOCAL, $media->getExportFormat());
+		$this->assertSame(1200, $media->getMeta()->getOriginal()->getWidth());
+		$this->assertSame('600x400', $media->getMeta()->getSmall()->getSize());
+		$this->assertSame(0.0, $media->getMeta()->getFocus()->getX());
+		$this->assertSame($media->getMeta(), $document->getMeta(), 'the generated meta is kept on the document');
+	}
+
+	public function testConvertToMediaAttachmentWithoutUrlGeneratorLeavesLocalUrlsEmpty(): void {
+		$document = new Document();
+		$document->setMediaType('video/mp4')
+			->setUrl('https://files.mastodon.social/media/clip.mp4');
+
+		$media = $document->convertToMediaAttachment(null, ACore::FORMAT_ACTIVITYPUB);
+
+		$this->assertSame('video', $media->getType());
+		$this->assertNull($media->getUrl());
+		$this->assertSame('', $media->getPreviewUrl());
+		$this->assertSame(ACore::FORMAT_ACTIVITYPUB, $media->getExportFormat());
+	}
+
+	public function testJsonSerializeAddsTheDocumentFieldsAndParentIdOnlyWhenComplete(): void {
+		$document = new Document();
+		$document->setId('https://a.example/1')
+			->setMediaType('image/png')
+			->setMimeType('image/png')
+			->setLocalCopy('abc')
+			->setResizedCopy('abc_s')
+			->setParentId('https://a.example/n/1');
+
+		$json = $document->jsonSerialize();
+
+		$this->assertSame('Document', $json['type']);
+		$this->assertSame('image/png', $json['mediaType']);
+		$this->assertSame('image/png', $json['mimeType']);
+		$this->assertSame('abc', $json['localCopy']);
+		$this->assertSame('abc_s', $json['resizedCopy']);
+		$this->assertArrayNotHasKey('parentId', $json);
+
+		$document->setCompleteDetails(true);
+		$this->assertSame('https://a.example/n/1', $document->jsonSerialize()['parentId']);
+	}
+
+	public function testCopySizesDefaultToZero(): void {
+		$document = new Document();
+
+		$this->assertSame([0, 0], $document->getLocalCopySize());
+		$this->assertSame([0, 0], $document->getResizedCopySize());
+	}
+}

--- a/tests/Model/ActivityPub/Object/FollowTest.php
+++ b/tests/Model/ActivityPub/Object/FollowTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model\ActivityPub\Object;
+
+use OCA\Social\Model\ActivityPub\Object\Follow;
+use PHPUnit\Framework\TestCase;
+
+class FollowTest extends TestCase {
+	public function testConstructorSetsTheType(): void {
+		$this->assertSame('Follow', (new Follow())->getType());
+	}
+
+	public function testImportReadsActorAndObject(): void {
+		$follow = new Follow();
+
+		$follow->import([
+			'id' => 'https://mastodon.social/users/alice#follows/1',
+			'type' => 'Follow',
+			'actor' => 'https://mastodon.social/users/alice',
+			'object' => 'https://cloud.example.org/apps/social/@bob',
+		]);
+
+		$this->assertSame('https://mastodon.social/users/alice', $follow->getActorId());
+		$this->assertSame('https://cloud.example.org/apps/social/@bob', $follow->getObjectId());
+		$this->assertFalse($follow->isAccepted());
+	}
+
+	public function testImportFromDatabaseReadsTheFollowColumns(): void {
+		$follow = new Follow();
+
+		$follow->importFromDatabase([
+			'id' => 'https://mastodon.social/users/alice#follows/1',
+			'type' => 'Follow',
+			'accepted' => 1,
+			'follow_id' => 'https://cloud.example.org/apps/social/@bob#accepts/1',
+			'follow_id_prim' => 'abc',
+		]);
+
+		$this->assertTrue($follow->isAccepted());
+		$this->assertSame('https://cloud.example.org/apps/social/@bob#accepts/1', $follow->getFollowId());
+		$this->assertSame('abc', $follow->getFollowIdPrim());
+	}
+
+	public function testJsonSerializeExposesFollowStateOnlyWithCompleteDetails(): void {
+		$follow = new Follow();
+		$follow->setFollowId('https://a.example/accept/1')
+			->setFollowIdPrim('abc')
+			->setAccepted(true);
+
+		$json = $follow->jsonSerialize();
+		$this->assertSame('Follow', $json['type']);
+		$this->assertArrayNotHasKey('accepted', $json);
+
+		$follow->setCompleteDetails(true);
+		$json = $follow->jsonSerialize();
+		$this->assertSame('https://a.example/accept/1', $json['follow_id']);
+		$this->assertSame('abc', $json['follow_id_prim']);
+		$this->assertTrue($json['accepted']);
+	}
+}

--- a/tests/Model/ActivityPub/Object/ImageTest.php
+++ b/tests/Model/ActivityPub/Object/ImageTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model\ActivityPub\Object;
+
+use OCA\Social\Model\ActivityPub\Object\Document;
+use OCA\Social\Model\ActivityPub\Object\Image;
+use PHPUnit\Framework\TestCase;
+
+class ImageTest extends TestCase {
+	public function testIsADocumentOfTypeImage(): void {
+		$image = new Image();
+
+		$this->assertInstanceOf(Document::class, $image);
+		$this->assertSame('Image', $image->getType());
+	}
+
+	public function testImportBehavesLikeADocument(): void {
+		$image = new Image();
+		$image->setUrlCloud('https://cloud.example.org');
+
+		$image->import(['type' => 'Image', 'mediaType' => 'image/png', 'url' => 'https://a.example/avatar.png']);
+
+		$this->assertSame('Image', $image->getType());
+		$this->assertSame('image/png', $image->getMediaType());
+		$this->assertStringStartsWith('https://cloud.example.org/documents/g/', $image->getId());
+		$this->assertSame('Image', $image->jsonSerialize()['type']);
+	}
+}

--- a/tests/Model/ActivityPub/Object/LikeTest.php
+++ b/tests/Model/ActivityPub/Object/LikeTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model\ActivityPub\Object;
+
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Object\Like;
+use PHPUnit\Framework\TestCase;
+
+class LikeTest extends TestCase {
+	public function testConstructorSetsTheType(): void {
+		$this->assertSame('Like', (new Like())->getType());
+	}
+
+	public function testImportAndExportOfAMastodonLike(): void {
+		$like = new Like();
+
+		$like->import([
+			'id' => 'https://mastodon.social/users/alice#likes/1',
+			'type' => 'Like',
+			'actor' => 'https://mastodon.social/users/alice',
+			'object' => 'https://cloud.example.org/apps/social/@bob/1',
+		]);
+		$export = $like->jsonSerialize();
+
+		$this->assertSame([ACore::CONTEXT_ACTIVITYSTREAMS], $export['@context']);
+		$this->assertSame('https://mastodon.social/users/alice#likes/1', $export['id']);
+		$this->assertSame('Like', $export['type']);
+		$this->assertSame('https://mastodon.social/users/alice', $export['actor']);
+		$this->assertSame('https://cloud.example.org/apps/social/@bob/1', $export['object']);
+	}
+}

--- a/tests/Model/ActivityPub/Object/MentionTest.php
+++ b/tests/Model/ActivityPub/Object/MentionTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model\ActivityPub\Object;
+
+use OCA\Social\AP;
+use OCA\Social\Model\ActivityPub\Object\Mention;
+use OCA\Social\Model\ActivityPub\Stream;
+use OCA\Social\Tests\Model\TActivityPubMocks;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../TActivityPubMocks.php';
+
+class MentionTest extends TestCase {
+	use TActivityPubMocks;
+
+	protected function setUp(): void {
+		$this->installActivityPub();
+		\OC::$server->register(IURLGenerator::class, $this->createMock(IURLGenerator::class));
+	}
+
+	protected function tearDown(): void {
+		AP::$activityPub = null;
+		\OC::$server->reset();
+	}
+
+	public function testIsAStreamOfTypeMention(): void {
+		$mention = new Mention();
+
+		$this->assertInstanceOf(Stream::class, $mention);
+		$this->assertSame('Mention', $mention->getType());
+	}
+
+	public function testImportReadsTheStreamFields(): void {
+		$mention = new Mention();
+
+		$mention->import([
+			'id' => 'https://a.example/n/1',
+			'type' => 'Mention',
+			'content' => '<p>@bob hi</p>',
+			'attributedTo' => 'https://a.example/users/alice',
+			'published' => '2024-05-01T12:00:00Z',
+		]);
+
+		$this->assertSame('<p>@bob hi</p>', $mention->getContent());
+		$this->assertSame('https://a.example/users/alice', $mention->getAttributedTo());
+		$this->assertSame(1714564800, $mention->getPublishedTime());
+		$this->assertSame('Mention', $mention->jsonSerialize()['type']);
+	}
+
+	public function testImportFromDatabaseReadsTheRow(): void {
+		$mention = new Mention();
+
+		$mention->importFromDatabase(['nid' => 4, 'id' => 'https://a.example/n/1', 'type' => 'Mention', 'content' => 'x']);
+
+		$this->assertSame(4, $mention->getNid());
+		$this->assertSame('x', $mention->getContent());
+	}
+}

--- a/tests/Model/ActivityPub/Object/NoteTest.php
+++ b/tests/Model/ActivityPub/Object/NoteTest.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model\ActivityPub\Object;
+
+use OCA\Social\AP;
+use OCA\Social\Exceptions\ItemNotFoundException;
+use OCA\Social\Interfaces\Actor\PersonInterface;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Model\Client\MediaAttachment;
+use OCA\Social\Tests\Model\TActivityPubMocks;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../TActivityPubMocks.php';
+
+class NoteTest extends TestCase {
+	use TActivityPubMocks;
+
+	protected function setUp(): void {
+		$this->installActivityPub();
+		\OC::$server->register(IURLGenerator::class, $this->createMock(IURLGenerator::class));
+	}
+
+	protected function tearDown(): void {
+		AP::$activityPub = null;
+		\OC::$server->reset();
+	}
+
+	/** A Note as Mastodon delivers it inside a Create. */
+	private function mastodonNote(): array {
+		return [
+			'id' => 'https://mastodon.social/users/alice/statuses/112000000000000001',
+			'type' => 'Note',
+			'summary' => 'CW: cats',
+			'inReplyTo' => 'https://mastodon.social/users/bob/statuses/111999999999999999',
+			'published' => '2024-05-01T12:00:00Z',
+			'url' => 'https://mastodon.social/@alice/112000000000000001',
+			'attributedTo' => 'https://mastodon.social/users/alice',
+			'to' => [ACore::CONTEXT_PUBLIC],
+			'cc' => ['https://mastodon.social/users/alice/followers', 'https://remote.example/users/bob'],
+			'sensitive' => true,
+			'atomUri' => 'https://mastodon.social/users/alice/statuses/112000000000000001',
+			'conversation' => 'tag:mastodon.social,2024-05-01:objectId=1:objectType=Conversation',
+			'content' => '<p><span class="h-card"><a href="https://remote.example/@bob" class="u-url mention">@<span>bob</span></a></span> look at this <a href="https://mastodon.social/tags/nextcloud" class="mention hashtag" rel="tag">#<span>nextcloud</span></a></p>',
+			'contentMap' => ['en' => '<p>...</p>'],
+			'attachment' => [
+				[
+					'type' => 'Document',
+					'mediaType' => 'image/jpeg',
+					'url' => 'https://files.mastodon.social/media_attachments/files/112/000/original/cat.jpg',
+					'name' => 'A cat',
+					'blurhash' => 'UBL_:rOpGG-oBUNG,qRj2so|=eE1w^n4S5NH',
+					'width' => 1200,
+					'height' => 800,
+				],
+			],
+			'tag' => [
+				['type' => 'Mention', 'href' => 'https://remote.example/users/bob', 'name' => '@bob@remote.example'],
+				['type' => 'Hashtag', 'href' => 'https://mastodon.social/tags/nextcloud', 'name' => '#nextcloud'],
+			],
+			'replies' => ['id' => 'https://mastodon.social/users/alice/statuses/112000000000000001/replies', 'type' => 'Collection'],
+			'likes' => ['id' => 'https://mastodon.social/users/alice/statuses/112000000000000001/likes', 'type' => 'Collection', 'totalItems' => 5],
+			'shares' => ['id' => 'https://mastodon.social/users/alice/statuses/112000000000000001/shares', 'type' => 'Collection', 'totalItems' => 2],
+		];
+	}
+
+	private function nobodyIsKnown(): void {
+		$this->apInterface(PersonInterface::class)->method('getItemById')
+			->willThrowException(new ItemNotFoundException());
+	}
+
+	public function testConstructorSetsTheType(): void {
+		$this->assertSame('Note', (new Note())->getType());
+	}
+
+	public function testImportReadsAMastodonNote(): void {
+		$this->nobodyIsKnown();
+		$note = new Note();
+
+		$note->import($this->mastodonNote());
+
+		$this->assertSame('https://mastodon.social/users/alice/statuses/112000000000000001', $note->getId());
+		$this->assertSame('https://mastodon.social/@alice/112000000000000001', $note->getUrl());
+		$this->assertSame('CW: cats', $note->getSummary());
+		$this->assertTrue($note->isSensitive());
+		$this->assertSame('https://mastodon.social/users/bob/statuses/111999999999999999', $note->getInReplyTo());
+		$this->assertSame('https://mastodon.social/users/alice', $note->getAttributedTo());
+		$this->assertSame('2024-05-01T12:00:00Z', $note->getPublished());
+		$this->assertSame(1714564800, $note->getPublishedTime());
+		$this->assertStringContainsString('look at this', $note->getContent());
+		$this->assertSame('tag:mastodon.social,2024-05-01:objectId=1:objectType=Conversation', $note->getConversation());
+
+		$this->assertTrue($note->isPublic());
+		$this->assertSame([ACore::CONTEXT_PUBLIC], $note->getToArray());
+		$this->assertSame(
+			['https://mastodon.social/users/alice/followers', 'https://remote.example/users/bob'],
+			$note->getCcArray()
+		);
+		$this->assertNotContains(ACore::CONTEXT_PUBLIC, $note->getRecipients(true));
+
+		$this->assertSame([
+			['type' => 'Mention', 'href' => 'https://remote.example/users/bob', 'name' => '@bob@remote.example'],
+			['type' => 'Hashtag', 'href' => 'https://mastodon.social/tags/nextcloud', 'name' => '#nextcloud'],
+		], $note->getTags());
+		$this->assertSame(['nextcloud'], $note->getHashtags());
+
+		$this->assertSame(5, $note->getDetailInt('likes'));
+		$this->assertSame(2, $note->getDetailInt('boosts'));
+		$this->assertSame(0, $note->getDetailInt('replies'), 'replies collection without totalItems');
+
+		$attachments = $note->getAttachments();
+		$this->assertCount(1, $attachments);
+		$this->assertInstanceOf(MediaAttachment::class, $attachments[0]);
+		$this->assertSame('image', $attachments[0]->getType());
+		$this->assertSame(
+			'https://files.mastodon.social/media_attachments/files/112/000/original/cat.jpg',
+			$attachments[0]->getRemoteUrl()
+		);
+	}
+
+	public function testFillMentionsKeepsTagDataForUnknownActors(): void {
+		$this->nobodyIsKnown();
+		$note = new Note();
+		$note->setTags([
+			['type' => 'Mention', 'href' => 'https://remote.example/users/bob', 'name' => '@bob@remote.example'],
+			['type' => 'Hashtag', 'href' => 'https://mastodon.social/tags/nextcloud', 'name' => '#nextcloud'],
+		]);
+
+		$note->fillMentions();
+
+		$this->assertSame([
+			[
+				'id' => 0,
+				'username' => 'bob@remote.example',
+				'url' => 'https://remote.example/users/bob',
+				'acct' => 'bob@remote.example',
+			],
+		], $note->getDetails('mentions'));
+	}
+
+	public function testFillMentionsResolvesKnownActors(): void {
+		$bob = new Person();
+		$bob->setNid(77)
+			->setPreferredUsername('bob')
+			->setAccount('bob@remote.example');
+		$this->apInterface(PersonInterface::class)->method('getItemById')
+			->with('https://remote.example/users/bob')
+			->willReturn($bob);
+
+		$note = new Note();
+		$note->setTags([['type' => 'Mention', 'href' => 'https://remote.example/users/bob', 'name' => '@bob@remote.example']]);
+
+		$note->fillMentions();
+
+		$this->assertSame([
+			[
+				'id' => '77',
+				'username' => 'bob',
+				'url' => 'https://remote.example/users/bob',
+				'acct' => 'bob@remote.example',
+			],
+		], $note->getDetails('mentions'));
+	}
+
+	public function testFillHashtagsStripsTheHashAndIgnoresOtherTags(): void {
+		$note = new Note();
+		$note->setTags([
+			['type' => 'Hashtag', 'href' => 'https://mastodon.social/tags/nextcloud', 'name' => '#Nextcloud'],
+			['type' => 'Hashtag', 'href' => 'https://mastodon.social/tags/fediverse', 'name' => '#fediverse '],
+			['type' => 'Hashtag', 'href' => 'https://mastodon.social/tags/plain', 'name' => 'plain'],
+			['type' => 'Mention', 'href' => 'https://remote.example/users/bob', 'name' => '@bob'],
+		]);
+
+		$note->fillHashtags();
+
+		$this->assertSame(['Nextcloud', 'fediverse', 'plain'], $note->getHashtags());
+	}
+
+	public function testExportAsActivityPubRoundTripsTheImportedNote(): void {
+		$this->nobodyIsKnown();
+		$source = $this->mastodonNote();
+		$note = new Note();
+		$note->import($source);
+
+		$export = $note->exportAsActivityPub();
+
+		$this->assertSame([ACore::CONTEXT_ACTIVITYSTREAMS], $export['@context']);
+		foreach (['id', 'type', 'url', 'to', 'cc', 'published', 'summary', 'content', 'attributedTo', 'inReplyTo', 'sensitive', 'conversation', 'tag'] as $key) {
+			$this->assertSame($source[$key], $export[$key], $key . ' survives the round trip');
+		}
+		$this->assertArrayNotHasKey('actor', $export);
+		$this->assertArrayNotHasKey('object', $export);
+	}
+
+	public function testExportAsLocalOfAnImportedNote(): void {
+		$this->nobodyIsKnown();
+		$note = new Note();
+		$note->import($this->mastodonNote());
+
+		$status = $note->exportAsLocal();
+
+		$this->assertSame('https://mastodon.social/users/alice/statuses/112000000000000001', $status['uri']);
+		$this->assertSame('https://mastodon.social/users/alice/statuses/112000000000000001', $status['url']);
+		$this->assertStringContainsString('look at this', $status['content']);
+		$this->assertTrue($status['sensitive']);
+		$this->assertSame(5, $status['favourites_count']);
+		$this->assertSame(2, $status['reblogs_count']);
+		$this->assertCount(1, $status['media_attachments']);
+		$this->assertFalse($status['local']);
+	}
+
+	public function testImportFromDatabaseReadsHashtagsAndExposesThemOnlyWithCompleteDetails(): void {
+		$note = new Note();
+
+		$note->importFromDatabase([
+			'id' => 'https://mastodon.social/users/alice/statuses/1',
+			'type' => 'Note',
+			'hashtags' => '["nextcloud","fediverse"]',
+		]);
+
+		$this->assertSame(['nextcloud', 'fediverse'], $note->getHashtags());
+		$this->assertArrayNotHasKey('hashtags', $note->jsonSerialize());
+
+		$note->setCompleteDetails(true);
+		$this->assertSame(['nextcloud', 'fediverse'], $note->jsonSerialize()['hashtags']);
+	}
+}

--- a/tests/Model/ActivityPub/Object/TombstoneTest.php
+++ b/tests/Model/ActivityPub/Object/TombstoneTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model\ActivityPub\Object;
+
+use OCA\Social\Model\ActivityPub\Object\Tombstone;
+use PHPUnit\Framework\TestCase;
+
+class TombstoneTest extends TestCase {
+	public function testConstructorSetsTheType(): void {
+		$this->assertSame('Tombstone', (new Tombstone())->getType());
+	}
+
+	public function testImportKeepsTheIdOfTheDeletedObject(): void {
+		$tombstone = new Tombstone();
+
+		$tombstone->import(['id' => 'https://mastodon.social/users/alice/statuses/1', 'type' => 'Tombstone']);
+
+		$this->assertSame('https://mastodon.social/users/alice/statuses/1', $tombstone->getId());
+		$this->assertSame(
+			['id' => 'https://mastodon.social/users/alice/statuses/1', 'type' => 'Tombstone'],
+			array_intersect_key($tombstone->jsonSerialize(), ['id' => 1, 'type' => 1])
+		);
+	}
+}

--- a/tests/Model/ActivityPub/OrderedCollectionTest.php
+++ b/tests/Model/ActivityPub/OrderedCollectionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model\ActivityPub;
+
+use OCA\Social\Model\ActivityPub\OrderedCollection;
+use PHPUnit\Framework\TestCase;
+
+class OrderedCollectionTest extends TestCase {
+	public function testConstructorSetsTheType(): void {
+		$this->assertSame('OrderedCollection', (new OrderedCollection())->getType());
+	}
+
+	public function testImportReadsAMastodonFollowersCollection(): void {
+		$collection = new OrderedCollection();
+
+		$result = $collection->import([
+			'id' => 'https://mastodon.social/users/alice/followers',
+			'type' => 'OrderedCollection',
+			'totalItems' => 1234,
+			'first' => 'https://mastodon.social/users/alice/followers?page=1',
+			'last' => 'https://mastodon.social/users/alice/followers?page=13',
+		]);
+
+		$this->assertSame($collection, $result);
+		$this->assertSame(1234, $collection->getTotalItems());
+		$this->assertSame('https://mastodon.social/users/alice/followers?page=1', $collection->getFirst());
+		$this->assertSame('https://mastodon.social/users/alice/followers?page=13', $collection->getLast());
+	}
+
+	public function testJsonSerializeDropsEmptyCollectionFields(): void {
+		$collection = new OrderedCollection();
+		$collection->setId('https://mastodon.social/users/alice/followers');
+
+		$json = $collection->jsonSerialize();
+		$this->assertArrayNotHasKey('totalItems', $json);
+		$this->assertArrayNotHasKey('first', $json);
+		$this->assertArrayNotHasKey('last', $json);
+
+		$collection->setTotalItems(3)->setFirst('https://mastodon.social/users/alice/followers?page=1');
+		$json = $collection->jsonSerialize();
+		$this->assertSame(3, $json['totalItems']);
+		$this->assertSame('https://mastodon.social/users/alice/followers?page=1', $json['first']);
+		$this->assertArrayNotHasKey('last', $json);
+	}
+}

--- a/tests/Model/ActivityPub/StreamTest.php
+++ b/tests/Model/ActivityPub/StreamTest.php
@@ -1,0 +1,427 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model\ActivityPub;
+
+use OCA\Social\AP;
+use OCA\Social\Interfaces\Object\DocumentInterface;
+use OCA\Social\Interfaces\Object\ImageInterface;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Document;
+use OCA\Social\Model\ActivityPub\Object\Image;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Model\ActivityPub\Stream;
+use OCA\Social\Model\Client\MediaAttachment;
+use OCA\Social\Model\StreamAction;
+use OCA\Social\Tests\Model\TActivityPubMocks;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../TActivityPubMocks.php';
+
+class StreamTest extends TestCase {
+	use TActivityPubMocks;
+
+	private string $timezone;
+
+	protected function setUp(): void {
+		$this->timezone = date_default_timezone_get();
+		date_default_timezone_set('UTC');
+
+		$this->installActivityPub();
+
+		$urlGenerator = $this->createMock(IURLGenerator::class);
+		$urlGenerator->method('linkToRouteAbsolute')->willReturnCallback(
+			fn (string $route, array $args): string => 'https://cloud.example.org/' . $route . '/' . ($args['uuid'] ?? '')
+		);
+		\OC::$server->register(IURLGenerator::class, $urlGenerator);
+	}
+
+	protected function tearDown(): void {
+		date_default_timezone_set($this->timezone);
+		AP::$activityPub = null;
+		\OC::$server->reset();
+	}
+
+	public function testImportReadsTheMastodonNoteFields(): void {
+		$stream = new Stream();
+
+		$stream->import([
+			'id' => 'https://mastodon.social/users/alice/statuses/112000000000000001',
+			'type' => 'Note',
+			'summary' => 'CW: cats',
+			'inReplyTo' => 'https://mastodon.social/users/bob/statuses/111999999999999999',
+			'published' => '2024-05-01T12:00:00Z',
+			'url' => 'https://mastodon.social/@alice/112000000000000001',
+			'attributedTo' => 'https://mastodon.social/users/alice',
+			'to' => [ACore::CONTEXT_PUBLIC],
+			'cc' => ['https://mastodon.social/users/alice/followers'],
+			'sensitive' => true,
+			'conversation' => 'tag:mastodon.social,2024-05-01:objectId=1:objectType=Conversation',
+			'content' => '<p>Look at <b>this</b></p>',
+			'attachment' => [],
+			'likes' => ['id' => 'https://mastodon.social/users/alice/statuses/112000000000000001/likes', 'type' => 'Collection', 'totalItems' => 5],
+			'shares' => ['id' => 'https://mastodon.social/users/alice/statuses/112000000000000001/shares', 'type' => 'Collection', 'totalItems' => 2],
+			'replies' => ['id' => 'https://mastodon.social/users/alice/statuses/112000000000000001/replies', 'type' => 'Collection', 'totalItems' => 1],
+		]);
+
+		$this->assertSame('Note', $stream->getType());
+		$this->assertSame('CW: cats', $stream->getSummary());
+		$this->assertSame('https://mastodon.social/users/bob/statuses/111999999999999999', $stream->getInReplyTo());
+		$this->assertSame('https://mastodon.social/users/alice', $stream->getAttributedTo());
+		$this->assertSame(1714564800, $stream->getPublishedTime());
+		$this->assertTrue($stream->isSensitive());
+		$this->assertSame('tag:mastodon.social,2024-05-01:objectId=1:objectType=Conversation', $stream->getConversation());
+		$this->assertSame('<p>Look at <b>this</b></p>', $stream->getContent());
+		$this->assertTrue($stream->isPublic());
+		$this->assertSame([], $stream->getAttachments());
+		$this->assertSame(5, $stream->getDetailInt('likes'));
+		$this->assertSame(5, $stream->getDetailInt('remote_likes'));
+		$this->assertSame(2, $stream->getDetailInt('boosts'));
+		$this->assertSame(2, $stream->getDetailInt('remote_boosts'));
+		$this->assertSame(1, $stream->getDetailInt('replies'));
+	}
+
+	public function testImportLeavesCountsAloneWhenTheCollectionsCarryNoTotals(): void {
+		$stream = new Stream();
+
+		$stream->import([
+			'id' => 'https://mastodon.social/users/alice/statuses/1',
+			'type' => 'Note',
+			'likes' => ['id' => 'https://mastodon.social/users/alice/statuses/1/likes', 'type' => 'Collection'],
+		]);
+
+		$this->assertSame([], $stream->getDetailsAll());
+	}
+
+	public function testImportBuildsMediaAttachmentsThroughTheDocumentAndImageInterfaces(): void {
+		$this->apInterface(DocumentInterface::class)->expects($this->once())->method('save')
+			->with($this->isInstanceOf(Document::class));
+		$this->apInterface(ImageInterface::class)->expects($this->once())->method('save')
+			->with($this->isInstanceOf(Image::class));
+
+		$stream = new Stream();
+		$stream->import([
+			'id' => 'https://mastodon.social/users/alice/statuses/1',
+			'type' => 'Note',
+			'attachment' => [
+				['type' => 'Document', 'mediaType' => 'image/jpeg', 'url' => 'https://files.mastodon.social/media/cat.jpg', 'name' => 'A cat'],
+				['type' => 'Image', 'mediaType' => 'image/png', 'url' => 'https://files.mastodon.social/media/dog.png'],
+				['type' => 'Link', 'href' => 'https://example.org/'],
+				['type' => 'Document', 'mediaType' => 'video/mp4'],
+			],
+		]);
+
+		$attachments = $stream->getAttachments();
+		$this->assertCount(2, $attachments);
+		$this->assertContainsOnlyInstancesOf(MediaAttachment::class, $attachments);
+		$this->assertSame('image', $attachments[0]->getType());
+		$this->assertSame('https://files.mastodon.social/media/cat.jpg', $attachments[0]->getRemoteUrl());
+		$this->assertStringEndsWith('social.Api.mediaOpen/.jpeg', $attachments[0]->getUrl());
+		$this->assertStringEndsWith('.jpeg', $attachments[0]->getPreviewUrl());
+		$this->assertSame('https://files.mastodon.social/media/dog.png', $attachments[1]->getRemoteUrl());
+		$this->assertStringEndsWith('.png', $attachments[1]->getUrl());
+	}
+
+	public function testConvertPublishedIgnoresUnparsableDates(): void {
+		$stream = new Stream();
+		$stream->setPublished('not a date');
+
+		$stream->convertPublished();
+
+		$this->assertSame(0, $stream->getPublishedTime());
+	}
+
+	public function testExportAsActivityPubAddsTheStreamFields(): void {
+		$stream = new Note();
+		$stream->setId('https://cloud.example.org/apps/social/@alice/1')
+			->setContent('<p>hi</p>')
+			->setInReplyTo('https://mastodon.social/users/bob/statuses/2')
+			->setSensitive(true)
+			->setConversation('https://cloud.example.org/conv/1')
+			->setAttributedTo('@alice')
+			->setUrlSocial('https://cloud.example.org/apps/social/');
+
+		$export = $stream->exportAsActivityPub();
+
+		$this->assertSame('<p>hi</p>', $export['content']);
+		$this->assertSame('https://cloud.example.org/apps/social/@alice', $export['attributedTo']);
+		$this->assertSame('https://mastodon.social/users/bob/statuses/2', $export['inReplyTo']);
+		$this->assertTrue($export['sensitive']);
+		$this->assertSame('https://cloud.example.org/conv/1', $export['conversation']);
+		$this->assertArrayNotHasKey('details', $export);
+		$this->assertArrayNotHasKey('publishedTime', $export);
+	}
+
+	public function testExportAsActivityPubAddsInternalsOnlyWithCompleteDetails(): void {
+		$stream = new Note();
+		$stream->setPublishedTime(1714564800)
+			->setCompleteDetails(true);
+		$stream->setDetailInt('likes', 3);
+
+		$export = $stream->exportAsActivityPub();
+
+		$this->assertSame(['likes' => 3], $export['details']);
+		$this->assertSame(1714564800, $export['publishedTime']);
+		$this->assertArrayNotHasKey('action', $export, 'an unset action is dropped');
+		$this->assertArrayNotHasKey('cache', $export, 'an unset cache is dropped');
+		$this->assertSame('', $export['attributedTo'] ?? '', 'empty attributedTo stays out');
+	}
+
+	public function testExportAsLocalProducesAMastodonStatus(): void {
+		$actor = new Person();
+		$actor->setNid(3)
+			->setPreferredUsername('alice')
+			->setName('Alice')
+			->setLocal(true);
+
+		$action = new StreamAction();
+		$action->updateValueBool(StreamAction::LIKED, true);
+		$action->updateValueBool(StreamAction::BOOSTED, false);
+
+		$stream = new Note();
+		$stream->setId('https://cloud.example.org/apps/social/@alice/1')
+			->setNid(7)
+			->setContent('<p>hi</p>')
+			->setSensitive(true)
+			->setSpoilerText('cw')
+			->setVisibility(Stream::TYPE_PUBLIC)
+			->setLanguage('de')
+			->setPublishedTime(1714564800)
+			->setMentions([['id' => '3', 'username' => 'bob', 'url' => 'https://b.example/@bob', 'acct' => 'bob@b.example']])
+			->setLocal(true)
+			->setAction($action)
+			->setActor($actor);
+		$stream->setDetailInt('replies', 1);
+		$stream->setDetailInt('boosts', 2);
+		$stream->setDetailInt('likes', 5);
+
+		$status = $stream->exportAsLocal();
+
+		$this->assertSame('7', $status['id']);
+		$this->assertTrue($status['local']);
+		$this->assertSame('<p>hi</p>', $status['content']);
+		$this->assertTrue($status['sensitive']);
+		$this->assertSame('cw', $status['spoiler_text']);
+		$this->assertSame('public', $status['visibility']);
+		$this->assertSame('de', $status['language']);
+		$this->assertNull($status['in_reply_to_id']);
+		$this->assertSame('bob@b.example', $status['mentions'][0]['acct']);
+		$this->assertSame(1, $status['replies_count']);
+		$this->assertSame(2, $status['reblogs_count']);
+		$this->assertSame(5, $status['favourites_count']);
+		$this->assertTrue($status['favourited']);
+		$this->assertFalse($status['reblogged']);
+		$this->assertSame('https://cloud.example.org/apps/social/@alice/1', $status['uri']);
+		$this->assertSame('https://cloud.example.org/apps/social/@alice/1', $status['url']);
+		$this->assertNull($status['reblog']);
+		$this->assertSame([], $status['media_attachments']);
+		$this->assertSame('2024-05-01T12:00:00.000Z', $status['created_at']);
+		$this->assertSame('3', $status['account']['id']);
+		$this->assertSame('alice', $status['account']['username']);
+		$this->assertSame('alice', $status['account']['acct']);
+		$this->assertSame('Alice', $status['account']['display_name']);
+	}
+
+	public function testExportAsLocalWithoutActorHasNoAccount(): void {
+		$status = (new Note())->exportAsLocal();
+
+		$this->assertArrayNotHasKey('account', $status);
+		$this->assertFalse($status['favourited']);
+		$this->assertFalse($status['reblogged']);
+	}
+
+	public function notificationTypeProvider(): array {
+		return [
+			'like' => ['Like', 'favourite'],
+			'announce' => ['Announce', 'reblog'],
+			'mention' => ['Mention', 'mention'],
+			'follow' => ['Follow', 'follow'],
+			'other' => ['Create', ''],
+		];
+	}
+
+	/**
+	 * @dataProvider notificationTypeProvider
+	 */
+	public function testExportAsNotificationMapsTheSubTypeToMastodonTypes(string $subType, string $expected): void {
+		$actor = new Person();
+		$actor->setPreferredUsername('alice');
+		$status = new Note();
+		$stream = new Stream();
+		$stream->setNid(9)
+			->setSubType($subType)
+			->setPublishedTime(1714564800)
+			->setObject($status)
+			->setActor($actor);
+
+		$notification = $stream->exportAsNotification();
+
+		$this->assertSame('9', $notification['id']);
+		$this->assertSame($expected, $notification['type']);
+		$this->assertSame('2024-05-01T12:00:00.000Z', $notification['created_at']);
+		$this->assertSame($status, $notification['status']);
+		$this->assertSame('alice', $notification['account']['username']);
+	}
+
+	public function testJsonSerializeExposesTheAttachments(): void {
+		$media = (new MediaAttachment())->setId('4');
+		$stream = new Note();
+		$stream->setAttachments([$media]);
+
+		$this->assertSame([$media], $stream->jsonSerialize()['attachment']);
+	}
+
+	public function testImportFromLocalReadsAMastodonStatus(): void {
+		$stream = new Stream();
+
+		$stream->importFromLocal([
+			'id' => '123',
+			'url' => 'https://mastodon.social/@alice/123',
+			'local' => false,
+			'content' => '<p>hello</p>',
+			'sensitive' => true,
+			'spoiler_text' => 'cw',
+			'visibility' => 'unlisted',
+			'language' => 'de',
+			'favourited' => true,
+			'reblogged' => false,
+			'created_at' => '2024-05-01T12:00:00.000Z',
+			'media_attachments' => [
+				[
+					'id' => '55',
+					'type' => 'image',
+					'url' => 'https://files.mastodon.social/media/cat.jpg',
+					'preview_url' => 'https://files.mastodon.social/media/small/cat.jpg',
+					'remote_url' => null,
+					'description' => 'A cat',
+					'blurhash' => 'UBL_:rOp',
+					'meta' => ['original' => ['width' => 1200, 'height' => 800, 'size' => '1200x800'], 'small' => ['width' => 600, 'height' => 400], 'focus' => ['x' => 0, 'y' => 0]],
+				],
+			],
+			'mentions' => [['id' => '2', 'username' => 'bob', 'url' => 'https://b.example/@bob', 'acct' => 'bob@b.example']],
+			'account' => [
+				'id' => '31',
+				'username' => 'alice',
+				'acct' => 'alice@mastodon.social',
+				'display_name' => 'Alice W.',
+				'locked' => true,
+				'bot' => false,
+				'discoverable' => true,
+				'note' => '<p>bio</p>',
+				'url' => 'https://mastodon.social/@alice',
+				'avatar' => 'https://files.mastodon.social/avatars/alice.png',
+				'header' => 'https://files.mastodon.social/headers/alice.jpg',
+				'followers_count' => 10,
+				'following_count' => 5,
+				'statuses_count' => 42,
+				'created_at' => '2019-01-01T00:00:00.000Z',
+				'source' => ['privacy' => 'unlisted', 'sensitive' => true, 'language' => 'fr'],
+			],
+		]);
+
+		$this->assertSame(123, $stream->getNid());
+		$this->assertSame('https://mastodon.social/@alice/123', $stream->getId());
+		$this->assertSame('https://mastodon.social/@alice/123', $stream->getUrl());
+		$this->assertFalse($stream->isLocal());
+		$this->assertSame('<p>hello</p>', $stream->getContent());
+		$this->assertTrue($stream->isSensitive());
+		$this->assertSame('cw', $stream->getSpoilerText());
+		$this->assertSame('unlisted', $stream->getVisibility());
+		$this->assertSame('de', $stream->getLanguage());
+		$this->assertSame(1714564800, $stream->getPublishedTime());
+		$this->assertTrue($stream->getAction()->getValueBool(StreamAction::LIKED));
+		$this->assertFalse($stream->getAction()->getValueBool(StreamAction::BOOSTED));
+
+		$attachments = $stream->getAttachments();
+		$this->assertCount(1, $attachments);
+		$this->assertInstanceOf(MediaAttachment::class, $attachments[0]);
+		$this->assertSame('55', $attachments[0]->getId());
+		$this->assertSame('A cat', $attachments[0]->getDescription());
+		$this->assertSame(1200, $attachments[0]->getMeta()->getOriginal()->getWidth());
+		$this->assertSame('bob@b.example', $stream->getMentions()[0]['acct']);
+
+		$actor = $stream->getActor();
+		$this->assertSame(31, $actor->getNid());
+		$this->assertSame('alice', $actor->getPreferredUsername());
+		$this->assertSame('alice@mastodon.social', $actor->getAccount());
+		$this->assertSame('Alice W.', $actor->getDisplayName());
+		$this->assertTrue($actor->isLocked());
+		$this->assertFalse($actor->isBot());
+		$this->assertTrue($actor->isDiscoverable());
+		$this->assertSame('<p>bio</p>', $actor->getDescription());
+		$this->assertSame('https://files.mastodon.social/avatars/alice.png', $actor->getAvatar());
+		$this->assertSame('https://files.mastodon.social/headers/alice.jpg', $actor->getHeader());
+		$this->assertSame('unlisted', $actor->getPrivacy());
+		$this->assertTrue($actor->isSensitive());
+		$this->assertSame('fr', $actor->getLanguage());
+		$this->assertSame(1546300800, $actor->getCreation());
+		$this->assertSame(10, $actor->getDetails('count')['followers']);
+		$this->assertSame(42, $actor->getDetails('count')['post']);
+		$this->assertSame(ACore::FORMAT_LOCAL, $actor->getExportFormat());
+	}
+
+	public function testImportFromDatabaseFillsRemoteCountsFromTheSource(): void {
+		$stream = new Stream();
+
+		$stream->importFromDatabase([
+			'id' => 'https://mastodon.social/users/alice/statuses/1',
+			'type' => 'Note',
+			'published_time' => '2024-05-01 12:00:00',
+			'content' => '<p onclick="x()">hello</p>',
+			'visibility' => 'unlisted',
+			'details' => '{}',
+			'filter_duplicate' => '1',
+			'source' => '{"likes":{"totalItems":4},"shares":{"totalItems":2},"replies":{"totalItems":1}}',
+			'cache' => '{"_items":["https://a.example/1"],"https://a.example/1":{"url":"https://a.example/1","content":"{}","status":200}}',
+		]);
+
+		$this->assertSame(1714564800, $stream->getPublishedTime());
+		$this->assertSame('<p>hello</p>', $stream->getContent());
+		$this->assertSame('unlisted', $stream->getVisibility());
+		$this->assertTrue($stream->isFilterDuplicate());
+		$this->assertSame(4, $stream->getDetailInt('remote_likes'));
+		$this->assertSame(4, $stream->getDetailInt('likes'));
+		$this->assertSame(2, $stream->getDetailInt('remote_boosts'));
+		$this->assertSame(2, $stream->getDetailInt('boosts'));
+		$this->assertSame(1, $stream->getDetailInt('replies'));
+		$this->assertTrue($stream->hasCache());
+		$this->assertTrue($stream->getCache()->hasItem('https://a.example/1'));
+		$this->assertSame(200, $stream->getCache()->getItem('https://a.example/1')->getStatus());
+	}
+
+	public function testImportFromDatabaseKeepsLocalCountsWhenTheyExist(): void {
+		$stream = new Stream();
+
+		$stream->importFromDatabase([
+			'id' => 'https://mastodon.social/users/alice/statuses/1',
+			'type' => 'Note',
+			'details' => '{"likes":9,"remote_boosts":1,"boosts":1,"mentions":[{"acct":"bob@b.example"}]}',
+			'source' => '{"likes":{"totalItems":4},"shares":{"totalItems":7}}',
+		]);
+
+		$this->assertSame(9, $stream->getDetailInt('likes'), 'local likes are not overwritten by the remote total');
+		$this->assertSame(4, $stream->getDetailInt('remote_likes'));
+		$this->assertSame(1, $stream->getDetailInt('remote_boosts'), 'already known remote boosts stay');
+		$this->assertSame([['acct' => 'bob@b.example']], $stream->getMentions());
+	}
+
+	public function testAddCacheItemCreatesTheCacheOnDemandAndIgnoresDuplicates(): void {
+		$stream = new Stream();
+		$this->assertFalse($stream->hasCache());
+
+		$stream->addCacheItem('https://a.example/1');
+		$stream->addCacheItem('https://a.example/1');
+		$stream->addCacheItem('https://a.example/2');
+
+		$this->assertTrue($stream->hasCache());
+		$this->assertCount(2, $stream->getCache()->getItems());
+	}
+}

--- a/tests/Model/Client/AttachmentMetaDimTest.php
+++ b/tests/Model/Client/AttachmentMetaDimTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model\Client;
+
+use OCA\Social\Model\Client\AttachmentMetaDim;
+use PHPUnit\Framework\TestCase;
+
+class AttachmentMetaDimTest extends TestCase {
+	public function testConstructorDerivesSizeAndAspectFromWidthAndHeight(): void {
+		$dim = new AttachmentMetaDim([1200, 800]);
+
+		$this->assertSame(1200, $dim->getWidth());
+		$this->assertSame(800, $dim->getHeight());
+		$this->assertSame('1200x800', $dim->getSize());
+		$this->assertSame(1.5, $dim->getAspect());
+	}
+
+	public function emptyDimensionProvider(): array {
+		return [
+			'no dimensions' => [[]],
+			'one value' => [[100]],
+			'zero width' => [[0, 100]],
+			'negative height' => [[100, -1]],
+			'strings' => [['0', '0']],
+		];
+	}
+
+	/**
+	 * @dataProvider emptyDimensionProvider
+	 */
+	public function testConstructorLeavesUnusableDimensionsEmpty(array $dimensions): void {
+		$dim = new AttachmentMetaDim($dimensions);
+
+		$this->assertNull($dim->getWidth());
+		$this->assertNull($dim->getHeight());
+		$this->assertSame('', $dim->getSize());
+		$this->assertNull($dim->getAspect());
+	}
+
+	public function testImportReadsTheMastodonFields(): void {
+		$dim = new AttachmentMetaDim();
+
+		$dim->import(['width' => 640, 'height' => 480, 'size' => '640x480', 'aspect' => 2, 'duration' => 12, 'bitrate' => 96000, 'frame_rate' => '30']);
+
+		$this->assertSame(640, $dim->getWidth());
+		$this->assertSame(480, $dim->getHeight());
+		$this->assertSame('640x480', $dim->getSize());
+		$this->assertSame(2.0, $dim->getAspect());
+		$this->assertSame(12.0, $dim->getDuration());
+		$this->assertSame(96000.0, $dim->getBitrate());
+		$this->assertSame(30.0, $dim->getFrameRate());
+	}
+
+	public function testJsonSerializeDropsEmptyValues(): void {
+		$this->assertSame([], (new AttachmentMetaDim())->jsonSerialize());
+		$this->assertSame(
+			['width' => 1200, 'height' => 800, 'size' => '1200x800', 'aspect' => 1.5],
+			(new AttachmentMetaDim([1200, 800]))->jsonSerialize()
+		);
+	}
+}

--- a/tests/Model/Client/AttachmentMetaFocusTest.php
+++ b/tests/Model/Client/AttachmentMetaFocusTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model\Client;
+
+use OCA\Social\Model\Client\AttachmentMetaFocus;
+use PHPUnit\Framework\TestCase;
+
+class AttachmentMetaFocusTest extends TestCase {
+	public function testDefaultsToTheCenter(): void {
+		$focus = new AttachmentMetaFocus();
+
+		$this->assertSame(0.0, $focus->getX());
+		$this->assertSame(0.0, $focus->getY());
+		$this->assertSame(['x' => 0.0, 'y' => 0.0], $focus->jsonSerialize());
+	}
+
+	public function testCoordinatesCanBeSet(): void {
+		$focus = new AttachmentMetaFocus(0.5, -0.25);
+
+		$this->assertSame(0.5, $focus->getX());
+		$this->assertSame(-0.25, $focus->getY());
+
+		$focus->setX(-1)->setY(1);
+		$this->assertSame(['x' => -1.0, 'y' => 1.0], $focus->jsonSerialize());
+	}
+}

--- a/tests/Model/Client/AttachmentMetaTest.php
+++ b/tests/Model/Client/AttachmentMetaTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model\Client;
+
+use OCA\Social\Model\Client\AttachmentMeta;
+use OCA\Social\Model\Client\AttachmentMetaDim;
+use OCA\Social\Model\Client\AttachmentMetaFocus;
+use PHPUnit\Framework\TestCase;
+
+class AttachmentMetaTest extends TestCase {
+	public function testImportReadsMastodonMetaWithNestedDimensionsAndFocus(): void {
+		$meta = new AttachmentMeta();
+
+		$meta->import([
+			'width' => 1200,
+			'height' => 800,
+			'size' => '1200x800',
+			'length' => '0:00:12.5',
+			'fps' => 30,
+			'audio_encode' => 'aac',
+			'audio_bitrate' => '128 kb/s',
+			'audio_channels' => 'stereo',
+			'description' => 'A cat',
+			'blurhash' => 'UBL_:rOp',
+			'original' => ['width' => 1200, 'height' => 800, 'size' => '1200x800', 'frame_rate' => '30'],
+			'small' => ['width' => 600, 'height' => 400, 'size' => '600x400'],
+			'focus' => ['x' => 1, 'y' => -1],
+		]);
+
+		$this->assertSame(1200, $meta->getWidth());
+		$this->assertSame(800, $meta->getHeight());
+		$this->assertSame('1200x800', $meta->getSize());
+		$this->assertSame('0:00:12.5', $meta->getLength());
+		$this->assertSame(30.0, $meta->getFps());
+		$this->assertSame('aac', $meta->getAudioEncode());
+		$this->assertSame('128 kb/s', $meta->getAudioBitrate());
+		$this->assertSame('stereo', $meta->getAudioChannels());
+		$this->assertSame('A cat', $meta->getDescription());
+		$this->assertSame('UBL_:rOp', $meta->getBlurHash());
+		$this->assertSame(1200, $meta->getOriginal()->getWidth());
+		$this->assertSame(30.0, $meta->getOriginal()->getFrameRate());
+		$this->assertSame('600x400', $meta->getSmall()->getSize());
+		$this->assertSame(1.0, $meta->getFocus()->getX());
+		$this->assertSame(-1.0, $meta->getFocus()->getY());
+	}
+
+	public function testImportLeavesOptionalNumbersNullWhenAbsent(): void {
+		$meta = new AttachmentMeta();
+
+		$meta->import(['size' => '1x1']);
+
+		$this->assertNull($meta->getWidth());
+		$this->assertNull($meta->getHeight());
+		$this->assertNull($meta->getAspect());
+		$this->assertNull($meta->getDuration());
+		$this->assertSame(0.0, $meta->getFocus()->getX());
+	}
+
+	public function testJsonSerializeDropsUnsetValues(): void {
+		$meta = new AttachmentMeta();
+		$meta->setOriginal(new AttachmentMetaDim([1200, 800]))
+			->setSmall(new AttachmentMetaDim([600, 400]))
+			->setFocus(new AttachmentMetaFocus(0, 0))
+			->setDescription('A cat');
+
+		$json = $meta->jsonSerialize();
+
+		$this->assertSame(['original', 'small', 'focus', 'description'], array_keys($json));
+		$this->assertSame('A cat', $json['description']);
+		$this->assertSame(1200, $json['original']->getWidth());
+	}
+
+	public function testSettersRoundTrip(): void {
+		$meta = new AttachmentMeta();
+
+		$meta->setWidth(10)->setHeight(5)->setAspect(2.0)->setDuration(1.5)->setFps(24.0)->setLength('0:01')->setBlurHash('x');
+
+		$this->assertSame(10, $meta->getWidth());
+		$this->assertSame(5, $meta->getHeight());
+		$this->assertSame(2.0, $meta->getAspect());
+		$this->assertSame(1.5, $meta->getDuration());
+		$this->assertSame(24.0, $meta->getFps());
+		$this->assertSame('0:01', $meta->getLength());
+		$this->assertSame('x', $meta->getBlurHash());
+	}
+}

--- a/tests/Model/Client/MediaAttachmentTest.php
+++ b/tests/Model/Client/MediaAttachmentTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model\Client;
+
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\Client\AttachmentMeta;
+use OCA\Social\Model\Client\MediaAttachment;
+use PHPUnit\Framework\TestCase;
+
+class MediaAttachmentTest extends TestCase {
+	private function mastodonAttachment(): array {
+		return [
+			'id' => '55',
+			'type' => 'image',
+			'url' => 'https://files.mastodon.social/media/cat.jpg',
+			'preview_url' => 'https://files.mastodon.social/media/small/cat.jpg',
+			'remote_url' => 'https://remote.example/media/cat.jpg',
+			'text_url' => null,
+			'description' => 'A cat',
+			'blurhash' => 'UBL_:rOp',
+			'meta' => [
+				'original' => ['width' => 1200, 'height' => 800, 'size' => '1200x800'],
+				'small' => ['width' => 600, 'height' => 400, 'size' => '600x400'],
+				'focus' => ['x' => 0, 'y' => 0],
+			],
+		];
+	}
+
+	public function testImportReadsAMastodonMediaAttachment(): void {
+		$media = new MediaAttachment();
+
+		$result = $media->import($this->mastodonAttachment());
+
+		$this->assertSame($media, $result);
+		$this->assertSame('55', $media->getId());
+		$this->assertSame('image', $media->getType());
+		$this->assertSame('https://files.mastodon.social/media/cat.jpg', $media->getUrl());
+		$this->assertSame('https://files.mastodon.social/media/small/cat.jpg', $media->getPreviewUrl());
+		$this->assertSame('https://remote.example/media/cat.jpg', $media->getRemoteUrl());
+		$this->assertSame('A cat', $media->getDescription());
+		$this->assertSame('UBL_:rOp', $media->getBlurHash());
+		$this->assertInstanceOf(AttachmentMeta::class, $media->getMeta());
+		$this->assertSame(1200, $media->getMeta()->getOriginal()->getWidth());
+		$this->assertSame(400, $media->getMeta()->getSmall()->getHeight());
+	}
+
+	public function testAsLocalDropsEmptyFieldsAndKeepsTheMeta(): void {
+		$media = new MediaAttachment();
+		$media->import($this->mastodonAttachment());
+		$media->setDescription('');
+
+		$local = $media->asLocal();
+
+		$this->assertSame('55', $local['id']);
+		$this->assertSame('image', $local['type']);
+		$this->assertSame('https://files.mastodon.social/media/cat.jpg', $local['url']);
+		$this->assertSame('https://remote.example/media/cat.jpg', $local['remote_url']);
+		$this->assertSame($media->getMeta(), $local['meta']);
+		$this->assertArrayNotHasKey('description', $local);
+		$this->assertSame('UBL_:rOp', $local['blurhash']);
+	}
+
+	public function testAsDocumentBuildsAnActivityPubDocument(): void {
+		$media = new MediaAttachment();
+		$media->import($this->mastodonAttachment());
+
+		$this->assertSame([
+			'type' => 'Document',
+			'mediaType' => '',
+			'url' => 'https://files.mastodon.social/media/cat.jpg',
+			'name' => null,
+			'blurhash' => 'UBL_:rOp',
+			'width' => 1200,
+			'height' => 800,
+		], $media->asDocument());
+	}
+
+	public function testAsDocumentWithoutDimensionsUsesZero(): void {
+		$media = new MediaAttachment();
+		$media->import(['id' => '1', 'url' => 'https://a.example/x.png']);
+
+		$document = $media->asDocument();
+
+		$this->assertSame(0, $document['width']);
+		$this->assertSame(0, $document['height']);
+	}
+
+	public function testJsonSerializeFollowsTheExportFormat(): void {
+		$media = new MediaAttachment();
+		$media->import($this->mastodonAttachment());
+
+		$this->assertSame(ACore::FORMAT_LOCAL, $media->getExportFormat());
+		$this->assertSame($media->asLocal(), $media->jsonSerialize());
+
+		$media->setExportFormat(ACore::FORMAT_ACTIVITYPUB);
+		$this->assertSame($media->asDocument(), $media->jsonSerialize());
+	}
+}

--- a/tests/Model/Client/Options/CoreOptionsTest.php
+++ b/tests/Model/Client/Options/CoreOptionsTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model\Client\Options;
+
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\Client\Options\CoreOptions;
+use PHPUnit\Framework\TestCase;
+
+class CoreOptionsTest extends TestCase {
+	public function testDefaultsToTheActivityPubFormat(): void {
+		$this->assertSame(ACore::FORMAT_ACTIVITYPUB, (new CoreOptions())->getFormat());
+	}
+
+	public function testFormatCanBeSwitched(): void {
+		$options = new CoreOptions();
+
+		$this->assertSame($options, $options->setFormat(ACore::FORMAT_LOCAL));
+		$this->assertSame(ACore::FORMAT_LOCAL, $options->getFormat());
+	}
+}

--- a/tests/Model/Client/Options/ProbeOptionsTest.php
+++ b/tests/Model/Client/Options/ProbeOptionsTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model\Client\Options;
+
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\Client\Options\ProbeOptions;
+use OCP\IRequest;
+use PHPUnit\Framework\TestCase;
+
+class ProbeOptionsTest extends TestCase {
+	public function testDefaultsMatchTheMastodonTimelineDefaults(): void {
+		$options = new ProbeOptions();
+
+		$this->assertSame('', $options->getProbe());
+		$this->assertFalse($options->isLocal());
+		$this->assertFalse($options->isRemote());
+		$this->assertFalse($options->isOnlyMedia());
+		$this->assertSame(0, $options->getMinId());
+		$this->assertSame(0, $options->getMaxId());
+		$this->assertSame(0, $options->getSince());
+		$this->assertSame(20, $options->getLimit());
+		$this->assertFalse($options->isInverted());
+		$this->assertSame(ACore::FORMAT_ACTIVITYPUB, $options->getFormat());
+	}
+
+	public function testFromArrayReadsTheQueryParametersAsStrings(): void {
+		$options = new ProbeOptions();
+
+		$options->fromArray([
+			'local' => 'true',
+			'remote' => '0',
+			'only_media' => '1',
+			'min_id' => '10',
+			'max_id' => '99',
+			'since' => '5',
+			'limit' => '40',
+			'argument' => 'nextcloud',
+		]);
+
+		$this->assertTrue($options->isLocal());
+		$this->assertFalse($options->isRemote());
+		$this->assertTrue($options->isOnlyMedia());
+		$this->assertSame(10, $options->getMinId());
+		$this->assertSame(99, $options->getMaxId());
+		$this->assertSame(5, $options->getSince());
+		$this->assertSame(40, $options->getLimit());
+		$this->assertSame('nextcloud', $options->getArgument());
+	}
+
+	public function testFromArrayKeepsCurrentValuesForMissingParameters(): void {
+		$options = new ProbeOptions();
+		$options->setLimit(7)->setLocal(true)->setArgument('cats');
+
+		$options->fromArray(['max_id' => '3']);
+
+		$this->assertSame(7, $options->getLimit());
+		$this->assertTrue($options->isLocal());
+		$this->assertSame('cats', $options->getArgument());
+		$this->assertSame(3, $options->getMaxId());
+	}
+
+	public function testConstructorReadsTheRequestParameters(): void {
+		$request = $this->createMock(IRequest::class);
+		$request->method('getParams')->willReturn(['limit' => '15', 'local' => 'true']);
+
+		$options = new ProbeOptions($request);
+
+		$this->assertSame(15, $options->getLimit());
+		$this->assertTrue($options->isLocal());
+	}
+
+	public function testProbeIsLowercased(): void {
+		$options = new ProbeOptions();
+
+		$options->setProbe('Home');
+
+		$this->assertSame(ProbeOptions::HOME, $options->getProbe());
+	}
+
+	public function testJsonSerializeExposesTheProbeState(): void {
+		$options = new ProbeOptions();
+		$options->setProbe(ProbeOptions::HASHTAG)
+			->setAccountId('3')
+			->setArgument('nextcloud')
+			->setLimit(5)
+			->setTypes(['Note'])
+			->setExcludeTypes(['Announce'])
+			->setInverted(true);
+
+		$this->assertSame([
+			'probe' => 'hashtag',
+			'accountId' => '3',
+			'local' => false,
+			'remote' => false,
+			'only_media' => false,
+			'min_id' => 0,
+			'max_id' => 0,
+			'since' => 0,
+			'limit' => 5,
+			'argument' => 'nextcloud',
+		], $options->jsonSerialize());
+		$this->assertSame(['Note'], $options->getTypes());
+		$this->assertSame(['Announce'], $options->getExcludeTypes());
+		$this->assertTrue($options->isInverted());
+	}
+}

--- a/tests/Model/Client/SocialClientTest.php
+++ b/tests/Model/Client/SocialClientTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model\Client;
+
+use OCA\Social\Model\Client\SocialClient;
+use PHPUnit\Framework\TestCase;
+
+class SocialClientTest extends TestCase {
+	public function scopeProvider(): array {
+		return [
+			'mastodon default scopes' => ['read write follow', ['read', 'write', 'follow']],
+			'single scope' => ['read', ['read']],
+			'granular scopes' => ['read:accounts write:statuses', ['read:accounts', 'write:statuses']],
+		];
+	}
+
+	/**
+	 * @dataProvider scopeProvider
+	 */
+	public function testGetScopesFromStringSplitsOnSpaces(string $scopes, array $expected): void {
+		$this->assertSame($expected, (new SocialClient())->getScopesFromString($scopes));
+	}
+
+	public function testImportFromDatabaseReadsTheClientRow(): void {
+		$client = new SocialClient();
+
+		$client->importFromDatabase([
+			'id' => '4',
+			'app_name' => 'Tusky',
+			'app_website' => 'https://tusky.app',
+			'app_redirect_uris' => '["urn:ietf:wg:oauth:2.0:oob"]',
+			'app_client_id' => 'client-id',
+			'app_client_secret' => 'client-secret',
+			'app_scopes' => '["read","write"]',
+			'auth_scopes' => '["read"]',
+			'auth_account' => 'alice',
+			'auth_user_id' => 'alice',
+			'auth_code' => 'code-123',
+			'token' => 'token-456',
+			'last_update' => '2024-05-01 12:00:00',
+			'creation' => 1714500000,
+		]);
+
+		$this->assertSame(4, $client->getId());
+		$this->assertSame('Tusky', $client->getAppName());
+		$this->assertSame('https://tusky.app', $client->getAppWebsite());
+		$this->assertSame(['urn:ietf:wg:oauth:2.0:oob'], $client->getAppRedirectUris());
+		$this->assertSame('client-id', $client->getAppClientId());
+		$this->assertSame('client-secret', $client->getAppClientSecret());
+		$this->assertSame(['read', 'write'], $client->getAppScopes());
+		$this->assertSame(['read'], $client->getAuthScopes());
+		$this->assertSame('alice', $client->getAuthAccount());
+		$this->assertSame('alice', $client->getAuthUserId());
+		$this->assertSame('code-123', $client->getAuthCode());
+		$this->assertSame('token-456', $client->getToken());
+		$this->assertSame((new \DateTime('2024-05-01 12:00:00'))->getTimestamp(), $client->getLastUpdate());
+		$this->assertSame(1714500000, $client->getCreation());
+	}
+
+	public function testJsonSerializeUsesTheDatabaseColumnNames(): void {
+		$client = new SocialClient();
+		$client->setId(4)
+			->setAppName('Tusky')
+			->setAppScopes(['read'])
+			->setAppClientId('id')
+			->setAppClientSecret('secret')
+			->setAppRedirectUris(['urn:ietf:wg:oauth:2.0:oob'])
+			->setAuthScopes(['read'])
+			->setAuthAccount('alice')
+			->setAuthUserId('alice')
+			->setAuthCode('code')
+			->setToken('token')
+			->setLastUpdate(1714564800);
+		$client->setCreation(1714500000);
+
+		$this->assertSame([
+			'id' => 4,
+			'app_name' => 'Tusky',
+			'app_website' => '',
+			'app_scopes' => ['read'],
+			'app_client_id' => 'id',
+			'app_client_secret' => 'secret',
+			'app_redirect_uris' => ['urn:ietf:wg:oauth:2.0:oob'],
+			'auth_scopes' => ['read'],
+			'auth_account' => 'alice',
+			'auth_user_id' => 'alice',
+			'auth_code' => 'code',
+			'token' => 'token',
+			'last_update' => 1714564800,
+			'creation' => 1714500000,
+		], $client->jsonSerialize());
+	}
+
+	public function testTimestampsDefaultToMinusOne(): void {
+		$client = new SocialClient();
+
+		$this->assertSame(-1, $client->getLastUpdate());
+		$this->assertSame(-1, $client->getCreation());
+	}
+}

--- a/tests/Model/Client/StatusTest.php
+++ b/tests/Model/Client/StatusTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model\Client;
+
+use OCA\Social\Model\Client\Status;
+use PHPUnit\Framework\TestCase;
+
+class StatusTest extends TestCase {
+	public function testImportReadsTheMastodonPostStatusesParameters(): void {
+		$status = new Status();
+
+		$result = $status->import([
+			'status' => 'Hello @bob #nextcloud',
+			'visibility' => 'unlisted',
+			'spoiler_text' => 'cw',
+			'sensitive' => 'true',
+			'media_ids' => ['12', '13'],
+			'in_reply_to_id' => '99',
+			'content_type' => 'text/markdown',
+			'language' => 'de',
+		]);
+
+		$this->assertSame($status, $result);
+		$this->assertSame('Hello @bob #nextcloud', $status->getStatus());
+		$this->assertSame('unlisted', $status->getVisibility());
+		$this->assertSame('cw', $status->getSpoilerText());
+		$this->assertTrue($status->isSensitive());
+		$this->assertSame([12, 13], $status->getMediaIds());
+		$this->assertSame(99, $status->getInReplyToId());
+		$this->assertSame('text/markdown', $status->getContentType());
+	}
+
+	public function testImportAcceptsJsonEncodedMediaIdsAndBooleanSensitive(): void {
+		$status = new Status();
+
+		$status->import(['status' => 'x', 'sensitive' => false, 'media_ids' => '["7"]']);
+
+		$this->assertFalse($status->isSensitive());
+		$this->assertSame([7], $status->getMediaIds());
+	}
+
+	public function testImportOfAnEmptyRequestKeepsTheDefaults(): void {
+		$status = new Status();
+
+		$status->import([]);
+
+		$this->assertSame('', $status->getStatus());
+		$this->assertSame('', $status->getVisibility());
+		$this->assertSame('', $status->getSpoilerText());
+		$this->assertFalse($status->isSensitive());
+		$this->assertSame([], $status->getMediaIds());
+		$this->assertSame(0, $status->getInReplyToId());
+	}
+
+	public function testJsonSerializeExposesTheImportedValues(): void {
+		$status = new Status();
+		$status->setStatus('hi')
+			->setVisibility('public')
+			->setSpoilerText('')
+			->setSensitive(true)
+			->setMediaIds(['3'])
+			->setContentType('text/plain');
+
+		$this->assertSame([
+			'contentType' => 'text/plain',
+			'sensitive' => true,
+			'mediaIds' => [3],
+			'visibility' => 'public',
+			'spoilerText' => '',
+			'status' => 'hi',
+		], $status->jsonSerialize());
+	}
+}

--- a/tests/Model/InstancePathTest.php
+++ b/tests/Model/InstancePathTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model;
+
+use OCA\Social\Model\InstancePath;
+use PHPUnit\Framework\TestCase;
+
+class InstancePathTest extends TestCase {
+	public function uriProvider(): array {
+		return [
+			'shared inbox' => ['https://mastodon.social/inbox', 'https', 'mastodon.social', '/inbox'],
+			'user inbox with port' => ['http://localhost:8080/users/alice/inbox', 'http', 'localhost', '/users/alice/inbox'],
+			'host only' => ['https://mastodon.social', 'https', 'mastodon.social', ''],
+			'empty' => ['', '', '', ''],
+		];
+	}
+
+	/**
+	 * @dataProvider uriProvider
+	 */
+	public function testUriIsSplitIntoProtocolAddressAndPath(string $uri, string $protocol, string $address, string $path): void {
+		$instance = new InstancePath($uri);
+
+		$this->assertSame($protocol, $instance->getProtocol());
+		$this->assertSame($address, $instance->getAddress());
+		$this->assertSame($path, $instance->getPath());
+	}
+
+	public function testConstructorDefaultsToPublicTypeAndNoPriority(): void {
+		$instance = new InstancePath('https://mastodon.social/inbox');
+
+		$this->assertSame(InstancePath::TYPE_PUBLIC, $instance->getType());
+		$this->assertSame(InstancePath::PRIORITY_NONE, $instance->getPriority());
+	}
+
+	public function testImportAndJsonSerializeRoundTrip(): void {
+		$instance = new InstancePath();
+
+		$instance->import(['uri' => 'https://mastodon.social/inbox', 'type' => '3', 'priority' => '4']);
+
+		$this->assertSame('https://mastodon.social/inbox', $instance->getUri());
+		$this->assertSame(InstancePath::TYPE_FOLLOWERS, $instance->getType());
+		$this->assertSame(InstancePath::PRIORITY_TOP, $instance->getPriority());
+		$this->assertSame(
+			['uri' => 'https://mastodon.social/inbox', 'type' => 3, 'priority' => 4],
+			$instance->jsonSerialize()
+		);
+	}
+
+	public function testSettersAreFluent(): void {
+		$instance = (new InstancePath())
+			->setUri('https://a.example/inbox')
+			->setType(InstancePath::TYPE_INBOX)
+			->setPriority(InstancePath::PRIORITY_MEDIUM);
+
+		$this->assertSame('https://a.example/inbox', $instance->getUri());
+		$this->assertSame(1, $instance->getType());
+		$this->assertSame(2, $instance->getPriority());
+	}
+}

--- a/tests/Model/InstanceTest.php
+++ b/tests/Model/InstanceTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model;
+
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\Instance;
+use PHPUnit\Framework\TestCase;
+
+class InstanceTest extends TestCase {
+	public function testImportFromDatabaseReadsTheRowIncludingJsonColumns(): void {
+		$instance = new Instance();
+
+		$result = $instance->importFromDatabase([
+			'local' => '1',
+			'uri' => 'cloud.example.org',
+			'title' => 'Nextcloud Social',
+			'version' => '0.7.0',
+			'short_description' => 'short',
+			'description' => 'long',
+			'email' => 'admin@cloud.example.org',
+			'urls' => '{"streaming_api":"wss://cloud.example.org"}',
+			'stats' => '{"user_count":3,"status_count":10,"domain_count":2}',
+			'usage' => '{"users":{"active_month":2}}',
+			'image' => 'https://cloud.example.org/thumb.png',
+			'languages' => '["en","de"]',
+			'account_prim' => 'abc',
+		]);
+
+		$this->assertSame($instance, $result);
+		$this->assertTrue($instance->isLocal());
+		$this->assertSame('cloud.example.org', $instance->getUri());
+		$this->assertSame('Nextcloud Social', $instance->getTitle());
+		$this->assertSame('0.7.0', $instance->getVersion());
+		$this->assertSame('short', $instance->getShortDescription());
+		$this->assertSame('long', $instance->getDescription());
+		$this->assertSame('admin@cloud.example.org', $instance->getEmail());
+		$this->assertSame(['streaming_api' => 'wss://cloud.example.org'], $instance->getUrls());
+		$this->assertSame(['user_count' => 3, 'status_count' => 10, 'domain_count' => 2], $instance->getStats());
+		$this->assertSame(['users' => ['active_month' => 2]], $instance->getUsage());
+		$this->assertSame('https://cloud.example.org/thumb.png', $instance->getImage());
+		$this->assertSame(['en', 'de'], $instance->getLanguages());
+		$this->assertSame('abc', $instance->getAccountPrim());
+		$this->assertFalse($instance->hasContactAccount());
+	}
+
+	public function testJsonSerializeProducesTheMastodonInstanceEntity(): void {
+		$instance = (new Instance())
+			->setUri('cloud.example.org')
+			->setTitle('Nextcloud Social')
+			->setVersion('0.7.0')
+			->setShortDescription('short')
+			->setDescription('long')
+			->setEmail('admin@cloud.example.org')
+			->setUrls(['streaming_api' => 'wss://cloud.example.org'])
+			->setStats(['user_count' => 3])
+			->setImage('https://cloud.example.org/thumb.png')
+			->setLanguages(['en'])
+			->setRegistrations(true)
+			->setApprovalRequired(false)
+			->setInvitesEnabled(true);
+
+		$json = $instance->jsonSerialize();
+
+		$this->assertSame([
+			'uri' => 'cloud.example.org',
+			'title' => 'Nextcloud Social',
+			'version' => '0.7.0',
+			'short_description' => 'short',
+			'description' => 'long',
+			'email' => 'admin@cloud.example.org',
+			'urls' => ['streaming_api' => 'wss://cloud.example.org'],
+			'stats' => ['user_count' => 3],
+			'thumbnail' => 'https://cloud.example.org/thumb.png',
+			'languages' => ['en'],
+			'registrations' => true,
+			'approval_required' => false,
+			'invites_enabled' => true,
+		], $json);
+		$this->assertArrayNotHasKey('contact_account', $json);
+	}
+
+	public function testContactAccountIsExposedWhenSet(): void {
+		$admin = new Person();
+		$admin->setPreferredUsername('admin');
+		$instance = new Instance();
+
+		$instance->setContactAccount($admin);
+
+		$this->assertTrue($instance->hasContactAccount());
+		$this->assertSame($admin, $instance->getContactAccount());
+		$this->assertSame($admin, $instance->jsonSerialize()['contact_account']);
+	}
+
+	public function testAccountPrimIsNullUntilSet(): void {
+		$instance = new Instance();
+
+		$this->assertNull($instance->getAccountPrim());
+		$this->assertSame('abc', $instance->setAccountPrim('abc')->getAccountPrim());
+	}
+}

--- a/tests/Model/LinkedDataSignatureTest.php
+++ b/tests/Model/LinkedDataSignatureTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model;
+
+use OCA\Social\Exceptions\LinkedDataSignatureMissingException;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\LinkedDataSignature;
+use OCP\Files\AppData\IAppDataFactory;
+use OCP\Files\IAppData;
+use OCP\Files\SimpleFS\ISimpleFile;
+use OCP\Files\SimpleFS\ISimpleFolder;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * JSON-LD canonicalisation needs the remote @context documents; they are
+ * served from the copies bundled in context/ through a mocked app-data folder,
+ * so no network is touched.
+ */
+class LinkedDataSignatureTest extends TestCase {
+	private static string $privateKey;
+	private static string $publicKey;
+	private static string $otherPublicKey;
+
+	public static function setUpBeforeClass(): void {
+		[self::$privateKey, self::$publicKey] = self::generateKeyPair();
+		[, self::$otherPublicKey] = self::generateKeyPair();
+	}
+
+	/** @return array{0: string, 1: string} private and public PEM */
+	private static function generateKeyPair(): array {
+		$key = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+		openssl_pkey_export($key, $private);
+
+		return [$private, openssl_pkey_get_details($key)['key']];
+	}
+
+	protected function setUp(): void {
+		$folder = $this->createMock(ISimpleFolder::class);
+		$folder->method('getFile')->willReturnCallback(function (string $name): ISimpleFile {
+			$path = dirname(__DIR__, 2) . '/context/' . $name;
+			if (!is_file($path)) {
+				throw new \RuntimeException('no bundled context document for ' . $name);
+			}
+			$file = $this->createMock(ISimpleFile::class);
+			$file->method('getMTime')->willReturn(time());
+			$file->method('getContent')->willReturn(file_get_contents($path));
+
+			return $file;
+		});
+		$appData = $this->createMock(IAppData::class);
+		$appData->method('getFolder')->with('context')->willReturn($folder);
+		$factory = $this->createMock(IAppDataFactory::class);
+		$factory->method('get')->with('social')->willReturn($appData);
+		\OC::$server->register(IAppDataFactory::class, $factory);
+	}
+
+	protected function tearDown(): void {
+		\OC::$server->reset();
+	}
+
+	private function note(): array {
+		return [
+			'@context' => ACore::CONTEXT_ACTIVITYSTREAMS,
+			'id' => 'https://cloud.example.org/apps/social/@alice/1',
+			'type' => 'Note',
+			'attributedTo' => 'https://cloud.example.org/apps/social/@alice',
+			'to' => [ACore::CONTEXT_PUBLIC],
+			'content' => '<p>Signed hello</p>',
+			'published' => '2024-05-01T12:00:00Z',
+		];
+	}
+
+	private function signedNote(): LinkedDataSignature {
+		$signature = new LinkedDataSignature();
+		$signature->setType('RsaSignature2017')
+			->setCreator('https://cloud.example.org/apps/social/@alice#main-key')
+			->setCreated('2024-05-01T12:00:00Z')
+			->setPrivateKey(self::$privateKey)
+			->setObject($this->note());
+		$signature->sign();
+
+		return $signature;
+	}
+
+	public function testSignThenVerifyWithTheMatchingPublicKey(): void {
+		$signature = $this->signedNote();
+
+		$this->assertNotSame('', $signature->getSignatureValue());
+		$this->assertNotFalse(base64_decode($signature->getSignatureValue(), true));
+
+		$signature->setPublicKey(self::$publicKey);
+		$this->assertTrue($signature->verify());
+	}
+
+	public function testVerifyFailsWhenTheObjectWasTamperedWith(): void {
+		$signature = $this->signedNote();
+		$signature->setPublicKey(self::$publicKey);
+
+		$tampered = $signature->getObject();
+		$tampered['content'] = '<p>Something else</p>';
+		$signature->setObject($tampered);
+
+		$this->assertFalse($signature->verify());
+	}
+
+	public function testVerifyFailsWhenTheHeaderWasTamperedWith(): void {
+		$signature = $this->signedNote();
+		$signature->setPublicKey(self::$publicKey);
+
+		$signature->setCreated('2024-05-02T12:00:00Z');
+
+		$this->assertFalse($signature->verify());
+	}
+
+	public function testVerifyFailsWithAnotherKey(): void {
+		$signature = $this->signedNote();
+
+		$signature->setPublicKey(self::$otherPublicKey);
+
+		$this->assertFalse($signature->verify());
+	}
+
+	public function testASignedDocumentCanBeImportedAndVerified(): void {
+		$signed = $this->signedNote();
+		$document = $this->note();
+		$document['signature'] = $signed->jsonSerialize();
+
+		$received = new LinkedDataSignature();
+		$received->import($document);
+		$received->setPublicKey(self::$publicKey);
+
+		$this->assertSame('RsaSignature2017', $received->getType());
+		$this->assertSame('https://cloud.example.org/apps/social/@alice#main-key', $received->getCreator());
+		$this->assertSame('2024-05-01T12:00:00Z', $received->getCreated());
+		$this->assertSame($signed->getSignatureValue(), $received->getSignatureValue());
+		$this->assertSame($this->note(), $received->getObject(), 'the signature block is removed from the object');
+		$this->assertTrue($received->verify());
+	}
+
+	public function testImportReadsTheNonce(): void {
+		$signature = new LinkedDataSignature();
+
+		$signature->import([
+			'type' => 'Note',
+			'signature' => ['type' => 'RsaSignature2017', 'creator' => 'https://a.example/#key', 'created' => '2024-05-01T12:00:00Z', 'nonce' => 'abc', 'signatureValue' => 'Zm9v'],
+		]);
+
+		$this->assertSame('abc', $signature->getNonce());
+		$this->assertSame(['type' => 'Note'], $signature->getObject());
+	}
+
+	public function testImportRequiresASignatureBlock(): void {
+		$this->expectException(LinkedDataSignatureMissingException::class);
+
+		(new LinkedDataSignature())->import($this->note());
+	}
+
+	public function testJsonSerializeExposesTheSignatureBlock(): void {
+		$signature = new LinkedDataSignature();
+		$signature->setType('RsaSignature2017')
+			->setCreator('https://a.example/#key')
+			->setCreated('2024-05-01T12:00:00Z')
+			->setSignatureValue('Zm9v');
+
+		$this->assertSame([
+			'type' => 'RsaSignature2017',
+			'creator' => 'https://a.example/#key',
+			'created' => '2024-05-01T12:00:00Z',
+			'signatureValue' => 'Zm9v',
+		], $signature->jsonSerialize());
+	}
+}

--- a/tests/Model/PostTest.php
+++ b/tests/Model/PostTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model;
+
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Document;
+use OCA\Social\Model\ActivityPub\Stream;
+use OCA\Social\Model\Client\MediaAttachment;
+use OCA\Social\Model\Post;
+use PHPUnit\Framework\TestCase;
+
+class PostTest extends TestCase {
+	private function alice(): Person {
+		$alice = new Person();
+		$alice->setId('https://cloud.example.org/apps/social/@alice')
+			->setPreferredUsername('alice');
+
+		return $alice;
+	}
+
+	public function testConstructorStoresTheAuthor(): void {
+		$alice = $this->alice();
+
+		$post = new Post($alice);
+
+		$this->assertSame($alice, $post->getActor());
+		$this->assertSame([], $post->getTo());
+		$this->assertSame('', $post->getContent());
+	}
+
+	public function testAddToTrimsSkipsEmptyAndDeduplicates(): void {
+		$post = new Post($this->alice());
+
+		$post->addTo(' @bob@mastodon.social ')
+			->addTo('@bob@mastodon.social')
+			->addTo('')
+			->addTo('   ')
+			->addTo('@carol@remote.example');
+
+		$this->assertSame(['@bob@mastodon.social', '@carol@remote.example'], $post->getTo());
+
+		$post->setTo(['@dave@remote.example']);
+		$this->assertSame(['@dave@remote.example'], $post->getTo());
+	}
+
+	public function testAddHashtagTrimsSkipsEmptyAndDeduplicates(): void {
+		$post = new Post($this->alice());
+
+		$post->addHashtag(' nextcloud ')
+			->addHashtag('nextcloud')
+			->addHashtag('')
+			->addHashtag('fediverse');
+
+		$this->assertSame(['nextcloud', 'fediverse'], $post->getHashtags());
+
+		$post->setHashtags(['cats']);
+		$this->assertSame(['cats'], $post->getHashtags());
+	}
+
+	public function testContentReplyTypeAndAttachmentsAreStored(): void {
+		$post = new Post($this->alice());
+		$media = (new MediaAttachment())->setId('4');
+		$document = new Document();
+
+		$post->setContent('Hello world');
+		$post->setReplyTo('https://mastodon.social/users/bob/statuses/1')
+			->setType(Stream::TYPE_UNLISTED)
+			->setAttachments(['4'])
+			->setMedias([$media])
+			->setDocuments([$document]);
+
+		$this->assertSame('Hello world', $post->getContent());
+		$this->assertSame('https://mastodon.social/users/bob/statuses/1', $post->getReplyTo());
+		$this->assertSame('unlisted', $post->getType());
+		$this->assertSame(['4'], $post->getAttachments());
+		$this->assertSame([$media], $post->getMedias());
+		$this->assertSame([$document], $post->getDocuments());
+	}
+
+	public function testJsonSerializeDescribesThePost(): void {
+		$alice = $this->alice();
+		$post = new Post($alice);
+		$post->setContent('Hello #nextcloud');
+		$post->addTo('@bob@mastodon.social')
+			->addHashtag('nextcloud')
+			->setReplyTo('https://mastodon.social/users/bob/statuses/1')
+			->setType(Stream::TYPE_PUBLIC)
+			->setAttachments(['4']);
+
+		$this->assertSame([
+			'actor' => $alice,
+			'to' => ['@bob@mastodon.social'],
+			'replyTo' => 'https://mastodon.social/users/bob/statuses/1',
+			'content' => 'Hello #nextcloud',
+			'attachments' => ['4'],
+			'hashtags' => ['nextcloud'],
+			'type' => 'public',
+		], $post->jsonSerialize());
+	}
+}

--- a/tests/Model/RelationshipTest.php
+++ b/tests/Model/RelationshipTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model;
+
+use OCA\Social\Model\Relationship;
+use PHPUnit\Framework\TestCase;
+
+class RelationshipTest extends TestCase {
+	public function testANewRelationshipHasNoFlagsSet(): void {
+		$relationship = new Relationship(5);
+
+		$json = $relationship->jsonSerialize();
+
+		$this->assertSame(5, $json['id']);
+		unset($json['id']);
+		$this->assertSame(array_fill_keys([
+			'following', 'showing_reblogs', 'notifying', 'followed_by', 'blocking', 'blocked_by',
+			'muting', 'muting_notifications', 'requested', 'domain_blocking', 'endorsed',
+		], false), $json);
+	}
+
+	public function testJsonSerializeUsesTheMastodonFieldNames(): void {
+		$relationship = (new Relationship())
+			->setId(3)
+			->setFollowing(true)
+			->setShowingReblogs(true)
+			->setNotifying(true)
+			->setFollowedBy(true)
+			->setBlocking(true)
+			->setBlockedBy(true)
+			->setMuting(true)
+			->setMutingNotifications(true)
+			->setRequested(true)
+			->setDomainBlocking(true)
+			->setEndorsed(true);
+
+		$this->assertSame(3, $relationship->getId());
+		$this->assertTrue($relationship->isFollowing());
+		$this->assertTrue($relationship->isFollowedBy());
+		$this->assertTrue($relationship->isRequested());
+		$this->assertSame([
+			'id' => 3,
+			'following' => true,
+			'showing_reblogs' => true,
+			'notifying' => true,
+			'followed_by' => true,
+			'blocking' => true,
+			'blocked_by' => true,
+			'muting' => true,
+			'muting_notifications' => true,
+			'requested' => true,
+			'domain_blocking' => true,
+			'endorsed' => true,
+		], $relationship->jsonSerialize());
+	}
+}

--- a/tests/Model/RequestQueueTest.php
+++ b/tests/Model/RequestQueueTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model;
+
+use OCA\Social\Model\InstancePath;
+use OCA\Social\Model\RequestQueue;
+use PHPUnit\Framework\TestCase;
+
+class RequestQueueTest extends TestCase {
+	private const UUID_PATTERN = '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/';
+
+	public function testConstructorStoresActivityAuthorAndInstanceAndPicksUpItsPriority(): void {
+		$instance = new InstancePath('https://mastodon.social/inbox', InstancePath::TYPE_GLOBAL, InstancePath::PRIORITY_HIGH);
+
+		$queue = new RequestQueue('{"type":"Create"}', $instance, 'https://cloud.example.org/apps/social/@alice');
+
+		$this->assertSame('{"type":"Create"}', $queue->getActivity());
+		$this->assertSame('https://cloud.example.org/apps/social/@alice', $queue->getAuthor());
+		$this->assertSame($instance, $queue->getInstance());
+		$this->assertSame(InstancePath::PRIORITY_HIGH, $queue->getPriority());
+		$this->assertSame(RequestQueue::STATUS_STANDBY, $queue->getStatus());
+		$this->assertSame(0, $queue->getTries());
+		$this->assertSame(0, $queue->getLast());
+	}
+
+	public function testConstructorWithoutInstanceHasNoInstanceAndNoPriority(): void {
+		$queue = new RequestQueue();
+
+		$this->assertNull($queue->getInstance());
+		$this->assertSame(0, $queue->getPriority());
+	}
+
+	public function testTokenIsAUuidThatChangesOnReset(): void {
+		$queue = new RequestQueue();
+		$first = $queue->getToken();
+
+		$this->assertMatchesRegularExpression(self::UUID_PATTERN, $first);
+
+		$queue->resetToken();
+		$this->assertMatchesRegularExpression(self::UUID_PATTERN, $queue->getToken());
+		$this->assertNotSame($first, $queue->getToken());
+	}
+
+	public function testTimeoutDefaultsToFiveSeconds(): void {
+		$queue = new RequestQueue();
+
+		$this->assertSame(5, $queue->getTimeout());
+		$this->assertSame(30, $queue->setTimeout(30)->getTimeout());
+	}
+
+	public function testImportFromDatabaseReadsTheRowAndTheSerializedInstance(): void {
+		$queue = new RequestQueue();
+
+		$queue->importFromDatabase([
+			'id' => '12',
+			'token' => 'tok',
+			'author' => 'https://cloud.example.org/apps/social/@alice',
+			'instance' => '{"uri":"https://mastodon.social/inbox","type":2,"priority":3}',
+			'priority' => '3',
+			'activity' => '{"type":"Create"}',
+			'status' => '1',
+			'tries' => '2',
+			'last' => '2024-05-01 12:00:00',
+		]);
+
+		$this->assertSame(12, $queue->getId());
+		$this->assertSame('tok', $queue->getToken());
+		$this->assertSame('https://cloud.example.org/apps/social/@alice', $queue->getAuthor());
+		$this->assertSame('https://mastodon.social/inbox', $queue->getInstance()->getUri());
+		$this->assertSame(InstancePath::TYPE_GLOBAL, $queue->getInstance()->getType());
+		$this->assertSame(3, $queue->getPriority());
+		$this->assertSame('{"type":"Create"}', $queue->getActivity());
+		$this->assertSame(RequestQueue::STATUS_RUNNING, $queue->getStatus());
+		$this->assertSame(2, $queue->getTries());
+		$this->assertSame((new \DateTime('2024-05-01 12:00:00'))->getTimestamp(), $queue->getLast());
+	}
+
+	public function testImportFromDatabaseWithoutLastRunSetsZero(): void {
+		$queue = new RequestQueue();
+
+		$queue->importFromDatabase(['id' => 1, 'last' => '']);
+
+		$this->assertSame(0, $queue->getLast());
+	}
+
+	public function testJsonSerializeIncludesTheInstance(): void {
+		$instance = new InstancePath('https://mastodon.social/inbox', InstancePath::TYPE_INBOX, InstancePath::PRIORITY_LOW);
+		$queue = new RequestQueue('act', $instance, 'author');
+		$queue->setId(3)->setToken('tok')->setStatus(RequestQueue::STATUS_SUCCESS)->setTries(1)->setLast(1714564800);
+
+		$this->assertSame([
+			'id' => 3,
+			'token' => 'tok',
+			'author' => 'author',
+			'instance' => ['uri' => 'https://mastodon.social/inbox', 'type' => 1, 'priority' => 1],
+			'priority' => 1,
+			'status' => 9,
+			'tries' => 1,
+			'last' => 1714564800,
+		], json_decode(json_encode($queue), true));
+	}
+}

--- a/tests/Model/StreamActionTest.php
+++ b/tests/Model/StreamActionTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model;
+
+use OCA\Social\Model\StreamAction;
+use PHPUnit\Framework\TestCase;
+
+class StreamActionTest extends TestCase {
+	public function testConstructorStoresActorAndStream(): void {
+		$action = new StreamAction('https://a.example/users/alice', 'https://a.example/n/1');
+
+		$this->assertSame('https://a.example/users/alice', $action->getActorId());
+		$this->assertSame('https://a.example/n/1', $action->getStreamId());
+		$this->assertSame(0, $action->getId());
+		$this->assertSame([], $action->getValues());
+		$this->assertSame([], $action->getAffected());
+	}
+
+	public function testUpdateValueBoolTracksAcceptedKeysAsAffected(): void {
+		$action = new StreamAction();
+
+		$action->updateValueBool(StreamAction::LIKED, true);
+		$action->updateValueBool(StreamAction::BOOSTED, false);
+		$action->updateValueBool(StreamAction::LIKED, false);
+
+		$this->assertTrue($action->hasValue(StreamAction::LIKED));
+		$this->assertFalse($action->getValueBool(StreamAction::LIKED));
+		$this->assertFalse($action->getValueBool(StreamAction::BOOSTED));
+		$this->assertFalse($action->hasValue(StreamAction::REPLIED));
+		$this->assertSame([StreamAction::LIKED, StreamAction::BOOSTED], $action->getAffected(), 'each key once, in first-touched order');
+	}
+
+	public function testUpdateValueAndIntStoreTypedValues(): void {
+		$action = new StreamAction();
+
+		$action->updateValue(StreamAction::REPLIED, 'yes');
+		$action->updateValueInt('custom_count', 3);
+
+		$this->assertSame('yes', $action->getValue(StreamAction::REPLIED));
+		$this->assertSame(3, $action->getValueInt('custom_count'));
+		$this->assertSame([StreamAction::REPLIED], $action->getAffected(), 'unknown keys are stored but not marked affected');
+		$this->assertSame([StreamAction::REPLIED => 'yes', 'custom_count' => 3], $action->getValues());
+	}
+
+	public function testSetDefaultValuesOnlyFillsMissingKeys(): void {
+		$action = new StreamAction();
+		$action->updateValueBool(StreamAction::LIKED, true);
+
+		$action->setDefaultValues([StreamAction::LIKED => false, StreamAction::BOOSTED => false]);
+
+		$this->assertTrue($action->getValueBool(StreamAction::LIKED));
+		$this->assertFalse($action->getValueBool(StreamAction::BOOSTED));
+		$this->assertSame([StreamAction::LIKED], $action->getAffected(), 'defaults do not count as changes');
+	}
+
+	public function testImportFromDatabaseReadsTheThreeFlags(): void {
+		$action = new StreamAction();
+
+		$action->importFromDatabase([
+			'id' => '7',
+			'actor_id' => 'https://a.example/users/alice',
+			'stream_id' => 'https://a.example/n/1',
+			'liked' => '1',
+			'boosted' => '0',
+			'replied' => true,
+		]);
+
+		$this->assertSame(7, $action->getId());
+		$this->assertSame('https://a.example/users/alice', $action->getActorId());
+		$this->assertSame('https://a.example/n/1', $action->getStreamId());
+		$this->assertSame(
+			[StreamAction::LIKED => true, StreamAction::BOOSTED => false, StreamAction::REPLIED => true],
+			$action->getValues()
+		);
+	}
+
+	public function testJsonSerializeExposesIdActorStreamAndValues(): void {
+		$action = new StreamAction('actor', 'stream');
+		$action->setId(2);
+		$action->updateValueBool(StreamAction::BOOSTED, true);
+
+		$this->assertSame([
+			'id' => 2,
+			'actorId' => 'actor',
+			'streamId' => 'stream',
+			'values' => [StreamAction::BOOSTED => true],
+		], $action->jsonSerialize());
+	}
+}

--- a/tests/Model/StreamDestTest.php
+++ b/tests/Model/StreamDestTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model;
+
+use OCA\Social\Model\StreamDest;
+use PHPUnit\Framework\TestCase;
+
+class StreamDestTest extends TestCase {
+	public function testImportFromDatabaseReadsTheRow(): void {
+		$dest = new StreamDest();
+
+		$dest->importFromDatabase([
+			'stream_id' => 'abc',
+			'actor_id' => 'def',
+			'type' => 'recipient',
+			'subtype' => 'to',
+		]);
+
+		$this->assertSame('abc', $dest->getStreamId());
+		$this->assertSame('def', $dest->getActorId());
+		$this->assertSame('recipient', $dest->getType());
+		$this->assertSame('to', $dest->getSubtype());
+	}
+
+	public function testJsonSerializeUsesCamelCaseKeys(): void {
+		$dest = (new StreamDest())
+			->setStreamId('abc')
+			->setActorId('def')
+			->setType('recipient')
+			->setSubtype('cc');
+
+		$this->assertSame(
+			['streamId' => 'abc', 'actorId' => 'def', 'type' => 'recipient', 'subtype' => 'cc'],
+			$dest->jsonSerialize()
+		);
+	}
+}

--- a/tests/Model/StreamDetailsTest.php
+++ b/tests/Model/StreamDetailsTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model;
+
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Model\StreamDetails;
+use PHPUnit\Framework\TestCase;
+
+class StreamDetailsTest extends TestCase {
+	public function testConstructorStoresTheStream(): void {
+		$note = new Note();
+
+		$details = new StreamDetails($note);
+
+		$this->assertSame($note, $details->getStream());
+		$this->assertSame([], $details->getHomeViewers());
+		$this->assertSame([], $details->getDirectViewers());
+		$this->assertFalse($details->isPublic());
+		$this->assertFalse($details->isFederated());
+	}
+
+	public function testViewersCanBeAddedAndReplaced(): void {
+		$alice = (new Person())->setPreferredUsername('alice');
+		$bob = (new Person())->setPreferredUsername('bob');
+		$details = new StreamDetails(new Note());
+
+		$details->addHomeViewer($alice)->addHomeViewer($bob);
+		$details->addDirectViewer($bob);
+
+		$this->assertSame([$alice, $bob], $details->getHomeViewers());
+		$this->assertSame([$bob], $details->getDirectViewers());
+
+		$details->setHomeViewers([$bob])->setDirectViewers([]);
+		$this->assertSame([$bob], $details->getHomeViewers());
+		$this->assertSame([], $details->getDirectViewers());
+	}
+
+	public function testJsonSerializeDescribesTheDelivery(): void {
+		$note = new Note();
+		$alice = (new Person())->setPreferredUsername('alice');
+		$details = (new StreamDetails(new Note()))
+			->setStream($note)
+			->addHomeViewer($alice)
+			->setPublic(true)
+			->setFederated(true);
+
+		$this->assertSame([
+			'stream' => $note,
+			'homeViewers' => [$alice],
+			'directViewers' => [],
+			'public' => true,
+			'federated' => true,
+		], $details->jsonSerialize());
+	}
+}

--- a/tests/Model/StreamQueueTest.php
+++ b/tests/Model/StreamQueueTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model;
+
+use OCA\Social\Model\StreamQueue;
+use PHPUnit\Framework\TestCase;
+
+class StreamQueueTest extends TestCase {
+	public function testConstructorStoresTokenTypeAndStream(): void {
+		$queue = new StreamQueue('tok', StreamQueue::TYPE_CACHE, 'https://a.example/n/1');
+
+		$this->assertSame('tok', $queue->getToken());
+		$this->assertSame('Cache', $queue->getType());
+		$this->assertSame('https://a.example/n/1', $queue->getStreamId());
+		$this->assertSame(StreamQueue::STATUS_STANDBY, $queue->getStatus());
+		$this->assertSame(0, $queue->getTries());
+		$this->assertSame(0, $queue->getLast());
+	}
+
+	public function testImportFromDatabaseReadsTheRow(): void {
+		$queue = new StreamQueue();
+
+		$queue->importFromDatabase([
+			'id' => '4',
+			'token' => 'tok',
+			'stream_id' => 'https://a.example/n/1',
+			'type' => StreamQueue::TYPE_VERIFY,
+			'status' => '1',
+			'tries' => '3',
+			'last' => '2024-05-01 12:00:00',
+		]);
+
+		$this->assertSame(4, $queue->getId());
+		$this->assertSame('tok', $queue->getToken());
+		$this->assertSame('https://a.example/n/1', $queue->getStreamId());
+		$this->assertSame('Signature', $queue->getType());
+		$this->assertSame(StreamQueue::STATUS_RUNNING, $queue->getStatus());
+		$this->assertSame(3, $queue->getTries());
+		$this->assertSame((new \DateTime('2024-05-01 12:00:00'))->getTimestamp(), $queue->getLast());
+	}
+
+	public function testImportFromDatabaseWithoutLastRunSetsZero(): void {
+		$queue = new StreamQueue();
+		$queue->setLast(99);
+
+		$queue->importFromDatabase(['id' => 1, 'last' => '']);
+
+		$this->assertSame(0, $queue->getLast());
+	}
+
+	public function testJsonSerializeExposesTheQueueEntry(): void {
+		$queue = (new StreamQueue('tok', StreamQueue::TYPE_CACHE, 'stream'))
+			->setId(2)
+			->setStatus(StreamQueue::STATUS_SUCCESS)
+			->setTries(1)
+			->setLast(1714564800);
+
+		$this->assertSame([
+			'id' => 2,
+			'token' => 'tok',
+			'streamId' => 'stream',
+			'type' => 'Cache',
+			'status' => 9,
+			'tries' => 1,
+			'last' => 1714564800,
+		], $queue->jsonSerialize());
+	}
+}

--- a/tests/Model/TActivityPubMocks.php
+++ b/tests/Model/TActivityPubMocks.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model;
+
+use OCA\Social\AP;
+use OCA\Social\Interfaces\Activity\AcceptInterface;
+use OCA\Social\Interfaces\Activity\AddInterface;
+use OCA\Social\Interfaces\Activity\BlockInterface;
+use OCA\Social\Interfaces\Activity\CreateInterface;
+use OCA\Social\Interfaces\Activity\DeleteInterface;
+use OCA\Social\Interfaces\Activity\MoveInterface;
+use OCA\Social\Interfaces\Activity\RejectInterface;
+use OCA\Social\Interfaces\Activity\RemoveInterface;
+use OCA\Social\Interfaces\Activity\UndoInterface;
+use OCA\Social\Interfaces\Activity\UpdateInterface;
+use OCA\Social\Interfaces\Actor\ApplicationInterface;
+use OCA\Social\Interfaces\Actor\GroupInterface;
+use OCA\Social\Interfaces\Actor\OrganizationInterface;
+use OCA\Social\Interfaces\Actor\PersonInterface;
+use OCA\Social\Interfaces\Actor\ServiceInterface;
+use OCA\Social\Interfaces\Internal\SocialAppNotificationInterface;
+use OCA\Social\Interfaces\Object\AnnounceInterface;
+use OCA\Social\Interfaces\Object\DocumentInterface;
+use OCA\Social\Interfaces\Object\FollowInterface;
+use OCA\Social\Interfaces\Object\ImageInterface;
+use OCA\Social\Interfaces\Object\LikeInterface;
+use OCA\Social\Interfaces\Object\NoteInterface;
+use OCA\Social\Service\ConfigService;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Builds an AP dispatcher whose 22 interfaces are mocks, so model code that
+ * reaches AP::$activityPub can run without a server. Tests using it must reset
+ * AP::$activityPub to null in tearDown().
+ */
+trait TActivityPubMocks {
+	/**
+	 * Methods rather than constants: a trait cannot declare a constant before
+	 * PHP 8.2, and the app supports 8.1.
+	 */
+	protected static function cloudUrl(): string {
+		return 'https://cloud.example.org';
+	}
+
+	/**
+	 * Constructor argument order of AP.
+	 *
+	 * @return list<class-string>
+	 */
+	private static function apInterfaceClasses(): array {
+		return [
+			AcceptInterface::class,
+			AddInterface::class,
+			AnnounceInterface::class,
+			BlockInterface::class,
+			CreateInterface::class,
+			DeleteInterface::class,
+			DocumentInterface::class,
+			FollowInterface::class,
+			ImageInterface::class,
+			LikeInterface::class,
+			MoveInterface::class,
+			NoteInterface::class,
+			SocialAppNotificationInterface::class,
+			PersonInterface::class,
+			ServiceInterface::class,
+			GroupInterface::class,
+			OrganizationInterface::class,
+			ApplicationInterface::class,
+			RejectInterface::class,
+			RemoveInterface::class,
+			UndoInterface::class,
+			UpdateInterface::class,
+		];
+	}
+
+	/** @var array<class-string, MockObject> */
+	private array $apInterfaces = [];
+
+	protected function createActivityPub(?string $cloudUrl = null): AP {
+		$cloudUrl ??= self::cloudUrl();
+		$args = [];
+		foreach (self::apInterfaceClasses() as $class) {
+			$this->apInterfaces[$class] = $this->createMock($class);
+			$args[] = $this->apInterfaces[$class];
+		}
+
+		$configService = $this->createMock(ConfigService::class);
+		$configService->method('getCloudUrl')->willReturn($cloudUrl);
+		$args[] = $configService;
+
+		return new AP(...$args);
+	}
+
+	/** Installs a fresh AP as the global dispatcher the models reach for. */
+	protected function installActivityPub(?string $cloudUrl = null): AP {
+		AP::$activityPub = $this->createActivityPub($cloudUrl);
+
+		return AP::$activityPub;
+	}
+
+	/**
+	 * @param class-string $class one of the 22 interface classes
+	 */
+	protected function apInterface(string $class): MockObject {
+		return $this->apInterfaces[$class];
+	}
+}

--- a/tests/Model/TestTest.php
+++ b/tests/Model/TestTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Model;
+
+use OCA\Social\Model\Test;
+use OCA\Social\Tools\Model\SimpleDataStore;
+use PHPUnit\Framework\TestCase;
+
+class TestTest extends TestCase {
+	public function testConstructorStoresNameAndSeverity(): void {
+		$test = new Test('webfinger', Test::SEVERITY_MANDATORY);
+
+		$this->assertInstanceOf(SimpleDataStore::class, $test);
+		$this->assertSame('webfinger', $test->getName());
+		$this->assertSame('mandatory', $test->getSeverity());
+		$this->assertFalse($test->isSuccess());
+		$this->assertSame([], $test->getMessages());
+	}
+
+	public function testSeverityDefaultsToOptional(): void {
+		$this->assertSame(Test::SEVERITY_OPTIONAL, (new Test('x'))->getSeverity());
+	}
+
+	public function testMessagesAccumulate(): void {
+		$test = new Test('x');
+
+		$test->addMessage('first')->addMessage('second');
+
+		$this->assertSame(['first', 'second'], $test->getMessages());
+	}
+
+	public function testJsonSerializeIncludesDetailsMessagesAndSuccess(): void {
+		$test = new Test('webfinger', Test::SEVERITY_MANDATORY);
+		$test->s('host', 'cloud.example.org');
+		$test->sInt('status', 200);
+		$test->addMessage('resolved')
+			->setSuccess(true);
+
+		$this->assertSame([
+			'name' => 'webfinger',
+			'severity' => 'mandatory',
+			'details' => ['host' => 'cloud.example.org', 'status' => 200],
+			'message' => ['resolved'],
+			'success' => true,
+		], $test->jsonSerialize());
+	}
+
+	public function testJsonSerializeAlwaysReportsSuccessEvenWhenFalse(): void {
+		$test = new Test('x');
+		$test->s('k', 'v');
+
+		$json = $test->jsonSerialize();
+
+		$this->assertArrayNotHasKey('message', $json, 'empty lists are filtered out');
+		$this->assertFalse($json['success']);
+	}
+}

--- a/tests/Notification/NotifierTest.php
+++ b/tests/Notification/NotifierTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Notification;
+
+use OCA\Social\Notification\Notifier;
+use OCP\Contacts\IManager;
+use OCP\Federation\ICloudIdManager;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\L10N\IFactory;
+use OCP\Notification\IAction;
+use OCP\Notification\INotification;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class NotifierTest extends TestCase {
+	/** @var IL10N&MockObject */
+	private $l10n;
+	/** @var IFactory&MockObject */
+	private $factory;
+	/** @var IURLGenerator&MockObject */
+	private $urlGenerator;
+	private Notifier $notifier;
+
+	protected function setUp(): void {
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->factory = $this->createMock(IFactory::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+
+		$this->notifier = new Notifier(
+			$this->l10n,
+			$this->factory,
+			$this->createMock(IManager::class),
+			$this->urlGenerator,
+			$this->createMock(ICloudIdManager::class)
+		);
+	}
+
+	/** @return INotification&MockObject */
+	private function notification(string $app, string $subject, array $actions = []): INotification {
+		$notification = $this->createMock(INotification::class);
+		$notification->method('getApp')->willReturn($app);
+		$notification->method('getSubject')->willReturn($subject);
+		$notification->method('getSubjectParameters')->willReturn([]);
+		$notification->method('getActions')->willReturn($actions);
+
+		return $notification;
+	}
+
+	/** @return IAction&MockObject */
+	private function action(string $label): IAction {
+		$action = $this->createMock(IAction::class);
+		$action->method('getLabel')->willReturn($label);
+		$action->method('setParsedLabel')->willReturnSelf();
+		$action->method('setPrimary')->willReturnSelf();
+
+		return $action;
+	}
+
+	/** @return IL10N&MockObject */
+	private function translationsFor(string $language): IL10N {
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnCallback(fn (string $text): string => '[' . $language . '] ' . $text);
+		$this->factory->method('get')->with('social', $language)->willReturn($l10n);
+
+		return $l10n;
+	}
+
+	public function testIdIsTheAppId(): void {
+		$this->assertSame('social', $this->notifier->getID());
+	}
+
+	public function testNameIsTranslated(): void {
+		$this->l10n->method('t')->with('Social')->willReturn('Sozial');
+
+		$this->assertSame('Sozial', $this->notifier->getName());
+	}
+
+	public function testNotificationsOfOtherAppsAreRejected(): void {
+		$notification = $this->notification('spreed', 'update_alpha3');
+		$this->factory->expects($this->never())->method('get');
+
+		$this->expectException(\InvalidArgumentException::class);
+
+		$this->notifier->prepare($notification, 'en');
+	}
+
+	public function testUnknownSubjectsAreRejected(): void {
+		$this->translationsFor('en');
+		$notification = $this->notification('social', 'new_follower');
+
+		$this->expectException(\InvalidArgumentException::class);
+
+		$this->notifier->prepare($notification, 'en');
+	}
+
+	public function testUpdateAlpha3IsParsedInTheRequestedLanguage(): void {
+		$this->translationsFor('de');
+		$this->urlGenerator->method('imagePath')->with('social', 'social_dark.svg')->willReturn('/apps/social/img/social_dark.svg');
+		$this->urlGenerator->method('getAbsoluteURL')->with('/apps/social/img/social_dark.svg')->willReturn('https://cloud.example/apps/social/img/social_dark.svg');
+
+		$notification = $this->notification('social', 'update_alpha3');
+		$notification->expects($this->once())->method('setIcon')->with('https://cloud.example/apps/social/img/social_dark.svg');
+		$notification->expects($this->once())->method('setParsedSubject')->with('The Social App has been updated to alpha3.');
+		$notification->expects($this->once())->method('setParsedMessage')
+			->with($this->stringStartsWith('[de] Please note that the data from alpha2 can only be migrated manually.'));
+
+		$this->assertSame($notification, $this->notifier->prepare($notification, 'de'));
+	}
+
+	public function testHelpActionBecomesThePrimaryParsedAction(): void {
+		$this->translationsFor('en');
+		$help = $this->action('help');
+		$help->expects($this->once())->method('setParsedLabel')->with('[en] Help');
+		$help->expects($this->once())->method('setPrimary')->with(true);
+
+		$notification = $this->notification('social', 'update_alpha3', [$help]);
+		$notification->expects($this->once())->method('addParsedAction')->with($help);
+
+		$this->notifier->prepare($notification, 'en');
+	}
+
+	public function testUnknownActionsAreForwardedUnparsed(): void {
+		$this->translationsFor('en');
+		$other = $this->action('dismiss');
+		$other->expects($this->never())->method('setParsedLabel');
+		$other->expects($this->never())->method('setPrimary');
+
+		$notification = $this->notification('social', 'update_alpha3', [$other]);
+		$notification->expects($this->once())->method('addParsedAction')->with($other);
+
+		$this->notifier->prepare($notification, 'en');
+	}
+}

--- a/tests/Providers/ContactsMenuProviderTest.php
+++ b/tests/Providers/ContactsMenuProviderTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Providers;
+
+use OCA\Social\Exceptions\AccountDoesNotExistException;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Providers\ContactsMenuProvider;
+use OCA\Social\Service\AccountService;
+use OCP\Contacts\ContactsMenu\IActionFactory;
+use OCP\Contacts\ContactsMenu\IEntry;
+use OCP\Contacts\ContactsMenu\ILinkAction;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ContactsMenuProviderTest extends TestCase {
+	/** @var IActionFactory&MockObject */
+	private $actionFactory;
+	/** @var IURLGenerator&MockObject */
+	private $urlGenerator;
+	/** @var IUserManager&MockObject */
+	private $userManager;
+	/** @var AccountService&MockObject */
+	private $accountService;
+	private ContactsMenuProvider $provider;
+
+	protected function setUp(): void {
+		$this->actionFactory = $this->createMock(IActionFactory::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->accountService = $this->createMock(AccountService::class);
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnCallback(fn (string $text, array $params): string => vsprintf($text, $params));
+
+		$this->provider = new ContactsMenuProvider(
+			$this->actionFactory,
+			$this->urlGenerator,
+			$this->userManager,
+			$l10n,
+			$this->accountService
+		);
+	}
+
+	/** @return IEntry&MockObject */
+	private function entry(?string $uid, bool $localSystemBook = true): IEntry {
+		$entry = $this->createMock(IEntry::class);
+		$entry->method('getProperty')->willReturnMap([
+			['UID', $uid],
+			['isLocalSystemBook', $localSystemBook],
+		]);
+
+		return $entry;
+	}
+
+	private function knownUser(string $uid, string $displayName): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$user->method('getDisplayName')->willReturn($displayName);
+		$this->userManager->method('get')->with($uid)->willReturn($user);
+	}
+
+	public function testUsersWithASocialAccountGetAFollowAction(): void {
+		$this->knownUser('bob', 'Bob Builder');
+		$actor = $this->createMock(Person::class);
+		$actor->method('getPreferredUsername')->willReturn('bob');
+		$this->accountService->method('getActorFromUserId')->with('bob')->willReturn($actor);
+		$this->urlGenerator->method('imagePath')->with('social', 'social-dark.svg')->willReturn('/apps/social/img/social-dark.svg');
+		$this->urlGenerator->method('getAbsoluteURL')->with('/apps/social/img/social-dark.svg')->willReturn('https://cloud.example/apps/social/img/social-dark.svg');
+		$this->urlGenerator->method('linkToRouteAbsolute')->with('social.ActivityPub.actorAlias', ['username' => 'bob'])
+			->willReturn('https://cloud.example/apps/social/@bob');
+		$action = $this->createMock(ILinkAction::class);
+		$this->actionFactory->expects($this->once())->method('newLinkAction')
+			->with(
+				'https://cloud.example/apps/social/img/social-dark.svg',
+				'Follow Bob Builder on Social',
+				'https://cloud.example/apps/social/@bob',
+				'social'
+			)
+			->willReturn($action);
+		$entry = $this->entry('bob');
+		$entry->expects($this->once())->method('addAction')->with($action);
+
+		$this->provider->process($entry);
+	}
+
+	public function testUsersWithoutASocialAccountGetNoAction(): void {
+		$this->knownUser('bob', 'Bob');
+		$this->accountService->method('getActorFromUserId')->willThrowException(new AccountDoesNotExistException());
+		$this->actionFactory->expects($this->never())->method('newLinkAction');
+		$entry = $this->entry('bob');
+		$entry->expects($this->never())->method('addAction');
+
+		$this->provider->process($entry);
+	}
+
+	public function testEntriesWithoutAUidAreSkipped(): void {
+		$this->userManager->expects($this->never())->method('get');
+		$this->accountService->expects($this->never())->method('getActorFromUserId');
+		$entry = $this->entry(null);
+		$entry->expects($this->never())->method('addAction');
+
+		$this->provider->process($entry);
+	}
+
+	public function testRemoteAddressBookEntriesAreSkipped(): void {
+		$this->userManager->expects($this->never())->method('get');
+		$entry = $this->entry('bob', false);
+		$entry->expects($this->never())->method('addAction');
+
+		$this->provider->process($entry);
+	}
+
+	public function testUnknownUsersAreSkipped(): void {
+		$this->userManager->method('get')->with('ghost')->willReturn(null);
+		$this->accountService->expects($this->never())->method('getActorFromUserId');
+		$entry = $this->entry('ghost');
+		$entry->expects($this->never())->method('addAction');
+
+		$this->provider->process($entry);
+	}
+}

--- a/tests/Search/UnifiedSearchProviderTest.php
+++ b/tests/Search/UnifiedSearchProviderTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Search;
+
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Document;
+use OCA\Social\Search\UnifiedSearchProvider;
+use OCA\Social\Search\UnifiedSearchResult;
+use OCA\Social\Service\AccountService;
+use OCA\Social\Service\CacheActorService;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\FollowService;
+use OCA\Social\Service\SearchService;
+use OCA\Social\Service\StreamService;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\Search\ISearchQuery;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class UnifiedSearchProviderTest extends TestCase {
+	/** @var IL10N&MockObject */
+	private $l10n;
+	/** @var IURLGenerator&MockObject */
+	private $urlGenerator;
+	/** @var SearchService&MockObject */
+	private $searchService;
+	private UnifiedSearchProvider $provider;
+
+	protected function setUp(): void {
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->l10n->method('t')->willReturnArgument(0);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->searchService = $this->createMock(SearchService::class);
+
+		$this->provider = new UnifiedSearchProvider(
+			$this->l10n,
+			$this->urlGenerator,
+			$this->createMock(StreamService::class),
+			$this->createMock(FollowService::class),
+			$this->createMock(CacheActorService::class),
+			$this->createMock(AccountService::class),
+			$this->searchService,
+			$this->createMock(ConfigService::class),
+			new NullLogger()
+		);
+	}
+
+	/** @return ISearchQuery&MockObject */
+	private function query(string $term, int $limit = 5, ?int $cursor = null): ISearchQuery {
+		$query = $this->createMock(ISearchQuery::class);
+		$query->method('getTerm')->willReturn($term);
+		$query->method('getLimit')->willReturn($limit);
+		$query->method('getCursor')->willReturn($cursor);
+
+		return $query;
+	}
+
+	/** @return Person&MockObject */
+	private function account(string $username, string $account, ?string $iconUrl = null): Person {
+		$person = $this->createMock(Person::class);
+		$person->method('getPreferredUsername')->willReturn($username);
+		$person->method('getAccount')->willReturn($account);
+		$person->method('hasIcon')->willReturn($iconUrl !== null);
+		if ($iconUrl !== null) {
+			$icon = $this->createMock(Document::class);
+			$icon->method('getUrl')->willReturn($iconUrl);
+			$person->method('getIcon')->willReturn($icon);
+		}
+
+		return $person;
+	}
+
+	public function testIdentity(): void {
+		$this->assertSame('social', $this->provider->getId());
+		$this->assertSame('Social', $this->provider->getName());
+		$this->assertSame(12, $this->provider->getOrder('files.View.index', []));
+		$this->assertSame(12, $this->provider->getOrder('social.Navigation.navigate', ['path' => 'home']));
+	}
+
+	public function testSearchTrimsTheTermAndQueriesAccountsUrisAndHashtags(): void {
+		$this->searchService->expects($this->once())->method('searchUri')->with('alice')->willReturn([]);
+		$this->searchService->expects($this->once())->method('searchAccounts')->with('alice')->willReturn([]);
+		$this->searchService->expects($this->once())->method('searchHashtags')->with('alice')->willReturn([]);
+
+		$result = $this->provider->search($this->createMock(IUser::class), $this->query('  alice '));
+
+		$this->assertSame('Social', $result->jsonSerialize()['name']);
+		$this->assertSame([], $result->jsonSerialize()['entries']);
+	}
+
+	public function testAccountsBecomeEntriesLinkingToTheActorPage(): void {
+		$this->searchService->method('searchUri')->willReturn([$this->account('bob', 'bob@remote.example', 'https://remote.example/bob.png')]);
+		$this->searchService->method('searchAccounts')->willReturn([$this->account('alice', 'alice@cloud.example')]);
+		$this->searchService->method('searchHashtags')->willReturn([]);
+		$this->urlGenerator->method('linkToRoute')->willReturnCallback(
+			fn (string $route, array $args): string => $route . '?username=' . $args['username']
+		);
+
+		$entries = $this->provider->search($this->createMock(IUser::class), $this->query('x'))->jsonSerialize()['entries'];
+
+		$this->assertCount(2, $entries);
+		$this->assertContainsOnlyInstancesOf(UnifiedSearchResult::class, $entries);
+		[$bob, $alice] = $entries;
+		$this->assertSame('bob', $bob->getTitle());
+		$this->assertSame('@bob@remote.example', $bob->getSubline());
+		$this->assertSame('social.ActivityPub.actorAlias?username=bob@remote.example', $bob->getResourceUrl());
+		$this->assertSame('https://remote.example/bob.png', $bob->getThumbnailUrl());
+		$this->assertSame('https://remote.example/bob.png', $bob->getIcon());
+		$this->assertSame('alice', $alice->getTitle());
+		$this->assertSame('', $alice->getThumbnailUrl(), 'accounts without icon have no thumbnail');
+	}
+
+	public function testHashtagsBecomeEntriesLinkingToTheTagTimeline(): void {
+		$this->searchService->method('searchUri')->willReturn([]);
+		$this->searchService->method('searchAccounts')->willReturn([]);
+		$this->searchService->method('searchHashtags')->willReturn([
+			['hashtag' => 'nextcloud', 'trend' => ['10d' => 42]],
+		]);
+		$this->urlGenerator->method('linkToRouteAbsolute')
+			->with('social.Navigation.timeline', ['path' => 'tags/nextcloud'])
+			->willReturn('https://cloud.example/apps/social/timeline/tags/nextcloud');
+
+		$entries = $this->provider->search($this->createMock(IUser::class), $this->query('nextcloud'))->jsonSerialize()['entries'];
+
+		$this->assertCount(1, $entries);
+		$this->assertSame("42 posts related to 'nextcloud'", $entries[0]->getTitle());
+		$this->assertSame('#nextcloud', $entries[0]->getSubline());
+		$this->assertSame('https://cloud.example/apps/social/timeline/tags/nextcloud', $entries[0]->getResourceUrl());
+		$this->assertSame('', $entries[0]->getThumbnailUrl());
+	}
+
+	public function testResultIsPaginatedFromTheCursor(): void {
+		$this->searchService->method('searchUri')->willReturn([]);
+		$this->searchService->method('searchAccounts')->willReturn([]);
+		$this->searchService->method('searchHashtags')->willReturn([]);
+
+		$first = $this->provider->search($this->createMock(IUser::class), $this->query('x', 5))->jsonSerialize();
+		$next = $this->provider->search($this->createMock(IUser::class), $this->query('x', 5, 10))->jsonSerialize();
+
+		$this->assertTrue($first['isPaginated']);
+		$this->assertSame(5, $first['cursor']);
+		$this->assertSame(15, $next['cursor']);
+	}
+}

--- a/tests/Search/UnifiedSearchResultTest.php
+++ b/tests/Search/UnifiedSearchResultTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Search;
+
+use OCA\Social\Search\UnifiedSearchResult;
+use OCP\Search\SearchResultEntry;
+use PHPUnit\Framework\TestCase;
+
+class UnifiedSearchResultTest extends TestCase {
+	public function testDefaultsAreEmptyAndSquare(): void {
+		$result = new UnifiedSearchResult();
+
+		$this->assertInstanceOf(SearchResultEntry::class, $result);
+		$this->assertSame('', $result->getThumbnailUrl());
+		$this->assertSame('', $result->getTitle());
+		$this->assertSame('', $result->getSubline());
+		$this->assertSame('', $result->getResourceUrl());
+		$this->assertSame('', $result->getIcon());
+		$this->assertFalse($result->isRounded());
+	}
+
+	public function testConstructorArgumentsAreExposedThroughGetters(): void {
+		$result = new UnifiedSearchResult('https://x/thumb.png', 'alice', '@alice@cloud.example', 'https://x/@alice', 'icon-user', true);
+
+		$this->assertSame('https://x/thumb.png', $result->getThumbnailUrl());
+		$this->assertSame('alice', $result->getTitle());
+		$this->assertSame('@alice@cloud.example', $result->getSubline());
+		$this->assertSame('https://x/@alice', $result->getResourceUrl());
+		$this->assertSame('icon-user', $result->getIcon());
+		$this->assertTrue($result->isRounded());
+	}
+
+	public function testSettersAreFluentAndFeedTheSerialisedEntry(): void {
+		$result = (new UnifiedSearchResult())
+			->setThumbnailUrl('https://x/t.png')
+			->setTitle('title')
+			->setSubline('sub')
+			->setResourceUrl('https://x/r')
+			->setIcon('icon-x')
+			->setRounded(true);
+
+		$this->assertInstanceOf(UnifiedSearchResult::class, $result);
+		$json = $result->jsonSerialize();
+		$this->assertSame('https://x/t.png', $json['thumbnailUrl']);
+		$this->assertSame('title', $json['title']);
+		$this->assertSame('sub', $json['subline']);
+		$this->assertSame('https://x/r', $json['resourceUrl']);
+		$this->assertSame('icon-x', $json['icon']);
+		$this->assertTrue($json['rounded']);
+	}
+}

--- a/tests/Service/AccountServiceTest.php
+++ b/tests/Service/AccountServiceTest.php
@@ -1,0 +1,406 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use OCA\Social\AP;
+use OCA\Social\Db\ActorsRequest;
+use OCA\Social\Db\FollowsRequest;
+use OCA\Social\Db\StreamRequest;
+use OCA\Social\Exceptions\AccountAlreadyExistsException;
+use OCA\Social\Exceptions\AccountDoesNotExistException;
+use OCA\Social\Exceptions\ActorDoesNotExistException;
+use OCA\Social\Exceptions\ItemUnknownException;
+use OCA\Social\Exceptions\StreamNotFoundException;
+use OCA\Social\Interfaces\Actor\PersonInterface;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Activity\Delete;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Model\InstancePath;
+use OCA\Social\Service\AccountService;
+use OCA\Social\Service\ActivityService;
+use OCA\Social\Service\ActorService;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\DocumentService;
+use OCA\Social\Service\SignatureService;
+use OCP\Accounts\IAccount;
+use OCP\Accounts\IAccountManager;
+use OCP\Accounts\IAccountProperty;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class AccountServiceTest extends TestCase {
+	private const ALICE = 'https://cloud.example.com/apps/social/@alice';
+
+	private IUserManager|MockObject $userManager;
+	private IUserSession|MockObject $userSession;
+	private IAccountManager|MockObject $accountManager;
+	private ActorsRequest|MockObject $actorsRequest;
+	private FollowsRequest|MockObject $followsRequest;
+	private StreamRequest|MockObject $streamRequest;
+	private ActorService|MockObject $actorService;
+	private ActivityService|MockObject $activityService;
+	private DocumentService|MockObject $documentService;
+	private SignatureService|MockObject $signatureService;
+	private AccountService $service;
+	private int $errorReporting;
+
+	protected function setUp(): void {
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->accountManager = $this->createMock(IAccountManager::class);
+		$this->actorsRequest = $this->createMock(ActorsRequest::class);
+		$this->followsRequest = $this->createMock(FollowsRequest::class);
+		$this->streamRequest = $this->createMock(StreamRequest::class);
+		$this->actorService = $this->createMock(ActorService::class);
+		$this->activityService = $this->createMock(ActivityService::class);
+		$this->documentService = $this->createMock(DocumentService::class);
+		$this->signatureService = $this->createMock(SignatureService::class);
+
+		// AccountService assigns its collaborators to undeclared properties; PHP reports
+		// "Creation of dynamic property" for each of them, which PHPUnit would treat as
+		// unexpected output. Silence that single known deprecation around construction.
+		$this->errorReporting = error_reporting(E_ALL & ~E_DEPRECATED);
+		$this->service = new AccountService(
+			$this->userManager,
+			$this->userSession,
+			$this->accountManager,
+			$this->actorsRequest,
+			$this->followsRequest,
+			$this->streamRequest,
+			$this->actorService,
+			$this->activityService,
+			$this->documentService,
+			$this->signatureService,
+			$this->createMock(ConfigService::class),
+			new NullLogger(),
+		);
+		error_reporting($this->errorReporting);
+	}
+
+	protected function tearDown(): void {
+		AP::$activityPub = null;
+		error_reporting($this->errorReporting);
+	}
+
+	private function user(string $uid): IUser|MockObject {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+
+		return $user;
+	}
+
+	private function alice(): Person {
+		$alice = new Person();
+		$alice->setId(self::ALICE);
+		$alice->setUserId('alice');
+		$alice->setPreferredUsername('alice');
+		$alice->setInbox(self::ALICE . '/inbox');
+		$alice->setLocal(true);
+
+		return $alice;
+	}
+
+	/** Point the display-name account property at a value with the given scope. */
+	private function withDisplayName(string $name, string $scope): void {
+		$property = $this->createMock(IAccountProperty::class);
+		$property->method('getScope')->willReturn($scope);
+		$property->method('getValue')->willReturn($name);
+		$account = $this->createMock(IAccount::class);
+		$account->method('getProperty')->with(IAccountManager::PROPERTY_DISPLAYNAME)->willReturn($property);
+		$this->accountManager->method('getAccount')->willReturn($account);
+	}
+
+	public function testGetActorAndGetFromIdDelegate(): void {
+		$alice = $this->alice();
+		$this->actorsRequest->expects($this->once())->method('getFromUsername')->with('alice')->willReturn($alice);
+		$this->actorsRequest->expects($this->once())->method('getFromId')->with(self::ALICE)->willReturn($alice);
+
+		$this->assertSame($alice, $this->service->getActor('alice'));
+		$this->assertSame($alice, $this->service->getFromId(self::ALICE));
+	}
+
+	public function testConfirmUserIdNormalisesToTheRealUid(): void {
+		$this->userManager->method('get')->with('Alice')->willReturn($this->user('alice'));
+
+		$userId = 'Alice';
+		$user = $this->service->confirmUserId($userId);
+
+		$this->assertSame('alice', $userId);
+		$this->assertSame('alice', $user->getUID());
+	}
+
+	public function testGetCurrentViewerRequiresALoggedInUser(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+
+		$this->expectException(AccountDoesNotExistException::class);
+		$this->expectExceptionMessage('No user is currently logged in');
+		$this->service->getCurrentViewer();
+	}
+
+	public function testGetCurrentViewerReturnsTheActorOfTheSessionUser(): void {
+		$this->userSession->method('getUser')->willReturn($this->user('alice'));
+		$this->userManager->method('get')->with('alice')->willReturn($this->user('alice'));
+		$alice = $this->alice();
+		$this->actorsRequest->method('getFromUserId')->with('alice')->willReturn($alice);
+
+		$this->assertSame($alice, $this->service->getCurrentViewer());
+	}
+
+	public function testGetCurrentViewerWrapsAMissingActor(): void {
+		$this->userSession->method('getUser')->willReturn($this->user('alice'));
+		$this->userManager->method('get')->willReturn($this->user('alice'));
+		$this->actorsRequest->method('getFromUserId')->willThrowException(new ActorDoesNotExistException());
+
+		$this->expectException(AccountDoesNotExistException::class);
+		$this->expectExceptionMessage('Account not found for current user');
+		$this->service->getCurrentViewer();
+	}
+
+	public function testGetActorFromUserIdWithoutCreateThrowsForAMissingActor(): void {
+		$this->userManager->method('get')->willReturn($this->user('alice'));
+		$this->actorsRequest->method('getFromUserId')->willThrowException(new ActorDoesNotExistException());
+		$this->actorsRequest->expects($this->never())->method('create');
+
+		$this->expectException(ActorDoesNotExistException::class);
+		$this->expectExceptionMessage('Actor not found for user: alice');
+		$this->service->getActorFromUserId('alice');
+	}
+
+	public function testGetActorFromUserIdCreatesTheActorOnDemand(): void {
+		$this->userManager->method('get')->willReturn($this->user('alice'));
+		$this->actorsRequest->method('getFromUsername')->willThrowException(new ActorDoesNotExistException());
+		$created = null;
+		$this->actorsRequest->expects($this->once())
+			->method('create')
+			->willReturnCallback(function (Person $actor) use (&$created) {
+				$created = $actor;
+			});
+		// missing before creation (looked up twice), found afterwards
+		$this->actorsRequest->expects($this->exactly(3))
+			->method('getFromUserId')
+			->with('alice')
+			->willReturnCallback(function () use (&$created) {
+				if ($created === null) {
+					throw new ActorDoesNotExistException();
+				}
+
+				return $created;
+			});
+
+		$actor = $this->service->getActorFromUserId('alice', true);
+
+		$this->assertSame($created, $actor);
+		$this->assertSame('alice', $actor->getUserId());
+	}
+
+	public function testCreateActorGeneratesKeysStoresTheActorAndItsLoopbackFollow(): void {
+		$this->userManager->method('get')->with('alice')->willReturn($this->user('alice'));
+		$this->actorsRequest->method('getFromUsername')->willThrowException(new ActorDoesNotExistException());
+		$this->actorsRequest->method('getFromUserId')->willThrowException(new ActorDoesNotExistException());
+		$this->signatureService->expects($this->once())
+			->method('generateKeys')
+			->willReturnCallback(function (Person $actor) {
+				$actor->setPublicKey('PUB');
+				$actor->setPrivateKey('PRIV');
+			});
+		$created = null;
+		$this->actorsRequest->expects($this->once())
+			->method('create')
+			->willReturnCallback(function (Person $actor) use (&$created) {
+				$created = $actor;
+			});
+		$this->followsRequest->expects($this->once())
+			->method('generateLoopbackAccount')
+			->with($this->callback(function (Person $actor) use (&$created) {
+				return $actor === $created;
+			}));
+
+		$this->service->createActor('alice', 'alice');
+
+		$this->assertInstanceOf(Person::class, $created);
+		$this->assertSame('alice', $created->getUserId());
+		$this->assertSame('alice', $created->getPreferredUsername());
+		$this->assertSame('PUB', $created->getPublicKey());
+		$this->assertSame('PRIV', $created->getPrivateKey());
+	}
+
+	public function testCreateActorRefusesATakenUsername(): void {
+		$this->userManager->method('get')->willReturn($this->user('bob'));
+		$this->actorsRequest->method('getFromUsername')->with('alice')->willReturn($this->alice());
+		$this->actorsRequest->expects($this->never())->method('create');
+
+		$this->expectException(AccountAlreadyExistsException::class);
+		$this->expectExceptionMessage('already exist');
+		$this->service->createActor('bob', 'alice');
+	}
+
+	public function testCreateActorRefusesAUsernameStillInDeletionRetention(): void {
+		$this->userManager->method('get')->willReturn($this->user('bob'));
+		$deleted = $this->alice();
+		$deleted->setDeleted(time() - 10);
+		$this->actorsRequest->method('getFromUsername')->willReturn($deleted);
+
+		$this->expectException(AccountAlreadyExistsException::class);
+		$this->expectExceptionMessage('retention');
+		$this->service->createActor('bob', 'alice');
+	}
+
+	public function testCreateActorRefusesASecondAccountForTheSameUser(): void {
+		$this->userManager->method('get')->willReturn($this->user('alice'));
+		$this->actorsRequest->method('getFromUsername')->willThrowException(new ActorDoesNotExistException());
+		$this->actorsRequest->method('getFromUserId')->with('alice')->willReturn($this->alice());
+		$this->actorsRequest->expects($this->never())->method('create');
+
+		$this->expectException(AccountAlreadyExistsException::class);
+		$this->expectExceptionMessage('account for this user already exist');
+		$this->service->createActor('alice', 'alice2');
+	}
+
+	public function testDeleteActorMarksDeletesAndBroadcasts(): void {
+		$alice = $this->alice();
+		$this->actorsRequest->method('getFromUsername')->with('alice')->willReturn($alice);
+		$this->actorsRequest->expects($this->once())->method('setAsDeleted')->with('alice');
+		$personInterface = $this->createMock(PersonInterface::class);
+		$personInterface->expects($this->once())->method('delete')->with($this->identicalTo($alice));
+		$ap = $this->createMock(AP::class);
+		$ap->method('getInterfaceFromType')->with(Person::TYPE)->willReturn($personInterface);
+		AP::$activityPub = $ap;
+		$this->signatureService->expects($this->once())
+			->method('signObject')
+			->with($this->identicalTo($alice), $this->isInstanceOf(Delete::class));
+		$this->activityService->expects($this->once())
+			->method('request')
+			->with($this->callback(function (Delete $delete) {
+				$this->assertSame(self::ALICE . '#delete', $delete->getId());
+				$this->assertSame(self::ALICE, $delete->getActorId());
+				$this->assertSame(self::ALICE, $delete->getObjectId());
+				$this->assertSame([ACore::CONTEXT_PUBLIC], $delete->getToArray());
+				$paths = $delete->getInstancePaths();
+				$this->assertCount(1, $paths);
+				$this->assertSame(self::ALICE . '/inbox', $paths[0]->getUri());
+				$this->assertSame(InstancePath::TYPE_ALL, $paths[0]->getType());
+				$this->assertSame(InstancePath::PRIORITY_LOW, $paths[0]->getPriority());
+
+				return true;
+			}))
+			->willReturn('token');
+
+		$this->service->deleteActor('alice');
+	}
+
+	public function testDeleteActorIgnoresUnknownHandles(): void {
+		$this->actorsRequest->method('getFromUsername')->willThrowException(new ActorDoesNotExistException());
+		$this->actorsRequest->expects($this->never())->method('setAsDeleted');
+		$this->activityService->expects($this->never())->method('request');
+
+		$this->service->deleteActor('nobody');
+	}
+
+	public function testCacheLocalActorByUsernameEnrichesAndCachesTheActor(): void {
+		$alice = $this->alice();
+		$this->actorsRequest->method('getFromUsername')->with('alice')->willReturn($alice);
+		$this->userManager->method('get')->with('alice')->willReturn($this->user('alice'));
+		$this->withDisplayName('Alice Wonder', IAccountManager::SCOPE_PUBLISHED);
+		$this->documentService->expects($this->once())->method('cacheLocalAvatarByUsername')->with($this->identicalTo($alice))->willReturn('icon-42');
+		$this->actorService->method('getCachedHeader')->with($this->identicalTo($alice))->willReturn('https://cloud.example.com/header.jpg');
+		$this->followsRequest->method('countFollowers')->with(self::ALICE)->willReturn(3);
+		$this->followsRequest->method('countFollowing')->with(self::ALICE)->willReturn(2);
+		$this->streamRequest->method('countNotesFromActorId')->with(self::ALICE)->willReturn(7);
+		$lastNote = new Note();
+		$lastNote->setPublishedTime(mktime(12, 0, 0, 9, 1, 2026));
+		$this->streamRequest->method('lastNoteFromActorId')->with(self::ALICE)->willReturn($lastNote);
+		$this->actorService->expects($this->once())->method('cacheLocalActor')->with($this->identicalTo($alice));
+
+		$this->service->cacheLocalActorByUsername('alice');
+
+		$this->assertSame('Alice Wonder', $alice->getName());
+		$this->assertSame('icon-42', $alice->getIconId());
+		$this->assertSame('https://cloud.example.com/header.jpg', $alice->getHeader());
+		$this->assertSame(['followers' => 3, 'following' => 2, 'post' => 7], $alice->getDetails('count'));
+		$this->assertSame('2026-09-01', $alice->getDetailsAll()['last_post_creation']);
+	}
+
+	public function testCacheLocalActorByUsernameKeepsAPrivateDisplayNameOut(): void {
+		$alice = $this->alice();
+		$alice->setName('alice');
+		$this->actorsRequest->method('getFromUsername')->willReturn($alice);
+		$this->userManager->method('get')->willReturn($this->user('alice'));
+		$this->withDisplayName('Alice Wonder', IAccountManager::SCOPE_PRIVATE);
+		$this->documentService->method('cacheLocalAvatarByUsername')->willThrowException(new ItemUnknownException());
+		$this->streamRequest->method('lastNoteFromActorId')->willThrowException(new StreamNotFoundException());
+		$this->actorService->expects($this->once())->method('cacheLocalActor');
+
+		$this->service->cacheLocalActorByUsername('alice');
+
+		$this->assertSame('alice', $alice->getName());
+		$this->assertSame('', $alice->getIconId());
+		$this->assertSame('', $alice->getDetailsAll()['last_post_creation']);
+	}
+
+	public function testCacheLocalActorByUsernameIgnoresUnknownActors(): void {
+		$this->actorsRequest->method('getFromUsername')->willThrowException(new ActorDoesNotExistException());
+		$this->actorService->expects($this->never())->method('cacheLocalActor');
+
+		$this->service->cacheLocalActorByUsername('nobody');
+	}
+
+	public function testCacheLocalActorDetailCountOnlyAppliesToLocalActors(): void {
+		$remote = new Person();
+		$remote->setId('https://remote.example/users/bob');
+		$this->actorService->expects($this->never())->method('cacheLocalActorDetails');
+
+		$this->service->cacheLocalActorDetailCount($remote);
+	}
+
+	public function testCacheLocalActorDetailCountStoresTheCounters(): void {
+		$alice = $this->alice();
+		$this->followsRequest->method('countFollowers')->willReturn(1);
+		$this->followsRequest->method('countFollowing')->willReturn(4);
+		$this->streamRequest->method('countNotesFromActorId')->willReturn(9);
+		$this->streamRequest->method('lastNoteFromActorId')->willThrowException(new StreamNotFoundException());
+		$this->actorService->expects($this->once())->method('cacheLocalActorDetails')->with($this->identicalTo($alice));
+
+		$this->service->cacheLocalActorDetailCount($alice);
+
+		$this->assertSame(['followers' => 1, 'following' => 4, 'post' => 9], $alice->getDetails('count'));
+	}
+
+	public function testManageCacheLocalActorsRefreshesEveryLocalActor(): void {
+		$alice = $this->alice();
+		$bob = $this->alice();
+		$bob->setPreferredUsername('bob');
+		$this->actorsRequest->method('getAll')->willReturn([$alice, $bob]);
+		$this->actorsRequest->expects($this->exactly(2))
+			->method('getFromUsername')
+			->withConsecutive(['alice'], ['bob'])
+			->willThrowException(new ActorDoesNotExistException());
+
+		$this->assertSame(2, $this->service->manageCacheLocalActors());
+	}
+
+	public function testManageDeletedActorsSkipsLiveActors(): void {
+		$this->actorsRequest->method('getAll')->willReturn([$this->alice()]);
+		$this->actorsRequest->expects($this->never())->method('delete');
+
+		$this->assertSame(0, $this->service->manageDeletedActors());
+	}
+
+	public function testBlindKeyRotationWithoutActorsDoesNothing(): void {
+		$this->actorsRequest->method('getAll')->willReturn([]);
+		$this->signatureService->expects($this->never())->method('generateKeys');
+
+		$this->assertSame(0, $this->service->blindKeyRotation());
+	}
+}

--- a/tests/Service/ActionServiceTest.php
+++ b/tests/Service/ActionServiceTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use OCA\Social\Exceptions\InvalidActionException;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Service\ActionService;
+use OCA\Social\Service\BoostService;
+use OCA\Social\Service\LikeService;
+use OCA\Social\Service\StreamActionService;
+use OCA\Social\Service\StreamService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ActionServiceTest extends TestCase {
+	private const POST_ID = 'https://remote.example/notes/42';
+
+	private StreamService|MockObject $streamService;
+	private BoostService|MockObject $boostService;
+	private LikeService|MockObject $likeService;
+	private ActionService $service;
+	private Person $actor;
+	private Note $post;
+
+	protected function setUp(): void {
+		$this->streamService = $this->createMock(StreamService::class);
+		$this->boostService = $this->createMock(BoostService::class);
+		$this->likeService = $this->createMock(LikeService::class);
+		$this->service = new ActionService(
+			$this->streamService,
+			$this->boostService,
+			$this->likeService,
+			$this->createMock(StreamActionService::class),
+		);
+
+		$this->actor = new Person();
+		$this->actor->setId('https://cloud.example.com/apps/social/@alice');
+		$this->post = new Note();
+		$this->post->setId(self::POST_ID);
+		$this->post->setNid(42);
+	}
+
+	public function testUnknownActionIsRejectedBeforeLoadingThePost(): void {
+		$this->streamService->expects($this->never())->method('getStreamByNid');
+
+		$this->expectException(InvalidActionException::class);
+		$this->service->action($this->actor, 42, 'explode');
+	}
+
+	public function testFavouriteCreatesALike(): void {
+		$this->streamService->expects($this->once())->method('getStreamByNid')->with(42)->willReturn($this->post);
+		$this->likeService->expects($this->once())
+			->method('create')
+			->with($this->identicalTo($this->actor), self::POST_ID);
+		$this->likeService->expects($this->never())->method('delete');
+		$this->boostService->expects($this->never())->method('create');
+
+		$this->assertNull($this->service->action($this->actor, 42, 'favourite'));
+	}
+
+	public function testUnfavouriteDeletesTheLike(): void {
+		$this->streamService->method('getStreamByNid')->willReturn($this->post);
+		$this->likeService->expects($this->once())
+			->method('delete')
+			->with($this->identicalTo($this->actor), self::POST_ID);
+		$this->likeService->expects($this->never())->method('create');
+
+		$this->assertNull($this->service->action($this->actor, 42, 'unfavourite'));
+	}
+
+	public function testReblogCreatesABoost(): void {
+		$this->streamService->method('getStreamByNid')->willReturn($this->post);
+		$this->boostService->expects($this->once())
+			->method('create')
+			->with($this->identicalTo($this->actor), self::POST_ID);
+		$this->likeService->expects($this->never())->method('create');
+
+		$this->assertNull($this->service->action($this->actor, 42, 'reblog'));
+	}
+
+	public function testUnreblogDeletesTheBoost(): void {
+		$this->streamService->method('getStreamByNid')->willReturn($this->post);
+		$this->boostService->expects($this->once())
+			->method('delete')
+			->with($this->identicalTo($this->actor), self::POST_ID);
+		$this->boostService->expects($this->never())->method('create');
+
+		$this->assertNull($this->service->action($this->actor, 42, 'unreblog'));
+	}
+
+	public function testTranslateReturnsThePostItself(): void {
+		$this->streamService->method('getStreamByNid')->with(42)->willReturn($this->post);
+
+		$this->assertSame($this->post, $this->service->action($this->actor, 42, 'translate'));
+	}
+
+	/** @return array<string, array{string}> */
+	public function noopActionProvider(): array {
+		return [
+			'bookmark' => ['bookmark'],
+			'unbookmark' => ['unbookmark'],
+			'mute' => ['mute'],
+			'unmute' => ['unmute'],
+			'pin' => ['pin'],
+			'unpin' => ['unpin'],
+		];
+	}
+
+	/** @dataProvider noopActionProvider */
+	public function testKnownButUnimplementedActionsAreAcceptedSilently(string $action): void {
+		$this->streamService->expects($this->once())->method('getStreamByNid')->willReturn($this->post);
+		$this->likeService->expects($this->never())->method($this->anything());
+		$this->boostService->expects($this->never())->method($this->anything());
+
+		$this->assertNull($this->service->action($this->actor, 42, $action));
+	}
+}

--- a/tests/Service/ActivityServiceTest.php
+++ b/tests/Service/ActivityServiceTest.php
@@ -1,0 +1,695 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use OCA\Social\AP;
+use OCA\Social\Db\CacheActorsRequest;
+use OCA\Social\Db\FollowsRequest;
+use OCA\Social\Db\StreamRequest;
+use OCA\Social\Exceptions\ActorDoesNotExistException;
+use OCA\Social\Exceptions\EmptyQueueException;
+use OCA\Social\Exceptions\ItemAlreadyExistsException;
+use OCA\Social\Exceptions\NoHighPriorityRequestException;
+use OCA\Social\Exceptions\QueueStatusException;
+use OCA\Social\Exceptions\UnauthorizedFediverseException;
+use OCA\Social\Interfaces\Object\AnnounceInterface;
+use OCA\Social\Interfaces\Object\NoteInterface;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Activity\Create;
+use OCA\Social\Model\ActivityPub\Activity\Delete;
+use OCA\Social\Model\ActivityPub\Activity\Update;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Announce;
+use OCA\Social\Model\ActivityPub\Object\Follow;
+use OCA\Social\Model\ActivityPub\Object\Like;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Model\ActivityPub\Object\Tombstone;
+use OCA\Social\Model\ActivityPub\Stream;
+use OCA\Social\Model\InstancePath;
+use OCA\Social\Model\RequestQueue;
+use OCA\Social\Service\ActivityService;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\CurlService;
+use OCA\Social\Service\RequestQueueService;
+use OCA\Social\Service\SignatureService;
+use OCA\Social\Tools\Exceptions\RequestContentException;
+use OCA\Social\Tools\Exceptions\RequestNetworkException;
+use OCA\Social\Tools\Exceptions\RequestResultNotJsonException;
+use OCA\Social\Tools\Exceptions\RequestResultSizeException;
+use OCA\Social\Tools\Exceptions\RequestServerException;
+use OCA\Social\Tools\Model\NCRequest;
+use OCA\Social\Tools\Model\Request;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use ReflectionClass;
+
+class ActivityServiceTest extends TestCase {
+	private const CLOUD_URL = 'https://cloud.example';
+	private const ALICE_ID = 'https://social.example/@alice';
+	private const NOTE_ID = 'https://social.example/@alice/42';
+	private const BOB_INBOX = 'https://remote.example/users/bob/inbox';
+	private const TOKEN = 'a0b1c2d3-e4f5-4678-9abc-def012345678';
+
+	private FollowsRequest|MockObject $followsRequest;
+	private CacheActorsRequest|MockObject $cacheActorsRequest;
+	private SignatureService|MockObject $signatureService;
+	private RequestQueueService|MockObject $requestQueueService;
+	private CurlService|MockObject $curlService;
+	private NoteInterface|MockObject $noteInterface;
+	private AnnounceInterface|MockObject $announceInterface;
+	private ActivityService $service;
+
+	protected function setUp(): void {
+		$this->noteInterface = $this->createMock(NoteInterface::class);
+		$this->announceInterface = $this->createMock(AnnounceInterface::class);
+		$this->bootActivityPub([
+			NoteInterface::class => $this->noteInterface,
+			AnnounceInterface::class => $this->announceInterface,
+		]);
+
+		$this->followsRequest = $this->createMock(FollowsRequest::class);
+		$this->cacheActorsRequest = $this->createMock(CacheActorsRequest::class);
+		$this->signatureService = $this->createMock(SignatureService::class);
+		$this->requestQueueService = $this->createMock(RequestQueueService::class);
+		$this->curlService = $this->createMock(CurlService::class);
+
+		$this->service = new ActivityService(
+			$this->createMock(StreamRequest::class),
+			$this->followsRequest,
+			$this->cacheActorsRequest,
+			$this->signatureService,
+			$this->requestQueueService,
+			$this->curlService,
+			$this->createMock(ConfigService::class),
+			new NullLogger()
+		);
+	}
+
+	protected function tearDown(): void {
+		AP::$activityPub = null;
+	}
+
+	/**
+	 * @param array<class-string, object> $interfaces
+	 */
+	private function bootActivityPub(array $interfaces): void {
+		$args = [];
+		foreach ((new ReflectionClass(AP::class))->getConstructor()->getParameters() as $parameter) {
+			$class = $parameter->getType()->getName();
+			if (isset($interfaces[$class])) {
+				$args[] = $interfaces[$class];
+				continue;
+			}
+			$mock = $this->createMock($class);
+			if ($class === ConfigService::class) {
+				$mock->method('getCloudUrl')->willReturn(self::CLOUD_URL);
+			}
+			$args[] = $mock;
+		}
+		AP::$activityPub = new AP(...$args);
+	}
+
+	private function alice(): Person {
+		$alice = new Person();
+		$alice->setId(self::ALICE_ID);
+		$alice->setPreferredUsername('alice');
+		$alice->setFollowers(self::ALICE_ID . '/followers');
+		$alice->setLocal(true);
+
+		return $alice;
+	}
+
+	private function note(): Note {
+		$note = new Note();
+		$note->setId(self::NOTE_ID);
+		$note->setAttributedTo(self::ALICE_ID);
+		$note->setContent('hello');
+		$note->addInstancePath(new InstancePath(self::BOB_INBOX, InstancePath::TYPE_INBOX, InstancePath::PRIORITY_MEDIUM));
+
+		return $note;
+	}
+
+	private function follower(string $id, ?string $sharedInbox): Follow {
+		$follow = new Follow();
+		$follow->setActorId($id);
+		$follow->setObjectId(self::ALICE_ID);
+		if ($sharedInbox !== null) {
+			$actor = new Person();
+			$actor->setId($id);
+			$actor->setInbox($id . '/inbox');
+			$actor->setSharedInbox($sharedInbox);
+			$follow->setActor($actor);
+		}
+
+		return $follow;
+	}
+
+	private function queue(string $inbox = self::BOB_INBOX, int $type = InstancePath::TYPE_INBOX): RequestQueue {
+		$queue = new RequestQueue(
+			'{"type":"Like","id":"https://social.example/@alice#like/1"}',
+			new InstancePath($inbox, $type, InstancePath::PRIORITY_MEDIUM),
+			self::ALICE_ID
+		);
+		$queue->setToken(self::TOKEN);
+		$queue->setTimeout(10);
+
+		return $queue;
+	}
+
+	/** Queue a token and let the request flow run to the async hand-off without any inline delivery. */
+	private function expectQueuedWithoutInlineDelivery(): void {
+		$this->requestQueueService->method('generateRequestQueue')->willReturn(self::TOKEN);
+		$this->requestQueueService->method('getPriorityRequest')->willThrowException(new NoHighPriorityRequestException());
+		$this->requestQueueService->method('getRequestFromToken')->willReturn([]);
+	}
+
+	/**
+	 * Records the resolved InstancePath[] handed to the request queue.
+	 *
+	 * @param InstancePath[] $paths
+	 */
+	private function capturePaths(array &$paths): void {
+		$paths = [];
+		$this->requestQueueService->expects($this->once())
+			->method('generateRequestQueue')
+			->with($this->callback(function (array $instancePaths) use (&$paths): bool {
+				$paths = $instancePaths;
+
+				return true;
+			}), $this->isInstanceOf(ACore::class), $this->isType('string'))
+			->willReturn(self::TOKEN);
+		$this->requestQueueService->method('getPriorityRequest')->willThrowException(new NoHighPriorityRequestException());
+		$this->requestQueueService->method('getRequestFromToken')->willReturn([]);
+	}
+
+
+	// createActivity()
+
+	public function testCreateActivityWrapsItemSignsSavesAndQueuesIt(): void {
+		$alice = $this->alice();
+		$note = $this->note();
+
+		$this->signatureService->expects($this->once())
+			->method('signObject')
+			->with($this->identicalTo($alice), $this->isInstanceOf(Create::class));
+		$this->noteInterface->expects($this->once())->method('save')->with($this->identicalTo($note));
+
+		$queued = null;
+		$this->requestQueueService->expects($this->once())
+			->method('generateRequestQueue')
+			->with(
+				$this->identicalTo($note->getInstancePaths()),
+				$this->callback(function (ACore $item) use (&$queued): bool {
+					$queued = $item;
+
+					return true;
+				}),
+				self::ALICE_ID
+			)
+			->willReturn(self::TOKEN);
+		$this->requestQueueService->method('getPriorityRequest')->willThrowException(new NoHighPriorityRequestException());
+		$this->requestQueueService->method('getRequestFromToken')->with(self::TOKEN, RequestQueue::STATUS_STANDBY)->willReturn([]);
+
+		$activity = null;
+		$token = $this->service->createActivity($alice, $note, $activity);
+
+		$this->assertSame(self::TOKEN, $token);
+		$this->assertInstanceOf(Create::class, $activity);
+		$this->assertSame($activity, $queued);
+		$this->assertSame(self::NOTE_ID . '/activity', $activity->getId());
+		$this->assertSame($note, $activity->getObject());
+		$this->assertSame($activity, $note->getParent());
+		$this->assertSame($alice, $activity->getActor());
+		$this->assertSame(self::ALICE_ID, $activity->getActorId());
+		$this->assertSame($note->getInstancePaths(), $activity->getInstancePaths());
+		$this->assertTrue($activity->isRoot());
+	}
+
+	public function testCreateActivitySavesNestedObjectsInnermostFirst(): void {
+		$note = $this->note();
+		$announce = new Announce();
+		$announce->setId(self::ALICE_ID . '/boost/1');
+		$announce->setObject($note);
+		$this->expectQueuedWithoutInlineDelivery();
+
+		$order = [];
+		$this->noteInterface->expects($this->once())->method('save')->willReturnCallback(function () use (&$order): void {
+			$order[] = 'note';
+		});
+		$this->announceInterface->expects($this->once())->method('save')->willReturnCallback(function () use (&$order): void {
+			$order[] = 'announce';
+		});
+
+		$this->service->createActivity($this->alice(), $announce);
+
+		$this->assertSame(['note', 'announce'], $order);
+	}
+
+	public function testCreateActivityToleratesAnAlreadyStoredObject(): void {
+		$this->noteInterface->method('save')->willThrowException(new ItemAlreadyExistsException());
+		$this->expectQueuedWithoutInlineDelivery();
+
+		$this->assertSame(self::TOKEN, $this->service->createActivity($this->alice(), $this->note()));
+	}
+
+	public function testCreateActivityToleratesObjectsWithoutStorage(): void {
+		$stream = new Stream();
+		$stream->setId(self::NOTE_ID);
+		$stream->setType('Unknown');
+		$this->expectQueuedWithoutInlineDelivery();
+
+		$this->assertSame(self::TOKEN, $this->service->createActivity($this->alice(), $stream, $activity));
+		$this->assertSame($stream, $activity->getObject());
+	}
+
+
+	// updateActivity()
+
+	public function testUpdateActivityWrapsItemInSignedUpdateWithoutSavingIt(): void {
+		$alice = $this->alice();
+		$note = $this->note();
+		$this->signatureService->expects($this->once())
+			->method('signObject')
+			->with($this->identicalTo($alice), $this->isInstanceOf(Update::class));
+		$this->noteInterface->expects($this->never())->method('save');
+
+		$queued = null;
+		$this->requestQueueService->expects($this->once())
+			->method('generateRequestQueue')
+			->with($this->identicalTo($note->getInstancePaths()), $this->callback(function (ACore $item) use (&$queued): bool {
+				$queued = $item;
+
+				return true;
+			}), self::ALICE_ID)
+			->willReturn(self::TOKEN);
+		$this->requestQueueService->method('getPriorityRequest')->willThrowException(new NoHighPriorityRequestException());
+		$this->requestQueueService->method('getRequestFromToken')->willReturn([]);
+
+		$this->assertSame(self::TOKEN, $this->service->updateActivity($alice, $note));
+
+		$this->assertInstanceOf(Update::class, $queued);
+		$this->assertSame(self::NOTE_ID . '/activity#update', $queued->getId());
+		$this->assertSame($note, $queued->getObject());
+		$this->assertSame($queued, $note->getParent());
+		$this->assertSame($alice, $queued->getActor());
+	}
+
+
+	// deleteActivity()
+
+	public function testDeleteActivitySendsTombstoneOnBehalfOfItemAuthor(): void {
+		$note = $this->note();
+		$note->setActorId(self::ALICE_ID);
+		$this->signatureService->expects($this->never())->method('signObject');
+		$this->noteInterface->expects($this->never())->method('save');
+
+		$queued = null;
+		$this->requestQueueService->expects($this->once())
+			->method('generateRequestQueue')
+			->with($this->identicalTo($note->getInstancePaths()), $this->callback(function (ACore $item) use (&$queued): bool {
+				$queued = $item;
+
+				return true;
+			}), self::ALICE_ID)
+			->willReturn(self::TOKEN);
+		$this->requestQueueService->method('getPriorityRequest')->willThrowException(new NoHighPriorityRequestException());
+		$this->requestQueueService->method('getRequestFromToken')->willReturn([]);
+
+		$this->assertSame(self::TOKEN, $this->service->deleteActivity($note));
+
+		$this->assertInstanceOf(Delete::class, $queued);
+		$this->assertSame(self::NOTE_ID . '#delete', $queued->getId());
+		$this->assertSame(self::ALICE_ID, $queued->getActorId());
+		$this->assertFalse($queued->hasActor());
+		$this->assertInstanceOf(Tombstone::class, $queued->getObject());
+		$this->assertSame(self::NOTE_ID, $queued->getObject()->getId());
+		$this->assertSame(self::NOTE_ID, $queued->getObjectId());
+		$this->assertSame($queued, $queued->getObject()->getParent());
+	}
+
+
+	// request(): recipient resolution
+
+	public function testRequestKeepsDirectInboxTargets(): void {
+		$paths = [];
+		$this->capturePaths($paths);
+		$like = new Like();
+		$like->setActorId(self::ALICE_ID);
+		$direct = new InstancePath(self::BOB_INBOX, InstancePath::TYPE_INBOX, InstancePath::PRIORITY_HIGH);
+		$like->addInstancePath($direct);
+
+		$this->assertSame(self::TOKEN, $this->service->request($like));
+		$this->assertSame([$direct], $paths);
+	}
+
+	public function testRequestExpandsFollowersToDeduplicatedSharedInboxes(): void {
+		$paths = [];
+		$this->capturePaths($paths);
+		$this->followsRequest->expects($this->once())
+			->method('getFollowersByActorId')
+			->with(self::ALICE_ID)
+			->willReturn([
+				$this->follower('https://remote.example/users/bob', 'https://remote.example/inbox'),
+				$this->follower('https://remote.example/users/carol', 'https://remote.example/inbox'),
+				$this->follower('https://other.example/users/dave', 'https://other.example/inbox'),
+				$this->follower('https://gone.example/users/erin', null),
+			]);
+
+		$note = new Note();
+		$note->setActorId(self::ALICE_ID);
+		$note->addInstancePath(new InstancePath(self::ALICE_ID, InstancePath::TYPE_FOLLOWERS, InstancePath::PRIORITY_LOW));
+
+		$this->service->request($note);
+
+		$this->assertCount(2, $paths);
+		$this->assertSame('https://remote.example/inbox', $paths[0]->getUri());
+		$this->assertSame(InstancePath::TYPE_GLOBAL, $paths[0]->getType());
+		$this->assertSame(InstancePath::PRIORITY_LOW, $paths[0]->getPriority());
+		$this->assertSame('https://other.example/inbox', $paths[1]->getUri());
+		$this->assertSame(InstancePath::TYPE_GLOBAL, $paths[1]->getType());
+	}
+
+	public function testRequestExpandsAllToEveryKnownSharedInbox(): void {
+		$paths = [];
+		$this->capturePaths($paths);
+		$this->cacheActorsRequest->expects($this->once())
+			->method('getSharedInboxes')
+			->willReturn(['https://remote.example/inbox', 'https://other.example/inbox']);
+
+		$item = new Update();
+		$item->setActorId(self::ALICE_ID);
+		$item->addInstancePath(new InstancePath('https://social.example/', InstancePath::TYPE_ALL, InstancePath::PRIORITY_HIGH));
+
+		$this->service->request($item);
+
+		$this->assertCount(2, $paths);
+		$this->assertSame('https://remote.example/inbox', $paths[0]->getUri());
+		$this->assertSame(InstancePath::TYPE_GLOBAL, $paths[0]->getType());
+		$this->assertSame(InstancePath::PRIORITY_LOW, $paths[0]->getPriority());
+	}
+
+	public function testRequestCombinesFollowersAndDirectTargets(): void {
+		$paths = [];
+		$this->capturePaths($paths);
+		$this->followsRequest->method('getFollowersByActorId')->willReturn([
+			$this->follower('https://remote.example/users/bob', 'https://remote.example/inbox'),
+		]);
+
+		$note = $this->note();
+		$note->setActorId(self::ALICE_ID);
+		$note->addInstancePath(new InstancePath(self::ALICE_ID, InstancePath::TYPE_FOLLOWERS, InstancePath::PRIORITY_LOW));
+
+		$this->service->request($note);
+
+		$this->assertCount(2, $paths);
+		$this->assertSame(self::BOB_INBOX, $paths[0]->getUri());
+		$this->assertSame('https://remote.example/inbox', $paths[1]->getUri());
+	}
+
+	public function testRequestAuthorIsTheActorObjectWhenPresent(): void {
+		$item = new Like();
+		$item->setActorId('https://social.example/@someone-else');
+		$item->setActor($this->alice());
+		$this->requestQueueService->expects($this->once())
+			->method('generateRequestQueue')
+			->with([], $this->identicalTo($item), self::ALICE_ID)
+			->willReturn('');
+
+		$this->service->request($item);
+	}
+
+
+	// request(): queue lifecycle
+
+	public function testRequestWithoutAnyTargetNeedsNoToken(): void {
+		$this->requestQueueService->method('generateRequestQueue')->willReturn('');
+		$this->requestQueueService->expects($this->never())->method('getPriorityRequest');
+		$this->requestQueueService->expects($this->never())->method('getRequestFromToken');
+		$this->curlService->expects($this->never())->method('asyncWithToken');
+
+		$like = new Like();
+		$like->setActorId(self::ALICE_ID);
+
+		$this->assertSame('<request token not needed>', $this->service->request($like));
+	}
+
+	public function testRequestDeliversPriorityTargetInlineAndHandsTheRestToAsync(): void {
+		$direct = $this->queue();
+		$this->requestQueueService->method('generateRequestQueue')->willReturn(self::TOKEN);
+		$this->requestQueueService->expects($this->once())
+			->method('getPriorityRequest')
+			->with(self::TOKEN)
+			->willReturn($direct);
+		$this->requestQueueService->expects($this->once())->method('initRequest')->with($this->identicalTo($direct));
+		$this->signatureService->expects($this->once())->method('signRequest')->with($this->isInstanceOf(NCRequest::class), $this->identicalTo($direct));
+		$this->curlService->expects($this->once())->method('retrieveJson')->willReturn([]);
+		$this->requestQueueService->expects($this->once())->method('endRequest')->with($this->identicalTo($direct), true);
+		$this->requestQueueService->expects($this->once())
+			->method('getRequestFromToken')
+			->with(self::TOKEN, RequestQueue::STATUS_STANDBY)
+			->willReturn([$this->queue('https://other.example/inbox')]);
+		$this->curlService->expects($this->once())->method('asyncWithToken')->with(self::TOKEN);
+
+		$like = new Like();
+		$like->setActorId(self::ALICE_ID);
+		$like->addInstancePath(new InstancePath(self::BOB_INBOX, InstancePath::TYPE_INBOX, InstancePath::PRIORITY_HIGH));
+
+		$this->assertSame(self::TOKEN, $this->service->request($like));
+		$this->assertSame(ActivityService::TIMEOUT_LIVE, $direct->getTimeout());
+	}
+
+	public function testRequestSkipsAsyncWhenNothingIsLeftInStandby(): void {
+		$this->requestQueueService->method('generateRequestQueue')->willReturn(self::TOKEN);
+		$this->requestQueueService->method('getPriorityRequest')->willReturn($this->queue());
+		$this->curlService->method('retrieveJson')->willReturn([]);
+		$this->requestQueueService->method('getRequestFromToken')->willReturn([]);
+		$this->curlService->expects($this->never())->method('asyncWithToken');
+
+		$like = new Like();
+		$like->setActorId(self::ALICE_ID);
+		$like->addInstancePath(new InstancePath(self::BOB_INBOX, InstancePath::TYPE_INBOX, InstancePath::PRIORITY_TOP));
+
+		$this->assertSame(self::TOKEN, $this->service->request($like));
+	}
+
+	public function testRequestWithoutPriorityTargetGoesStraightToAsync(): void {
+		$this->requestQueueService->method('generateRequestQueue')->willReturn(self::TOKEN);
+		$this->requestQueueService->method('getPriorityRequest')->willThrowException(new NoHighPriorityRequestException());
+		$this->requestQueueService->expects($this->never())->method('initRequest');
+		$this->curlService->expects($this->never())->method('retrieveJson');
+		$this->requestQueueService->method('getRequestFromToken')->willReturn([$this->queue()]);
+		$this->curlService->expects($this->once())->method('asyncWithToken')->with(self::TOKEN);
+
+		$note = $this->note();
+		$note->setActorId(self::ALICE_ID);
+
+		$this->assertSame(self::TOKEN, $this->service->request($note));
+	}
+
+	public function testRequestReturnsTokenWhenQueueTurnsOutEmpty(): void {
+		$this->requestQueueService->method('generateRequestQueue')->willReturn(self::TOKEN);
+		$this->requestQueueService->method('getPriorityRequest')->willThrowException(new EmptyQueueException());
+		$this->requestQueueService->expects($this->never())->method('getRequestFromToken');
+		$this->curlService->expects($this->never())->method('asyncWithToken');
+
+		$note = $this->note();
+		$note->setActorId(self::ALICE_ID);
+
+		$this->assertSame(self::TOKEN, $this->service->request($note));
+	}
+
+
+	// manageRequest()
+
+	public function testManageRequestPostsSignedActivityToInboxAndEndsRequestOnSuccess(): void {
+		$queue = $this->queue();
+		$this->requestQueueService->expects($this->once())->method('initRequest')->with($this->identicalTo($queue));
+
+		$signed = null;
+		$this->signatureService->expects($this->once())
+			->method('signRequest')
+			->with($this->callback(function (NCRequest $request) use (&$signed): bool {
+				$signed = $request;
+
+				return true;
+			}), $this->identicalTo($queue));
+		$sent = null;
+		$this->curlService->expects($this->once())
+			->method('retrieveJson')
+			->with($this->callback(function (NCRequest $request) use (&$sent): bool {
+				$sent = $request;
+
+				return true;
+			}))
+			->willReturn(['ok' => true]);
+		$this->requestQueueService->expects($this->once())->method('endRequest')->with($this->identicalTo($queue), true);
+		$this->requestQueueService->expects($this->never())->method('deleteRequest');
+
+		$this->service->manageInit();
+		$this->service->manageRequest($queue);
+
+		$this->assertSame($signed, $sent);
+		$this->assertSame(Request::TYPE_POST, $sent->getType());
+		$this->assertSame('remote.example', $sent->getHost());
+		$this->assertSame('/users/bob/inbox', $sent->getPath());
+		$this->assertSame(['https'], $sent->getProtocols());
+		$this->assertSame(10, $sent->getTimeout());
+		$this->assertSame(json_decode($queue->getActivity(), true), $sent->getData());
+	}
+
+	/**
+	 * @return array<string, array{int, int}>
+	 */
+	public function requestTypeProvider(): array {
+		return [
+			'inbox is posted to' => [InstancePath::TYPE_INBOX, Request::TYPE_POST],
+			'shared inbox is posted to' => [InstancePath::TYPE_GLOBAL, Request::TYPE_POST],
+			'followers is posted to' => [InstancePath::TYPE_FOLLOWERS, Request::TYPE_POST],
+			'public path is fetched' => [InstancePath::TYPE_PUBLIC, Request::TYPE_GET],
+		];
+	}
+
+	/**
+	 * @dataProvider requestTypeProvider
+	 */
+	public function testManageRequestPicksHttpMethodFromTargetType(int $pathType, int $expectedMethod): void {
+		$sent = null;
+		$this->curlService->method('retrieveJson')->willReturnCallback(function (NCRequest $request) use (&$sent): array {
+			$sent = $request;
+
+			return [];
+		});
+
+		$this->service->manageInit();
+		$this->service->manageRequest($this->queue(self::BOB_INBOX, $pathType));
+
+		$this->assertSame($expectedMethod, $sent->getType());
+	}
+
+	/**
+	 * @return array<string, array{\Exception}>
+	 */
+	public function deliveredButNoJsonProvider(): array {
+		return [
+			'non-json answer' => [new RequestResultNotJsonException()],
+			'instance not authorized' => [new UnauthorizedFediverseException()],
+		];
+	}
+
+	/**
+	 * @dataProvider deliveredButNoJsonProvider
+	 */
+	public function testManageRequestTreatsNonJsonAnswersAsDelivered(\Exception $e): void {
+		$queue = $this->queue();
+		$this->curlService->method('retrieveJson')->willThrowException($e);
+		$this->requestQueueService->expects($this->once())->method('endRequest')->with($this->identicalTo($queue), true);
+		$this->requestQueueService->expects($this->never())->method('deleteRequest');
+
+		$this->service->manageInit();
+		$this->service->manageRequest($queue);
+	}
+
+	/**
+	 * @return array<string, array{\Exception}>
+	 */
+	public function hardErrorProvider(): array {
+		return [
+			'bad content' => [new RequestContentException()],
+			'answer too large' => [new RequestResultSizeException()],
+			'actor is gone' => [new ActorDoesNotExistException()],
+		];
+	}
+
+	/**
+	 * @dataProvider hardErrorProvider
+	 */
+	public function testManageRequestDropsRequestOnHardErrors(\Exception $e): void {
+		$queue = $this->queue();
+		$this->curlService->method('retrieveJson')->willThrowException($e);
+		$this->requestQueueService->expects($this->once())->method('deleteRequest')->with($this->identicalTo($queue));
+		$this->requestQueueService->expects($this->never())->method('endRequest');
+
+		$this->service->manageInit();
+		$this->service->manageRequest($queue);
+	}
+
+	/**
+	 * @return array<string, array{\Exception}>
+	 */
+	public function temporaryErrorProvider(): array {
+		return [
+			'network error' => [new RequestNetworkException()],
+			'server error' => [new RequestServerException()],
+		];
+	}
+
+	/**
+	 * @dataProvider temporaryErrorProvider
+	 */
+	public function testManageRequestMarksFailureAndSkipsSameInstanceForTheRestOfTheRun(\Exception $e): void {
+		$first = $this->queue(self::BOB_INBOX);
+		$second = $this->queue('https://remote.example/users/carol/inbox');
+		$elsewhere = $this->queue('https://other.example/inbox', InstancePath::TYPE_GLOBAL);
+
+		$this->curlService->expects($this->exactly(2))
+			->method('retrieveJson')
+			->willReturnCallback(function (NCRequest $request) use ($e): array {
+				if ($request->getHost() === 'remote.example') {
+					throw $e;
+				}
+
+				return [];
+			});
+		$inits = [];
+		$this->requestQueueService->expects($this->exactly(2))
+			->method('initRequest')
+			->willReturnCallback(function (RequestQueue $queue) use (&$inits): void {
+				$inits[] = $queue->getInstance()->getUri();
+			});
+		$ended = [];
+		$this->requestQueueService->expects($this->exactly(2))
+			->method('endRequest')
+			->willReturnCallback(function (RequestQueue $queue, bool $success) use (&$ended): void {
+				$ended[] = [$queue->getInstance()->getUri(), $success];
+			});
+		$this->requestQueueService->expects($this->never())->method('deleteRequest');
+
+		$this->service->manageInit();
+		$this->service->manageRequest($first);
+		$this->service->manageRequest($second);
+		$this->service->manageRequest($elsewhere);
+
+		$this->assertSame([self::BOB_INBOX, 'https://other.example/inbox'], $inits);
+		$this->assertSame([[self::BOB_INBOX, false], ['https://other.example/inbox', true]], $ended);
+	}
+
+	public function testManageInitForgetsFailedInstances(): void {
+		$this->curlService->method('retrieveJson')->willThrowException(new RequestNetworkException());
+		$this->requestQueueService->expects($this->exactly(2))->method('initRequest');
+		$this->requestQueueService->expects($this->exactly(2))->method('endRequest')->with($this->anything(), false);
+
+		$this->service->manageInit();
+		$this->service->manageRequest($this->queue());
+		$this->service->manageInit();
+		$this->service->manageRequest($this->queue());
+	}
+
+	public function testManageRequestGivesUpWhenQueueEntryCannotBeClaimed(): void {
+		$this->requestQueueService->method('initRequest')->willThrowException(new QueueStatusException());
+		$this->signatureService->expects($this->never())->method('signRequest');
+		$this->curlService->expects($this->never())->method('retrieveJson');
+		$this->requestQueueService->expects($this->never())->method('endRequest');
+		$this->requestQueueService->expects($this->never())->method('deleteRequest');
+
+		$this->service->manageInit();
+		$this->service->manageRequest($this->queue());
+	}
+}

--- a/tests/Service/ActorServiceTest.php
+++ b/tests/Service/ActorServiceTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use OCA\Social\AP;
+use OCA\Social\Db\CacheActorsRequest;
+use OCA\Social\Db\CacheDocumentsRequest;
+use OCA\Social\Exceptions\CacheActorDoesNotExistException;
+use OCA\Social\Exceptions\CacheDocumentDoesNotExistException;
+use OCA\Social\Exceptions\ItemUnknownException;
+use OCA\Social\Interfaces\Object\ImageInterface;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Image;
+use OCA\Social\Service\ActorService;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\CurlService;
+use OCA\Social\Service\MiscService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ActorServiceTest extends TestCase {
+	private const ALICE = 'https://cloud.example.com/apps/social/@alice';
+	private const ICON_URL = 'https://cloud.example.com/avatar/alice/128';
+
+	private CacheActorsRequest|MockObject $cacheActorsRequest;
+	private CacheDocumentsRequest|MockObject $cacheDocumentsRequest;
+	private AP|MockObject $ap;
+	private ActorService $service;
+
+	protected function setUp(): void {
+		$this->cacheActorsRequest = $this->createMock(CacheActorsRequest::class);
+		$this->cacheDocumentsRequest = $this->createMock(CacheDocumentsRequest::class);
+		$this->ap = $this->createMock(AP::class);
+		AP::$activityPub = $this->ap;
+
+		$this->service = new ActorService(
+			$this->cacheActorsRequest,
+			$this->cacheDocumentsRequest,
+			$this->createMock(CurlService::class),
+			$this->createMock(ConfigService::class),
+			$this->createMock(MiscService::class),
+		);
+	}
+
+	protected function tearDown(): void {
+		AP::$activityPub = null;
+	}
+
+	private function alice(bool $withIcon = false): Person {
+		$alice = new Person();
+		$alice->setId(self::ALICE);
+		$alice->setPreferredUsername('alice');
+		if ($withIcon) {
+			$icon = new Image();
+			$icon->setUrl(self::ICON_URL);
+			$icon->setMediaType('image/png');
+			$alice->setIcon($icon);
+		}
+
+		return $alice;
+	}
+
+	public function testCacheLocalActorUpdatesAnAlreadyCachedActor(): void {
+		$alice = $this->alice();
+		$this->cacheActorsRequest->method('getFromId')->with(self::ALICE)->willReturn(new Person());
+		$this->cacheActorsRequest->expects($this->once())->method('update')->with($this->identicalTo($alice))->willReturn(1);
+		$this->cacheActorsRequest->expects($this->never())->method('save');
+
+		$this->service->cacheLocalActor($alice);
+
+		$this->assertTrue($alice->isLocal());
+		$source = json_decode($alice->getSource(), true);
+		$this->assertSame(self::ALICE, $source['id']);
+		$this->assertSame('alice', $source['preferredUsername']);
+	}
+
+	public function testCacheLocalActorSavesANewActor(): void {
+		$alice = $this->alice();
+		$this->cacheActorsRequest->method('getFromId')->willThrowException(new CacheActorDoesNotExistException());
+		$this->cacheActorsRequest->expects($this->once())->method('save')->with($this->identicalTo($alice));
+		$this->cacheActorsRequest->expects($this->never())->method('update');
+
+		$this->service->cacheLocalActor($alice);
+	}
+
+	public function testCacheLocalActorDetailsDelegates(): void {
+		$alice = $this->alice();
+		$this->cacheActorsRequest->expects($this->once())->method('updateDetails')->with($this->identicalTo($alice));
+
+		$this->service->cacheLocalActorDetails($alice);
+	}
+
+	public function testSaveReusesAnAlreadyCachedIcon(): void {
+		$alice = $this->alice(true);
+		$cachedIcon = new Image();
+		$cachedIcon->setUrl(self::ICON_URL);
+		$cachedIcon->setLocalCopy('local-copy');
+		$this->cacheDocumentsRequest->expects($this->once())->method('getByUrl')->with(self::ICON_URL)->willReturn($cachedIcon);
+		$this->ap->expects($this->never())->method('getInterfaceFromType');
+		$this->cacheActorsRequest->expects($this->once())->method('save')->with($this->identicalTo($alice));
+
+		$this->service->save($alice);
+
+		$this->assertSame($cachedIcon, $alice->getIcon());
+		$this->assertSame($alice, $cachedIcon->getParent());
+	}
+
+	public function testSaveCachesAnUnknownIconThroughItsInterface(): void {
+		$alice = $this->alice(true);
+		$originalIcon = $alice->getIcon();
+		$this->cacheDocumentsRequest->method('getByUrl')->willThrowException(new CacheDocumentDoesNotExistException());
+		$imageInterface = $this->createMock(ImageInterface::class);
+		$imageInterface->expects($this->once())->method('save')->with($this->identicalTo($originalIcon));
+		$this->ap->expects($this->once())->method('getInterfaceFromType')->with(Image::TYPE)->willReturn($imageInterface);
+		$this->cacheActorsRequest->expects($this->once())->method('save');
+
+		$this->service->save($alice);
+
+		$this->assertSame($originalIcon, $alice->getIcon());
+	}
+
+	public function testSaveToleratesAnIconTypeWithoutInterface(): void {
+		$alice = $this->alice(true);
+		$this->cacheDocumentsRequest->method('getByUrl')->willThrowException(new CacheDocumentDoesNotExistException());
+		$this->ap->method('getInterfaceFromType')->willThrowException(new ItemUnknownException());
+		$this->cacheActorsRequest->expects($this->once())->method('save');
+
+		$this->service->save($alice);
+	}
+
+	public function testSaveWithoutIconSkipsTheDocumentCache(): void {
+		$this->cacheDocumentsRequest->expects($this->never())->method('getByUrl');
+		$this->cacheActorsRequest->expects($this->once())->method('save');
+
+		$this->service->save($this->alice());
+	}
+
+	public function testUpdateReturnsTheNumberOfTouchedRows(): void {
+		$alice = $this->alice(true);
+		$this->cacheDocumentsRequest->method('getByUrl')->willReturn(new Image());
+		$this->cacheActorsRequest->expects($this->once())->method('update')->with($this->identicalTo($alice))->willReturn(1);
+
+		$this->assertSame(1, $this->service->update($alice));
+	}
+
+	public function testGetCachedHeaderReadsTheLocalCache(): void {
+		$cached = new Person();
+		$cached->setHeader('https://cloud.example.com/apps/social/media/header.jpg');
+		$this->cacheActorsRequest->expects($this->once())->method('getFromLocalAccount')->with('alice')->willReturn($cached);
+
+		$this->assertSame('https://cloud.example.com/apps/social/media/header.jpg', $this->service->getCachedHeader($this->alice()));
+	}
+
+	public function testGetCachedHeaderIsEmptyWhenNoneIsSet(): void {
+		$this->cacheActorsRequest->method('getFromLocalAccount')->willReturn(new Person());
+
+		$this->assertSame('', $this->service->getCachedHeader($this->alice()));
+	}
+}

--- a/tests/Service/BlurServiceTest.php
+++ b/tests/Service/BlurServiceTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use GdImage;
+use OCA\Social\Service\BlurService;
+use PHPUnit\Framework\TestCase;
+
+class BlurServiceTest extends TestCase {
+	private const BASE83 = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz#$%*+,-.:;=?@[]^_{|}~';
+
+	private function solidImage(int $r, int $g, int $b, int $size = 4): GdImage {
+		$image = imagecreatetruecolor($size, $size);
+		imagefill($image, 0, 0, imagecolorallocate($image, $r, $g, $b));
+
+		return $image;
+	}
+
+	public function testGeneratesAFourByThreeComponentBlurhash(): void {
+		$hash = (new BlurService())->generateBlurHash($this->solidImage(200, 30, 30));
+
+		// 1 size flag + 1 max-AC + 4 DC + 2 per AC component (4 * 3 - 1 of them)
+		$this->assertSame(28, strlen($hash));
+		$this->assertMatchesRegularExpression('/^[' . preg_quote(self::BASE83, '/') . ']+$/', $hash);
+		// the first character encodes (x - 1) + (y - 1) * 9 = 3 + 2 * 9 = 21
+		$this->assertSame(self::BASE83[21], $hash[0]);
+	}
+
+	public function testHashIsDeterministicForIdenticalPixels(): void {
+		$service = new BlurService();
+
+		$this->assertSame(
+			$service->generateBlurHash($this->solidImage(10, 200, 90)),
+			$service->generateBlurHash($this->solidImage(10, 200, 90)),
+		);
+	}
+
+	public function testDifferentColorsGiveDifferentHashes(): void {
+		$service = new BlurService();
+
+		$this->assertNotSame(
+			$service->generateBlurHash($this->solidImage(255, 0, 0)),
+			$service->generateBlurHash($this->solidImage(0, 0, 255)),
+		);
+	}
+
+	public function testGradientProducesNonZeroAcComponents(): void {
+		$image = imagecreatetruecolor(8, 8);
+		for ($x = 0; $x < 8; $x++) {
+			imageline($image, $x, 0, $x, 7, imagecolorallocate($image, $x * 32, 0, 255 - $x * 32));
+		}
+		$solid = (new BlurService())->generateBlurHash($this->solidImage(128, 0, 128, 8));
+
+		$gradient = (new BlurService())->generateBlurHash($image);
+
+		// a solid color has every AC component at the neutral value, a gradient must not
+		$this->assertSame(28, strlen($gradient));
+		$this->assertNotSame(substr($solid, 6), substr($gradient, 6));
+	}
+}

--- a/tests/Service/BoostServiceTest.php
+++ b/tests/Service/BoostServiceTest.php
@@ -1,0 +1,403 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use OCA\Social\AP;
+use OCA\Social\Db\StreamRequest;
+use OCA\Social\Exceptions\CacheActorDoesNotExistException;
+use OCA\Social\Exceptions\ItemAlreadyExistsException;
+use OCA\Social\Exceptions\StreamNotFoundException;
+use OCA\Social\Interfaces\Object\AnnounceInterface;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Activity\Undo;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Announce;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Model\InstancePath;
+use OCA\Social\Model\StreamAction;
+use OCA\Social\Service\ActivityService;
+use OCA\Social\Service\BoostService;
+use OCA\Social\Service\CacheActorService;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\CurlService;
+use OCA\Social\Service\SignatureService;
+use OCA\Social\Service\StreamActionService;
+use OCA\Social\Service\StreamQueueService;
+use OCA\Social\Service\StreamService;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use ReflectionClass;
+
+/**
+ * BoostService relies on StreamService::assignItem() to address the Announce,
+ * so a real StreamService (over a mocked StreamRequest) is used here.
+ */
+class BoostServiceTest extends TestCase {
+	private const CLOUD_URL = 'https://cloud.example';
+	private const ALICE_ID = 'https://social.example/@alice';
+	private const ALICE_FOLLOWERS = 'https://social.example/@alice/followers';
+	private const GENERATED_ID = 'https://social.example/@alice/1234567890';
+	private const BOB_ID = 'https://remote.example/users/bob';
+	private const POST_ID = 'https://remote.example/notes/1';
+	private const ANNOUNCE_ID = 'https://social.example/@alice/777';
+
+	private StreamRequest|MockObject $streamRequest;
+	private SignatureService|MockObject $signatureService;
+	private ActivityService|MockObject $activityService;
+	private StreamActionService|MockObject $streamActionService;
+	private StreamQueueService|MockObject $streamQueueService;
+	private CacheActorService|MockObject $cacheActorService;
+	private AnnounceInterface|MockObject $announceInterface;
+	private BoostService $service;
+
+	protected function setUp(): void {
+		$this->announceInterface = $this->createMock(AnnounceInterface::class);
+		$this->bootActivityPub([AnnounceInterface::class => $this->announceInterface]);
+
+		$this->streamRequest = $this->createMock(StreamRequest::class);
+		$this->signatureService = $this->createMock(SignatureService::class);
+		$this->activityService = $this->createMock(ActivityService::class);
+		$this->streamActionService = $this->createMock(StreamActionService::class);
+		$this->streamQueueService = $this->createMock(StreamQueueService::class);
+		$this->cacheActorService = $this->createMock(CacheActorService::class);
+
+		$configService = $this->createMock(ConfigService::class);
+		$configService->method('generateId')->willReturn(self::GENERATED_ID);
+		$configService->method('getSocialUrl')->willReturn('https://social.example/');
+
+		$streamService = new StreamService(
+			$this->createMock(IURLGenerator::class),
+			$this->streamRequest,
+			$this->activityService,
+			$this->cacheActorService,
+			$configService,
+			$this->createMock(CurlService::class),
+			new NullLogger()
+		);
+
+		$this->service = new BoostService(
+			$this->streamRequest,
+			$streamService,
+			$this->signatureService,
+			$this->activityService,
+			$this->streamActionService,
+			$this->streamQueueService,
+			$this->cacheActorService,
+			new NullLogger()
+		);
+	}
+
+	protected function tearDown(): void {
+		AP::$activityPub = null;
+	}
+
+	/**
+	 * @param array<class-string, object> $interfaces
+	 */
+	private function bootActivityPub(array $interfaces): void {
+		$args = [];
+		foreach ((new ReflectionClass(AP::class))->getConstructor()->getParameters() as $parameter) {
+			$class = $parameter->getType()->getName();
+			if (isset($interfaces[$class])) {
+				$args[] = $interfaces[$class];
+				continue;
+			}
+			$mock = $this->createMock($class);
+			if ($class === ConfigService::class) {
+				$mock->method('getCloudUrl')->willReturn(self::CLOUD_URL);
+			}
+			$args[] = $mock;
+		}
+		AP::$activityPub = new AP(...$args);
+	}
+
+	private function alice(): Person {
+		$alice = new Person();
+		$alice->setId(self::ALICE_ID);
+		$alice->setPreferredUsername('alice');
+		$alice->setFollowers(self::ALICE_FOLLOWERS);
+		$alice->setLocal(true);
+
+		return $alice;
+	}
+
+	private function bob(): Person {
+		$bob = new Person();
+		$bob->setId(self::BOB_ID);
+		$bob->setPreferredUsername('bob');
+		$bob->setInbox(self::BOB_ID . '/inbox');
+
+		return $bob;
+	}
+
+	private function publicNote(): Note {
+		$note = new Note();
+		$note->setId(self::POST_ID);
+		$note->setAttributedTo(self::BOB_ID);
+		$note->setTo(ACore::CONTEXT_PUBLIC);
+		$note->addCc(self::BOB_ID . '/followers');
+
+		return $note;
+	}
+
+	private function storedAnnounce(): Announce {
+		$announce = new Announce();
+		$announce->setId(self::ANNOUNCE_ID);
+		$announce->setActorId(self::ALICE_ID);
+		$announce->setObjectId(self::POST_ID);
+
+		return $announce;
+	}
+
+	/**
+	 * @param InstancePath[] $paths
+	 */
+	private function assertHasInstancePath(array $paths, string $uri, int $type, int $priority): void {
+		foreach ($paths as $path) {
+			if ($path->getUri() === $uri && $path->getType() === $type && $path->getPriority() === $priority) {
+				$this->addToAssertionCount(1);
+
+				return;
+			}
+		}
+
+		$this->fail('No instance path for ' . $uri . ' (type ' . $type . ', priority ' . $priority . ') in ' . json_encode($paths));
+	}
+
+
+	// create()
+
+	public function testCreateBuildsPublicAnnounceSavesFlagsAndFederatesIt(): void {
+		$alice = $this->alice();
+		$this->streamRequest->expects($this->once())
+			->method('getStreamById')
+			->with(self::POST_ID, true)
+			->willReturn($this->publicNote());
+		$this->cacheActorService->method('getFromId')->with(self::BOB_ID)->willReturn($this->bob());
+
+		$saved = null;
+		$this->announceInterface->expects($this->once())
+			->method('save')
+			->with($this->callback(function (ACore $item) use (&$saved): bool {
+				$saved = $item;
+
+				return true;
+			}));
+		$this->streamActionService->expects($this->once())
+			->method('setActionBool')
+			->with(self::ALICE_ID, self::POST_ID, StreamAction::BOOSTED, true);
+		$this->signatureService->expects($this->once())
+			->method('signObject')
+			->with($this->identicalTo($alice), $this->isInstanceOf(Announce::class));
+		$this->activityService->expects($this->once())
+			->method('request')
+			->with($this->isInstanceOf(Announce::class))
+			->willReturn('token-boost');
+		$this->streamQueueService->expects($this->once())
+			->method('cacheStreamByToken')
+			->with($this->callback(fn (string $t): bool => $t !== ''));
+
+		$token = '';
+		$announce = $this->service->create($alice, self::POST_ID, $token);
+
+		$this->assertSame('token-boost', $token);
+		$this->assertSame($saved, $announce);
+		$this->assertInstanceOf(Announce::class, $announce);
+		$this->assertSame(self::GENERATED_ID, $announce->getId());
+		$this->assertTrue($announce->isLocal());
+		$this->assertTrue($announce->isFilterDuplicate());
+		$this->assertSame($alice, $announce->getActor());
+		$this->assertSame(self::POST_ID, $announce->getObjectId());
+		$this->assertSame(ACore::CONTEXT_PUBLIC, $announce->getTo());
+		$this->assertSame([self::ALICE_FOLLOWERS], $announce->getCcArray());
+		$this->assertTrue($announce->isPublic());
+		$this->assertMatchesRegularExpression('/^[0-9a-f-]{36}$/', $announce->getRequestToken());
+
+		$paths = $announce->getInstancePaths();
+		$this->assertCount(2, $paths);
+		$this->assertHasInstancePath($paths, self::ALICE_ID, InstancePath::TYPE_FOLLOWERS, InstancePath::PRIORITY_LOW);
+		$this->assertHasInstancePath($paths, self::BOB_ID . '/inbox', InstancePath::TYPE_INBOX, InstancePath::PRIORITY_LOW);
+	}
+
+	public function testCreateStillReachesFollowersWhenAuthorCannotBeResolved(): void {
+		$this->streamRequest->method('getStreamById')->willReturn($this->publicNote());
+		$this->cacheActorService->method('getFromId')->willThrowException(new CacheActorDoesNotExistException());
+		$this->activityService->method('request')->willReturn('token');
+
+		$announce = $this->service->create($this->alice(), self::POST_ID);
+
+		$paths = $announce->getInstancePaths();
+		$this->assertCount(1, $paths);
+		$this->assertHasInstancePath($paths, self::ALICE_ID, InstancePath::TYPE_FOLLOWERS, InstancePath::PRIORITY_LOW);
+	}
+
+	public function testCreateRefusesToBoostSomethingThatIsNotANote(): void {
+		$this->streamRequest->method('getStreamById')->willReturn($this->storedAnnounce());
+		$this->announceInterface->expects($this->never())->method('save');
+		$this->streamActionService->expects($this->never())->method('setActionBool');
+		$this->activityService->expects($this->never())->method('request');
+
+		$this->expectException(StreamNotFoundException::class);
+		$this->expectExceptionMessage('Stream is not a Note');
+		$this->service->create($this->alice(), self::POST_ID);
+	}
+
+	/**
+	 * @return array<string, array{string, string[]}>
+	 */
+	public function nonPublicNoteProvider(): array {
+		return [
+			'followers-only' => [self::BOB_ID . '/followers', []],
+			'direct' => ['', [self::ALICE_ID]],
+		];
+	}
+
+	/**
+	 * @dataProvider nonPublicNoteProvider
+	 */
+	public function testCreateRefusesToBoostNonPublicNotes(string $to, array $toArray): void {
+		$note = new Note();
+		$note->setId(self::POST_ID);
+		$note->setAttributedTo(self::BOB_ID);
+		$note->setTo($to);
+		$note->setToArray($toArray);
+		$this->streamRequest->method('getStreamById')->willReturn($note);
+		$this->announceInterface->expects($this->never())->method('save');
+		$this->streamActionService->expects($this->never())->method('setActionBool');
+
+		$this->expectException(StreamNotFoundException::class);
+		$this->expectExceptionMessage('Stream is not Public');
+		$this->service->create($this->alice(), self::POST_ID);
+	}
+
+	public function testCreateFailsForUnknownPost(): void {
+		$this->streamRequest->method('getStreamById')->willThrowException(new StreamNotFoundException('Stream not found'));
+		$this->announceInterface->expects($this->never())->method('save');
+		$this->streamActionService->expects($this->never())->method('setActionBool');
+
+		$this->expectException(StreamNotFoundException::class);
+		$this->service->create($this->alice(), 'https://remote.example/notes/missing');
+	}
+
+	public function testCreateDoesNotFlagOrFederateWhenTheBoostAlreadyExists(): void {
+		$this->streamRequest->method('getStreamById')->willReturn($this->publicNote());
+		$this->cacheActorService->method('getFromId')->willReturn($this->bob());
+		$this->announceInterface->method('save')->willThrowException(new ItemAlreadyExistsException());
+		$this->streamActionService->expects($this->never())->method('setActionBool');
+		$this->activityService->expects($this->never())->method('request');
+		$this->streamQueueService->expects($this->never())->method('cacheStreamByToken');
+
+		$this->expectException(ItemAlreadyExistsException::class);
+		$this->service->create($this->alice(), self::POST_ID);
+	}
+
+
+	// get()
+
+	public function testGetLooksUpAnnounceByBoostedObject(): void {
+		$announce = $this->storedAnnounce();
+		$this->streamRequest->expects($this->once())
+			->method('getStreamByObjectId')
+			->with(self::POST_ID, Announce::TYPE)
+			->willReturn($announce);
+
+		$this->assertSame($announce, $this->service->get(self::POST_ID));
+	}
+
+	public function testGetPropagatesMissingBoost(): void {
+		$this->streamRequest->method('getStreamByObjectId')->willThrowException(new StreamNotFoundException());
+
+		$this->expectException(StreamNotFoundException::class);
+		$this->service->get(self::POST_ID);
+	}
+
+
+	// delete()
+
+	public function testDeleteSendsUndoRemovesAnnounceAndClearsFlag(): void {
+		$alice = $this->alice();
+		$announce = $this->storedAnnounce();
+		$this->streamRequest->method('getStreamById')->with(self::POST_ID, true)->willReturn($this->publicNote());
+		$this->streamRequest->method('getStreamByObjectId')->with(self::POST_ID, Announce::TYPE)->willReturn($announce);
+		$this->cacheActorService->method('getFromId')->willReturn($this->bob());
+
+		$this->announceInterface->expects($this->once())->method('delete')->with($this->identicalTo($announce));
+		$this->streamRequest->expects($this->once())->method('deleteById')->with(self::ANNOUNCE_ID, Announce::TYPE);
+		$this->signatureService->expects($this->once())
+			->method('signObject')
+			->with($this->identicalTo($alice), $this->isInstanceOf(Undo::class));
+		$this->activityService->expects($this->once())
+			->method('request')
+			->with($this->isInstanceOf(Undo::class))
+			->willReturn('token-undo');
+		$this->streamActionService->expects($this->once())
+			->method('setActionBool')
+			->with(self::ALICE_ID, self::POST_ID, StreamAction::BOOSTED, false);
+
+		$token = '';
+		$undo = $this->service->delete($alice, self::POST_ID, $token);
+
+		$this->assertSame('token-undo', $token);
+		$this->assertInstanceOf(Undo::class, $undo);
+		$this->assertSame(self::GENERATED_ID, $undo->getId());
+		$this->assertTrue($undo->isLocal());
+		$this->assertSame($alice, $undo->getActor());
+		$this->assertSame($alice, $announce->getActor());
+		$this->assertSame(self::ANNOUNCE_ID, $undo->getObjectId());
+		$this->assertSame(ACore::CONTEXT_PUBLIC, $undo->getTo());
+		$this->assertSame([self::ALICE_FOLLOWERS], $undo->getCcArray());
+
+		$paths = $undo->getInstancePaths();
+		$this->assertCount(2, $paths);
+		$this->assertHasInstancePath($paths, self::ALICE_ID, InstancePath::TYPE_FOLLOWERS, InstancePath::PRIORITY_LOW);
+		$this->assertHasInstancePath($paths, self::BOB_ID . '/inbox', InstancePath::TYPE_INBOX, InstancePath::PRIORITY_LOW);
+	}
+
+	public function testDeleteStillClearsFlagWhenNoBoostIsStored(): void {
+		$this->streamRequest->method('getStreamById')->willReturn($this->publicNote());
+		$this->streamRequest->method('getStreamByObjectId')->willThrowException(new StreamNotFoundException());
+		$this->cacheActorService->method('getFromId')->willReturn($this->bob());
+		$this->announceInterface->expects($this->never())->method('delete');
+		$this->streamRequest->expects($this->never())->method('deleteById');
+		$this->signatureService->expects($this->never())->method('signObject');
+		$this->activityService->expects($this->never())->method('request');
+		$this->streamActionService->expects($this->once())
+			->method('setActionBool')
+			->with(self::ALICE_ID, self::POST_ID, StreamAction::BOOSTED, false);
+
+		$token = 'untouched';
+		$undo = $this->service->delete($this->alice(), self::POST_ID, $token);
+
+		$this->assertSame('untouched', $token);
+		$this->assertInstanceOf(Undo::class, $undo);
+		$this->assertSame('', $undo->getObjectId());
+	}
+
+	public function testDeleteRefusesSomethingThatIsNotANote(): void {
+		$this->streamRequest->method('getStreamById')->willReturn($this->storedAnnounce());
+		$this->streamRequest->expects($this->never())->method('getStreamByObjectId');
+		$this->streamActionService->expects($this->never())->method('setActionBool');
+
+		$this->expectException(StreamNotFoundException::class);
+		$this->expectExceptionMessage('Stream is not a Note');
+		$this->service->delete($this->alice(), self::POST_ID);
+	}
+
+	public function testDeleteFailsForUnknownPost(): void {
+		$this->streamRequest->method('getStreamById')->willThrowException(new StreamNotFoundException());
+		$this->streamRequest->expects($this->never())->method('getStreamByObjectId');
+		$this->streamActionService->expects($this->never())->method('setActionBool');
+
+		$this->expectException(StreamNotFoundException::class);
+		$this->service->delete($this->alice(), 'https://remote.example/notes/missing');
+	}
+}

--- a/tests/Service/CacheActorServiceTest.php
+++ b/tests/Service/CacheActorServiceTest.php
@@ -1,0 +1,333 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use OCA\Social\AP;
+use OCA\Social\Db\ActorsRequest;
+use OCA\Social\Db\CacheActorsRequest;
+use OCA\Social\Exceptions\CacheActorDoesNotExistException;
+use OCA\Social\Exceptions\InvalidOriginException;
+use OCA\Social\Exceptions\InvalidResourceException;
+use OCA\Social\Exceptions\ItemAlreadyExistsException;
+use OCA\Social\Interfaces\Actor\PersonInterface;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Model\ActivityPub\OrderedCollection;
+use OCA\Social\Model\Client\Options\ProbeOptions;
+use OCA\Social\Service\CacheActorService;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\CurlService;
+use OCA\Social\Service\FediverseService;
+use OCA\Social\Tools\Exceptions\RequestContentException;
+use OCA\Social\Tools\Exceptions\RequestNetworkException;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class CacheActorServiceTest extends TestCase {
+	private const BOB = 'https://remote.example/users/bob';
+	private const ALICE = 'https://cloud.example.com/apps/social/@alice';
+
+	private ActorsRequest|MockObject $actorsRequest;
+	private CacheActorsRequest|MockObject $cacheActorsRequest;
+	private CurlService|MockObject $curlService;
+	private ConfigService|MockObject $configService;
+	private AP|MockObject $ap;
+	private PersonInterface|MockObject $personInterface;
+	private CacheActorService $service;
+
+	protected function setUp(): void {
+		$this->actorsRequest = $this->createMock(ActorsRequest::class);
+		$this->cacheActorsRequest = $this->createMock(CacheActorsRequest::class);
+		$this->curlService = $this->createMock(CurlService::class);
+		$this->configService = $this->createMock(ConfigService::class);
+		$this->configService->method('getCloudHost')->willReturn('cloud.example.com');
+		$this->configService->method('getSocialAddress')->willReturn('social.example.com');
+
+		$this->ap = $this->createMock(AP::class);
+		$this->personInterface = $this->createMock(PersonInterface::class);
+		$this->ap->method('getInterfaceFromType')->with(Person::TYPE)->willReturn($this->personInterface);
+		$this->ap->method('isActor')->willReturnCallback(fn ($item) => $item instanceof Person);
+		AP::$activityPub = $this->ap;
+
+		$this->service = new CacheActorService(
+			$this->createMock(IURLGenerator::class),
+			$this->actorsRequest,
+			$this->cacheActorsRequest,
+			$this->curlService,
+			$this->createMock(FediverseService::class),
+			$this->configService,
+			new NullLogger(),
+		);
+	}
+
+	protected function tearDown(): void {
+		AP::$activityPub = null;
+	}
+
+	private function person(string $id, string $username = 'bob'): Person {
+		$person = new Person();
+		$person->setId($id);
+		$person->setPreferredUsername($username);
+
+		return $person;
+	}
+
+	public function testGetFromIdReturnsTheCachedActorAndIgnoresTheKeyFragment(): void {
+		$bob = $this->person(self::BOB);
+		$this->cacheActorsRequest->expects($this->once())->method('getFromId')->with(self::BOB)->willReturn($bob);
+		$this->curlService->expects($this->never())->method('retrieveObject');
+
+		$this->assertSame($bob, $this->service->getFromId(self::BOB . '#main-key'));
+	}
+
+	public function testGetFromIdFetchesSavesAndReturnsAnUnknownActor(): void {
+		$this->cacheActorsRequest->method('getFromId')->willThrowException(new CacheActorDoesNotExistException());
+		$data = ['id' => self::BOB, 'type' => 'Person', 'preferredUsername' => 'bob', '_host' => 'remote.example'];
+		$this->curlService->expects($this->once())->method('retrieveObject')->with(self::BOB)->willReturn($data);
+		$bob = $this->person(self::BOB);
+		$this->ap->expects($this->once())->method('getItemFromData')->with($data)->willReturn($bob);
+		$this->personInterface->expects($this->once())->method('save')->with($this->identicalTo($bob));
+
+		$actor = $this->service->getFromId(self::BOB);
+
+		$this->assertSame($bob, $actor);
+		$this->assertSame('bob@remote.example', $actor->getAccount());
+	}
+
+	public function testGetFromIdWithRefreshSkipsTheCache(): void {
+		$this->cacheActorsRequest->expects($this->never())->method('getFromId');
+		$this->curlService->method('retrieveObject')->willReturn(['_host' => 'remote.example']);
+		$this->ap->method('getItemFromData')->willReturn($this->person(self::BOB));
+
+		$this->assertSame(self::BOB, $this->service->getFromId(self::BOB, true)->getId());
+	}
+
+	public function testGetFromIdRejectsADocumentThatIsNotAnActor(): void {
+		$this->cacheActorsRequest->method('getFromId')->willThrowException(new CacheActorDoesNotExistException());
+		$this->curlService->method('retrieveObject')->willReturn(['type' => 'Note']);
+		$this->ap->method('getItemFromData')->willReturn(new Note());
+		$this->personInterface->expects($this->never())->method('save');
+
+		$this->expectException(InvalidResourceException::class);
+		$this->service->getFromId(self::BOB);
+	}
+
+	public function testGetFromIdRejectsAnActorClaimingAnotherHost(): void {
+		$this->cacheActorsRequest->method('getFromId')->willThrowException(new CacheActorDoesNotExistException());
+		$this->curlService->method('retrieveObject')->willReturn(['_host' => 'remote.example']);
+		$this->ap->method('getItemFromData')->willReturn($this->person('https://evil.example/users/bob'));
+		$this->personInterface->expects($this->never())->method('save');
+
+		$this->expectException(InvalidOriginException::class);
+		$this->service->getFromId(self::BOB);
+	}
+
+	public function testGetFromIdWrapsSaveFailures(): void {
+		$this->cacheActorsRequest->method('getFromId')->willThrowException(new CacheActorDoesNotExistException());
+		$this->curlService->method('retrieveObject')->willReturn(['_host' => 'remote.example']);
+		$this->ap->method('getItemFromData')->willReturn($this->person(self::BOB));
+		$this->personInterface->method('save')->willThrowException(new ItemAlreadyExistsException('dup'));
+
+		$this->expectException(InvalidResourceException::class);
+		$this->expectExceptionMessage('dup');
+		$this->service->getFromId(self::BOB);
+	}
+
+	public function testRefreshOfAGoneActorDeletesTheCachedCopy(): void {
+		$cached = $this->person(self::BOB);
+		$this->cacheActorsRequest->expects($this->once())->method('getFromId')->with(self::BOB)->willReturn($cached);
+		$this->curlService->method('retrieveObject')->willThrowException(new RequestContentException('gone', 410));
+		$this->personInterface->expects($this->once())->method('delete')->with($this->identicalTo($cached));
+
+		$this->expectException(RequestContentException::class);
+		$this->service->getFromId(self::BOB, true);
+	}
+
+	public function testFetchFailureWithoutRefreshIsPropagatedWithoutDeleting(): void {
+		$this->cacheActorsRequest->method('getFromId')->willThrowException(new CacheActorDoesNotExistException());
+		$this->curlService->method('retrieveObject')->willThrowException(new RequestContentException('gone', 410));
+		$this->personInterface->expects($this->never())->method('delete');
+
+		$this->expectException(RequestContentException::class);
+		$this->service->getFromId(self::BOB);
+	}
+
+	/** @return array<string, array{string}> */
+	public function localAccountProvider(): array {
+		return [
+			'bare username' => ['alice'],
+			'leading at' => ['@alice'],
+			'cloud host' => ['alice@cloud.example.com'],
+			'social address' => ['@alice@social.example.com'],
+		];
+	}
+
+	/** @dataProvider localAccountProvider */
+	public function testGetFromLocalAccountResolvesLocalHandles(string $account): void {
+		$this->actorsRequest->expects($this->once())->method('getFromUsername')->with('alice')->willReturn($this->person(self::ALICE, 'alice'));
+		$cached = $this->person(self::ALICE, 'alice');
+		$this->cacheActorsRequest->expects($this->once())->method('getFromLocalAccount')->with('alice')->willReturn($cached);
+
+		$this->assertSame($cached, $this->service->getFromLocalAccount($account));
+	}
+
+	public function testGetFromLocalAccountRejectsRemoteHandles(): void {
+		$this->actorsRequest->expects($this->never())->method('getFromUsername');
+
+		$this->expectException(CacheActorDoesNotExistException::class);
+		$this->expectExceptionMessage('not local');
+		$this->service->getFromLocalAccount('bob@remote.example');
+	}
+
+	public function testGetFromLocalAccountRejectsDeletedAccounts(): void {
+		$deleted = $this->person(self::ALICE, 'alice');
+		$deleted->setDeleted(time() - 60);
+		$this->actorsRequest->method('getFromUsername')->willReturn($deleted);
+		$this->cacheActorsRequest->expects($this->never())->method('getFromLocalAccount');
+
+		$this->expectException(CacheActorDoesNotExistException::class);
+		$this->expectExceptionMessage('deleted');
+		$this->service->getFromLocalAccount('alice');
+	}
+
+	public function testGetFromAccountPrefersALocalAccount(): void {
+		$this->actorsRequest->method('getFromUsername')->willReturn($this->person(self::ALICE, 'alice'));
+		$alice = $this->person(self::ALICE, 'alice');
+		$this->cacheActorsRequest->method('getFromLocalAccount')->willReturn($alice);
+		$this->cacheActorsRequest->expects($this->never())->method('getFromAccount');
+		$this->curlService->expects($this->never())->method('retrieveAccount');
+
+		$this->assertSame($alice, $this->service->getFromAccount('alice@cloud.example.com'));
+	}
+
+	public function testGetFromAccountReturnsACachedRemoteActor(): void {
+		$bob = $this->person(self::BOB);
+		$this->cacheActorsRequest->expects($this->once())->method('getFromAccount')->with('bob@remote.example')->willReturn($bob);
+		$this->curlService->expects($this->never())->method('retrieveAccount');
+
+		$this->assertSame($bob, $this->service->getFromAccount('bob@remote.example'));
+	}
+
+	public function testGetFromAccountWebfingersAndCachesAnUnknownRemoteActor(): void {
+		$this->cacheActorsRequest->method('getFromAccount')->willThrowException(new CacheActorDoesNotExistException());
+		$bob = $this->person(self::BOB);
+		$this->curlService->expects($this->once())->method('retrieveAccount')->with('bob@remote.example')->willReturn($bob);
+		$this->personInterface->expects($this->once())->method('save')->with($this->identicalTo($bob));
+
+		$actor = $this->service->getFromAccount('bob@remote.example');
+
+		$this->assertSame($bob, $actor);
+		$this->assertSame('bob@remote.example', $actor->getAccount());
+	}
+
+	public function testGetFromAccountWithoutRetrieveFailsOnCacheMiss(): void {
+		$this->cacheActorsRequest->method('getFromAccount')->willThrowException(new CacheActorDoesNotExistException());
+		$this->curlService->expects($this->never())->method('retrieveAccount');
+
+		$this->expectException(CacheActorDoesNotExistException::class);
+		$this->service->getFromAccount('bob@remote.example', false);
+	}
+
+	public function testGetFromAccountWrapsSaveFailures(): void {
+		$this->cacheActorsRequest->method('getFromAccount')->willThrowException(new CacheActorDoesNotExistException());
+		$this->curlService->method('retrieveAccount')->willReturn($this->person(self::BOB));
+		$this->personInterface->method('save')->willThrowException(new ItemAlreadyExistsException('dup'));
+
+		$this->expectException(InvalidResourceException::class);
+		$this->service->getFromAccount('bob@remote.example');
+	}
+
+	public function testDelegatingLookups(): void {
+		$bob = $this->person(self::BOB);
+		$options = new ProbeOptions();
+		$this->cacheActorsRequest->expects($this->once())->method('searchAccounts')->with('bo')->willReturn([$bob]);
+		$this->cacheActorsRequest->expects($this->once())->method('getFromNids')->with([1, 2])->willReturn([$bob]);
+		$this->cacheActorsRequest->expects($this->once())->method('probeActors')->with($this->identicalTo($options))->willReturn([$bob]);
+		$this->cacheActorsRequest->expects($this->once())->method('setViewer')->with($this->identicalTo($bob));
+
+		$this->assertSame([$bob], $this->service->searchCachedAccounts('bo'));
+		$this->assertSame([$bob], $this->service->getFromNids([1, 2]));
+		$this->assertSame([$bob], $this->service->probeActors($options));
+		$this->service->setViewer($bob);
+	}
+
+	public function testMissingCacheRemoteActorsIsNotImplemented(): void {
+		$this->assertSame(0, $this->service->missingCacheRemoteActors());
+	}
+
+	public function testManageCacheRemoteActorsRefreshesEachStaleActorAndSurvivesFailures(): void {
+		$stale = [$this->person(self::BOB), $this->person('https://other.example/users/carol', 'carol')];
+		$this->cacheActorsRequest->expects($this->once())->method('getRemoteActorsToUpdate')->with(true)->willReturn($stale);
+		$this->curlService->expects($this->exactly(2))
+			->method('retrieveObject')
+			->withConsecutive([self::BOB], ['https://other.example/users/carol'])
+			->willReturnCallback(function (string $id) {
+				if ($id === self::BOB) {
+					return ['_host' => 'remote.example'];
+				}
+				throw new RequestNetworkException('down');
+			});
+		$this->ap->method('getItemFromData')->willReturn($this->person(self::BOB));
+		$this->personInterface->expects($this->once())->method('save');
+
+		$this->assertSame(2, $this->service->manageCacheRemoteActors(true));
+	}
+
+	public function testAddRemoteActorDetailCountReadsTheCollectionTotals(): void {
+		$bob = $this->person(self::BOB);
+		$bob->setFollowers(self::BOB . '/followers');
+		$bob->setFollowing(self::BOB . '/following');
+		$bob->setOutbox(self::BOB . '/outbox');
+		$totals = [self::BOB . '/followers' => 12, self::BOB . '/following' => 7, self::BOB . '/outbox' => 340];
+		$this->curlService->method('retrieveObject')->willReturnCallback(fn (string $id) => ['type' => 'OrderedCollection', 'id' => $id]);
+		$this->ap->method('getItemFromData')->willReturnCallback(function (array $data) use ($totals) {
+			$collection = new OrderedCollection();
+			$collection->setTotalItems($totals[$data['id']]);
+
+			return $collection;
+		});
+
+		$this->service->addRemoteActorDetailCount($bob);
+
+		$this->assertSame(['followers' => 12, 'following' => 7, 'post' => 340], $bob->getDetails('count'));
+	}
+
+	public function testAddRemoteActorDetailCountGivesUpWhenACollectionIsUnreachable(): void {
+		$bob = $this->person(self::BOB);
+		$bob->setFollowers(self::BOB . '/followers');
+		$this->curlService->method('retrieveObject')->willThrowException(new RequestNetworkException('down'));
+
+		$this->service->addRemoteActorDetailCount($bob);
+
+		$this->assertSame([], $bob->getDetails('count'));
+	}
+
+	public function testAddRemoteActorDetailCountRejectsNonCollections(): void {
+		$bob = $this->person(self::BOB);
+		$bob->setFollowers(self::BOB . '/followers');
+		$this->curlService->method('retrieveObject')->willReturn(['type' => 'Note']);
+		$this->ap->method('getItemFromData')->willReturn(new Note());
+
+		$this->service->addRemoteActorDetailCount($bob);
+
+		$this->assertSame([], $bob->getDetails('count'));
+	}
+
+	public function testManageDetailsRemoteActorsUpdatesEachActor(): void {
+		$bob = $this->person(self::BOB);
+		$this->cacheActorsRequest->method('getRemoteActorsToUpdateDetails')->with(false)->willReturn([$bob]);
+		$this->curlService->method('retrieveObject')->willThrowException(new RequestNetworkException('down'));
+		$this->cacheActorsRequest->expects($this->once())->method('updateDetails')->with($this->identicalTo($bob));
+
+		$this->assertSame(1, $this->service->manageDetailsRemoteActors());
+	}
+}

--- a/tests/Service/CacheDocumentServiceTest.php
+++ b/tests/Service/CacheDocumentServiceTest.php
@@ -1,0 +1,325 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use OCA\Social\Exceptions\CacheContentException;
+use OCA\Social\Exceptions\CacheContentMimeTypeException;
+use OCA\Social\Exceptions\CacheDocumentDoesNotExistException;
+use OCA\Social\Model\ActivityPub\Object\Document;
+use OCA\Social\Service\BlurService;
+use OCA\Social\Service\CacheDocumentService;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\CurlService;
+use OCA\Social\Tools\Exceptions\MalformedArrayException;
+use OCA\Social\Tools\Model\NCRequest;
+use OCA\Social\Tools\Model\Request;
+use OCP\Files\IAppData;
+use OCP\Files\NotFoundException;
+use OCP\Files\SimpleFS\ISimpleFile;
+use OCP\Files\SimpleFS\ISimpleFolder;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class CacheDocumentServiceTest extends TestCase {
+	private const UUID_PATTERN = '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/';
+
+	private IAppData|MockObject $appData;
+	private CurlService|MockObject $curlService;
+	private BlurService|MockObject $blurService;
+	private CacheDocumentService $service;
+
+	protected function setUp(): void {
+		$this->appData = $this->createMock(IAppData::class);
+		$this->curlService = $this->createMock(CurlService::class);
+		$this->blurService = $this->createMock(BlurService::class);
+		$this->service = new CacheDocumentService(
+			$this->appData,
+			$this->curlService,
+			$this->blurService,
+			$this->createMock(ConfigService::class),
+		);
+	}
+
+	/** A small real PNG, so mime detection and the resizer see a genuine image. */
+	private function pngBytes(int $width = 16, int $height = 10): string {
+		$image = imagecreatetruecolor($width, $height);
+		imagefill($image, 0, 0, imagecolorallocate($image, 20, 120, 220));
+		ob_start();
+		imagepng($image);
+
+		return ob_get_clean();
+	}
+
+	/**
+	 * The bundled gumlet/php-image-resize still calls finfo_close() and
+	 * imagedestroy(), both deprecated in PHP 8.5. Those notices are the
+	 * library's, not the service's: keep them out of the test output.
+	 */
+	private function quietly(callable $call): void {
+		$previous = error_reporting(E_ALL & ~E_DEPRECATED);
+		try {
+			$call();
+		} finally {
+			error_reporting($previous);
+		}
+	}
+
+	/**
+	 * Wire appData so every new file lands in $written (path => [name => bytes]).
+	 * Folders are reported missing first, so the service has to create them.
+	 */
+	private function captureWrites(array &$written): void {
+		$this->appData->method('getFolder')->willThrowException(new NotFoundException());
+		$this->appData->method('newFolder')->willReturnCallback(function (string $path) use (&$written) {
+			$folder = $this->createMock(ISimpleFolder::class);
+			$folder->method('newFile')->willReturnCallback(function (string $name) use ($path, &$written) {
+				$file = $this->createMock(ISimpleFile::class);
+				$file->method('putContent')->willReturnCallback(function (string $content) use ($path, $name, &$written) {
+					$written[$path][$name] = $content;
+				});
+
+				return $file;
+			});
+
+			return $folder;
+		});
+	}
+
+	/** @return array<string, array{string}> */
+	public function allowedMimeProvider(): array {
+		return [
+			'jpeg' => ['image/jpeg'],
+			'gif' => ['image/gif'],
+			'png' => ['image/png'],
+		];
+	}
+
+	/** @dataProvider allowedMimeProvider */
+	public function testFilterMimeTypesAcceptsImages(string $mime): void {
+		$this->service->filterMimeTypes($mime);
+		$this->addToAssertionCount(1);
+	}
+
+	/** @return array<string, array{string}> */
+	public function rejectedMimeProvider(): array {
+		return [
+			'svg' => ['image/svg+xml'],
+			'webp' => ['image/webp'],
+			'html' => ['text/html'],
+			'php' => ['application/x-httpd-php'],
+			'empty' => [''],
+		];
+	}
+
+	/** @dataProvider rejectedMimeProvider */
+	public function testFilterMimeTypesRejectsEverythingElse(string $mime): void {
+		$this->expectException(CacheContentMimeTypeException::class);
+		$this->service->filterMimeTypes($mime);
+	}
+
+	public function testSaveContentToCacheStoresOriginalAndResizedCopiesInHashedFolders(): void {
+		$written = [];
+		$this->captureWrites($written);
+		$this->blurService->expects($this->once())
+			->method('generateBlurHash')
+			->with($this->isInstanceOf(\GdImage::class))
+			->willReturn('LKO2?U%2Tw=w]~RBVZRi};RPxuwH');
+		$document = new Document();
+		$png = $this->pngBytes();
+
+		$mime = '';
+		$this->quietly(function () use ($document, $png, &$mime) {
+			$this->service->saveContentToCache($document, $png, $mime);
+		});
+
+		$this->assertSame('image/png', $mime);
+		$this->assertMatchesRegularExpression(self::UUID_PATTERN, $document->getLocalCopy());
+		$this->assertMatchesRegularExpression(self::UUID_PATTERN, $document->getResizedCopy());
+		$this->assertNotSame($document->getLocalCopy(), $document->getResizedCopy());
+		$this->assertSame([16, 10], $document->getLocalCopySize());
+		$this->assertSame([16, 10], $document->getResizedCopySize(), 'small images are not enlarged');
+		$this->assertSame('LKO2?U%2Tw=w]~RBVZRi};RPxuwH', $document->getBlurHash());
+
+		$this->assertCount(2, $written);
+		foreach ($written as $path => $files) {
+			$name = array_key_first($files);
+			// folder aa/bb/cc/dd/ derives from the first 8 chars of the file name
+			$this->assertSame(chunk_split(substr($name, 0, 8), 2, '/'), $path);
+			$this->assertSame('image/png', (new \finfo(FILEINFO_MIME_TYPE))->buffer($files[$name]));
+		}
+		$this->assertSame($png, $written[chunk_split(substr($document->getLocalCopy(), 0, 8), 2, '/')][$document->getLocalCopy()]);
+	}
+
+	public function testSaveContentToCacheReusesAnExistingFolder(): void {
+		$folder = $this->createMock(ISimpleFolder::class);
+		$file = $this->createMock(ISimpleFile::class);
+		$folder->method('newFile')->willReturn($file);
+		$this->appData->method('getFolder')->willReturn($folder);
+		$this->appData->expects($this->never())->method('newFolder');
+		$file->expects($this->exactly(2))->method('putContent');
+		$this->blurService->method('generateBlurHash')->willReturn('hash');
+
+		$this->quietly(fn () => $this->service->saveContentToCache(new Document(), $this->pngBytes()));
+	}
+
+	public function testSaveContentToCacheRefusesNonImagesBeforeTouchingStorage(): void {
+		$this->appData->expects($this->never())->method($this->anything());
+		$document = new Document();
+
+		$mime = '';
+		try {
+			$this->service->saveContentToCache($document, '<html><body>not an image</body></html>', $mime);
+			$this->fail('expected CacheContentMimeTypeException');
+		} catch (CacheContentMimeTypeException $e) {
+			$this->assertSame('text/html', $mime);
+			$this->assertSame('', $document->getLocalCopy());
+		}
+	}
+
+	public function testSaveLocalUploadToCacheIsAnAliasForSaveContent(): void {
+		$written = [];
+		$this->captureWrites($written);
+		$this->blurService->method('generateBlurHash')->willReturn('hash');
+		$document = new Document();
+
+		$mime = '';
+		$this->quietly(function () use ($document, &$mime) {
+			$this->service->saveLocalUploadToCache($document, $this->pngBytes(), $mime);
+		});
+
+		$this->assertSame('image/png', $mime);
+		$this->assertCount(2, $written);
+	}
+
+	public function testSaveFromTempToCacheReadsTheFileAndSetsTheMediaType(): void {
+		$tmp = tempnam(sys_get_temp_dir(), 'social-test-');
+		file_put_contents($tmp, $this->pngBytes(12, 12));
+		try {
+			$written = [];
+			$this->captureWrites($written);
+			$this->blurService->method('generateBlurHash')->willReturn('hash');
+			$document = new Document();
+
+			$this->quietly(fn () => $this->service->saveFromTempToCache($document, $tmp));
+
+			$this->assertSame('image/png', $document->getMediaType());
+			$this->assertSame('image/png', $document->getMimeType());
+			$this->assertMatchesRegularExpression(self::UUID_PATTERN, $document->getLocalCopy());
+			$this->assertSame([12, 12], $document->getLocalCopySize());
+			$this->assertCount(2, $written);
+		} finally {
+			unlink($tmp);
+		}
+	}
+
+	public function testSaveFromTempToCacheRejectsNonImages(): void {
+		$tmp = tempnam(sys_get_temp_dir(), 'social-test-');
+		file_put_contents($tmp, 'plain text');
+		try {
+			$this->appData->expects($this->never())->method($this->anything());
+
+			$this->expectException(CacheContentMimeTypeException::class);
+			$this->service->saveFromTempToCache(new Document(), $tmp);
+		} finally {
+			unlink($tmp);
+		}
+	}
+
+	public function testGetContentFromCacheReadsFromTheHashedFolder(): void {
+		$file = $this->createMock(ISimpleFile::class);
+		$folder = $this->createMock(ISimpleFolder::class);
+		$folder->expects($this->once())->method('getFile')->with('2b5a7a87-8db1-445f-a17b-405790f91c80')->willReturn($file);
+		$this->appData->expects($this->once())->method('getFolder')->with('2b/5a/7a/87/')->willReturn($folder);
+
+		$this->assertSame($file, $this->service->getContentFromCache('2b5a7a87-8db1-445f-a17b-405790f91c80'));
+	}
+
+	public function testGetContentFromCacheWithoutFilenameIsAMissingDocument(): void {
+		$this->appData->expects($this->never())->method('getFolder');
+
+		$this->expectException(CacheDocumentDoesNotExistException::class);
+		$this->service->getContentFromCache('');
+	}
+
+	public function testGetContentFromCacheDoesNotServeLocalAvatarPlaceholders(): void {
+		$this->appData->expects($this->never())->method('getFolder');
+
+		$this->expectException(CacheContentException::class);
+		$this->service->getContentFromCache('avatar');
+	}
+
+	public function testGetContentFromCacheWrapsStorageErrors(): void {
+		$this->appData->method('getFolder')->willThrowException(new NotFoundException());
+
+		$this->expectException(CacheContentException::class);
+		$this->service->getContentFromCache('2b5a7a87-8db1-445f-a17b-405790f91c80');
+	}
+
+	public function testGetFromUuidReadsTheFile(): void {
+		$file = $this->createMock(ISimpleFile::class);
+		$folder = $this->createMock(ISimpleFolder::class);
+		$folder->method('getFile')->with('2b5a7a87-8db1-445f-a17b-405790f91c80')->willReturn($file);
+		$this->appData->method('getFolder')->with('2b/5a/7a/87/')->willReturn($folder);
+
+		$this->assertSame($file, $this->service->getFromUuid('2b5a7a87-8db1-445f-a17b-405790f91c80'));
+	}
+
+	public function testGetFromUuidReportsAMissingDocument(): void {
+		$folder = $this->createMock(ISimpleFolder::class);
+		$folder->method('getFile')->willThrowException(new NotFoundException('no file'));
+		$this->appData->method('getFolder')->willReturn($folder);
+
+		$this->expectException(NotFoundException::class);
+		$this->expectExceptionMessage('document not found');
+		$this->service->getFromUuid('2b5a7a87-8db1-445f-a17b-405790f91c80');
+	}
+
+	public function testRetrieveContentIssuesABinaryGetWithoutJsonHeaders(): void {
+		$this->curlService->expects($this->once())
+			->method('doRequest')
+			->with($this->callback(function (NCRequest $request) {
+				$this->assertSame('/files/pic.png', $request->getPath());
+				$this->assertSame('remote.example', $request->getHost());
+				$this->assertSame(['https'], $request->getProtocols());
+				$this->assertSame(Request::TYPE_GET, $request->getType());
+				$this->assertTrue($request->isBinary());
+				$this->assertSame(['ignoreJsonHeaders' => true], $request->getClientOptions());
+
+				return true;
+			}))
+			->willReturn('PNG-BYTES');
+
+		$this->assertSame('PNG-BYTES', $this->service->retrieveContent('https://remote.example/files/pic.png'));
+	}
+
+	public function testRetrieveContentRejectsIncompleteUrls(): void {
+		$this->curlService->expects($this->never())->method('doRequest');
+
+		$this->expectException(MalformedArrayException::class);
+		$this->service->retrieveContent('/files/pic.png');
+	}
+
+	public function testSaveRemoteFileToCacheDownloadsThenStores(): void {
+		$this->curlService->method('doRequest')->willReturn($this->pngBytes());
+		$written = [];
+		$this->captureWrites($written);
+		$this->blurService->method('generateBlurHash')->willReturn('hash');
+		$document = new Document();
+		$document->setUrl('https://remote.example/files/pic.png');
+
+		$mime = '';
+		$this->quietly(function () use ($document, &$mime) {
+			$this->service->saveRemoteFileToCache($document, $mime);
+		});
+
+		$this->assertSame('image/png', $mime);
+		$this->assertMatchesRegularExpression(self::UUID_PATTERN, $document->getLocalCopy());
+	}
+}

--- a/tests/Service/CheckServiceTest.php
+++ b/tests/Service/CheckServiceTest.php
@@ -1,0 +1,277 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use Exception;
+use OCA\Social\Db\CacheActorsRequest;
+use OCA\Social\Db\FollowsRequest;
+use OCA\Social\Db\StreamDestRequest;
+use OCA\Social\Db\StreamRequest;
+use OCA\Social\Exceptions\ActorDoesNotExistException;
+use OCA\Social\Exceptions\CacheActorDoesNotExistException;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Follow;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Service\AccountService;
+use OCA\Social\Service\CheckService;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\MiscService;
+use OCP\Http\Client\IClient;
+use OCP\Http\Client\IClientService;
+use OCP\Http\Client\IResponse;
+use OCP\ICache;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class CheckServiceTest extends TestCase {
+	private IUserManager|MockObject $userManager;
+	private ICache|MockObject $cache;
+	private IConfig|MockObject $config;
+	private IClient|MockObject $client;
+	private IRequest|MockObject $request;
+	private IURLGenerator|MockObject $urlGenerator;
+	private FollowsRequest|MockObject $followRequest;
+	private CacheActorsRequest|MockObject $cacheActorsRequest;
+	private StreamRequest|MockObject $streamRequest;
+	private AccountService|MockObject $accountService;
+	private MiscService|MockObject $miscService;
+	private CheckService $service;
+
+	protected function setUp(): void {
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->cache = $this->createMock(ICache::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->client = $this->createMock(IClient::class);
+		$clientService = $this->createMock(IClientService::class);
+		$clientService->method('newClient')->willReturn($this->client);
+		$this->request = $this->createMock(IRequest::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->followRequest = $this->createMock(FollowsRequest::class);
+		$this->cacheActorsRequest = $this->createMock(CacheActorsRequest::class);
+		$this->streamRequest = $this->createMock(StreamRequest::class);
+		$this->accountService = $this->createMock(AccountService::class);
+		$this->miscService = $this->createMock(MiscService::class);
+
+		$this->service = new CheckService(
+			$this->userManager,
+			'alice',
+			$this->cache,
+			$this->config,
+			$clientService,
+			$this->request,
+			$this->urlGenerator,
+			$this->followRequest,
+			$this->cacheActorsRequest,
+			$this->createMock(StreamDestRequest::class),
+			$this->streamRequest,
+			$this->accountService,
+			$this->createMock(ConfigService::class),
+			$this->miscService,
+		);
+	}
+
+	private function response(int $status): IResponse|MockObject {
+		$response = $this->createMock(IResponse::class);
+		$response->method('getStatusCode')->willReturn($status);
+
+		return $response;
+	}
+
+	public function testCheckWellKnownTrustsTheCache(): void {
+		$this->cache->method('get')->with(CheckService::CACHE_PREFIX . 'wellknown')->willReturn('true');
+		$this->client->expects($this->never())->method('get');
+
+		$this->assertTrue($this->service->checkWellKnown());
+	}
+
+	public function testCheckWellKnownProbesTheConfiguredAddressFirstAndCachesSuccess(): void {
+		$this->cache->method('get')->willReturn(null);
+		$this->config->method('getAppValue')->with('social', 'address', '')->willReturn('https://social.example.com');
+		$this->config->method('getSystemValue')->with('social.checkssl', true)->willReturn(false);
+		$this->client->expects($this->once())
+			->method('get')
+			->with(
+				'https://social.example.com/.well-known/webfinger?resource=acct:alice@social.example.com',
+				['nextcloud' => ['allow_local_address' => true], 'verify' => false],
+			)
+			->willReturn($this->response(200));
+		$this->cache->expects($this->once())->method('set')->with(CheckService::CACHE_PREFIX . 'wellknown', 'true', 3600);
+
+		$this->assertTrue($this->service->checkWellKnown());
+	}
+
+	public function testCheckWellKnownFallsBackToTheRequestHostThenTheBaseUrl(): void {
+		$this->cache->method('get')->willReturn(null);
+		$this->config->method('getAppValue')->willReturn('');
+		$this->config->method('getSystemValue')->willReturn(true);
+		$this->request->method('getServerProtocol')->willReturn('https');
+		$this->request->method('getServerHost')->willReturn('cloud.example.com');
+		$this->urlGenerator->method('getBaseUrl')->willReturn('https://cloud.example.com/nextcloud');
+		$this->client->expects($this->exactly(2))
+			->method('get')
+			->withConsecutive(
+				['https://cloud.example.com/.well-known/webfinger?resource=acct:alice@cloud.example.com', $this->anything()],
+				['https://cloud.example.com/nextcloud/.well-known/webfinger?resource=acct:alice@cloud.example.com', $this->anything()],
+			)
+			->willReturnOnConsecutiveCalls($this->response(404), $this->response(200));
+
+		$this->assertTrue($this->service->checkWellKnown());
+	}
+
+	public function testCheckWellKnownFailsWhenEveryProbeFails(): void {
+		$this->cache->method('get')->willReturn(null);
+		$this->config->method('getAppValue')->willReturn('');
+		$this->request->method('getServerProtocol')->willReturn('http');
+		$this->request->method('getServerHost')->willReturn('localhost');
+		$this->urlGenerator->method('getBaseUrl')->willReturn('http://localhost');
+		$this->client->expects($this->exactly(2))
+			->method('get')
+			->willReturnCallback(function (string $url) {
+				if (str_contains($url, '?resource=acct:alice@localhost') && $url === 'http://localhost/.well-known/webfinger?resource=acct:alice@localhost') {
+					throw new Exception('connection refused');
+				}
+
+				return $this->response(500);
+			});
+		$this->cache->expects($this->never())->method('set');
+
+		$this->assertFalse($this->service->checkWellKnown());
+	}
+
+	public function testCheckDefaultReportsTheWellKnownCheck(): void {
+		$this->cache->method('get')->willReturn('true');
+
+		$this->assertSame(['success' => true, 'checks' => ['wellknown' => true]], $this->service->checkDefault());
+	}
+
+	public function testCheckDefaultFailsWhenACheckFails(): void {
+		$this->cache->method('get')->willReturn(null);
+		$this->config->method('getAppValue')->willReturn('');
+		$this->client->method('get')->willReturn($this->response(404));
+
+		$this->assertSame(['success' => false, 'checks' => ['wellknown' => false]], $this->service->checkDefault());
+	}
+
+	private function follow(string $id, string $actorId, string $objectId): Follow {
+		$follow = new Follow();
+		$follow->setId($id);
+		$follow->setActorId($actorId);
+		$follow->setObjectId($objectId);
+
+		return $follow;
+	}
+
+	public function testRemoveInvalidFollowsDropsFollowsWithAnUnknownActorOrObject(): void {
+		$known = 'https://cloud.example.com/apps/social/@alice';
+		$this->followRequest->method('getAll')->willReturn([
+			$this->follow('f1', $known, 'https://remote.example/users/bob'),
+			$this->follow('f2', $known, 'https://gone.example/users/x'),
+			$this->follow('f3', 'https://gone.example/users/y', $known),
+		]);
+		$this->cacheActorsRequest->method('getFromId')->willReturnCallback(function (string $id) {
+			if (str_starts_with($id, 'https://gone.example/')) {
+				throw new CacheActorDoesNotExistException();
+			}
+
+			return new Person();
+		});
+		$this->followRequest->expects($this->exactly(2))
+			->method('deleteById')
+			->withConsecutive(['f2'], ['f3']);
+		$this->miscService->expects($this->once())->method('log')->with('removeInvalidFollows removed 2 entries', 1);
+
+		$this->assertSame(2, $this->service->removeInvalidFollows());
+	}
+
+	public function testRemoveInvalidNotesDropsNotesFromUnknownAuthors(): void {
+		$valid = new Note();
+		$valid->setId('https://remote.example/notes/1');
+		$valid->setAttributedTo('https://remote.example/users/bob');
+		$orphan = new Note();
+		$orphan->setId('https://gone.example/notes/2');
+		$orphan->setAttributedTo('https://gone.example/users/x');
+		$this->streamRequest->method('getAll')->with(Note::TYPE)->willReturn([$valid, $orphan]);
+		$this->cacheActorsRequest->method('getFromId')->willReturnCallback(function (string $id) {
+			if ($id === 'https://gone.example/users/x') {
+				throw new CacheActorDoesNotExistException();
+			}
+
+			return new Person();
+		});
+		$this->streamRequest->expects($this->once())->method('deleteById')->with('https://gone.example/notes/2', Note::TYPE);
+		$this->miscService->expects($this->once())->method('log')->with('removeInvalidNotes removed 1 entries', 1);
+
+		$this->assertSame(1, $this->service->removeInvalidNotes());
+	}
+
+	public function testCheckInstallationStatusRunsRepairsAndLoopbackFollows(): void {
+		$this->followRequest->method('getAll')->willReturn([]);
+		$this->streamRequest->method('getAll')->willReturn([]);
+		$alice = $this->createMock(IUser::class);
+		$alice->method('getUID')->willReturn('alice');
+		$bob = $this->createMock(IUser::class);
+		$bob->method('getUID')->willReturn('bob');
+		$this->userManager->method('search')->with('')->willReturn([$alice, $bob]);
+		$actor = new Person();
+		$this->accountService->method('getActorFromUserId')->willReturnCallback(function (string $uid) use ($actor) {
+			if ($uid === 'bob') {
+				throw new ActorDoesNotExistException();
+			}
+
+			return $actor;
+		});
+		$this->followRequest->expects($this->once())->method('generateLoopbackAccount')->with($this->identicalTo($actor));
+
+		$result = $this->service->checkInstallationStatus();
+
+		$this->assertSame(['invalidFollows' => 0, 'invalidNotes' => 0], $result);
+	}
+
+	public function testLightInstallationStatusSkipsTheRepairs(): void {
+		$this->followRequest->expects($this->never())->method('getAll');
+		$this->streamRequest->expects($this->never())->method('getAll');
+		$this->userManager->method('search')->willReturn([]);
+
+		$this->assertSame([], $this->service->checkInstallationStatus(true));
+	}
+
+	public function testCheckInstallationStatusSurvivesLoopbackFailures(): void {
+		$this->userManager->method('search')->willThrowException(new Exception('ldap down'));
+
+		$this->assertSame([], $this->service->checkInstallationStatus(true));
+	}
+
+	public function testCheckStatusTableFollowsSeedsAPlaceholderWhenEmpty(): void {
+		$this->followRequest->method('countFollows')->willReturn(0);
+		$this->followRequest->expects($this->once())
+			->method('save')
+			->with($this->callback(function (Follow $follow) {
+				$this->assertSame('Unknown', $follow->getType());
+				$this->assertMatchesRegularExpression('/^[0-9a-f-]{36}$/', $follow->getId());
+				$this->assertNotSame($follow->getActorId(), $follow->getObjectId());
+
+				return true;
+			}));
+
+		$this->service->checkStatusTableFollows();
+	}
+
+	public function testCheckStatusTableFollowsLeavesAPopulatedTableAlone(): void {
+		$this->followRequest->method('countFollows')->willReturn(5);
+		$this->followRequest->expects($this->never())->method('save');
+
+		$this->service->checkStatusTableFollows();
+	}
+}

--- a/tests/Service/ClientServiceTest.php
+++ b/tests/Service/ClientServiceTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use Exception;
+use OCA\Social\Db\ClientRequest;
+use OCA\Social\Exceptions\ClientException;
+use OCA\Social\Exceptions\ClientNotFoundException;
+use OCA\Social\Model\Client\SocialClient;
+use OCA\Social\Service\ClientService;
+use OCA\Social\Service\MiscService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ClientServiceTest extends TestCase {
+	private ClientRequest|MockObject $clientRequest;
+	private ClientService $service;
+
+	protected function setUp(): void {
+		$this->clientRequest = $this->createMock(ClientRequest::class);
+		$this->service = new ClientService($this->clientRequest, $this->createMock(MiscService::class));
+	}
+
+	private function registeredClient(): SocialClient {
+		$client = new SocialClient();
+		$client->setAppName('Tusky');
+		$client->setAppRedirectUris(['urn:ietf:wg:oauth:2.0:oob', 'https://app.example/callback']);
+		$client->setAppScopes(['read', 'write']);
+		$client->setAuthScopes(['read']);
+		$client->setAppClientSecret('s3cret');
+		$client->setAuthCode('c0de');
+
+		return $client;
+	}
+
+	public function testCreateAppGeneratesCredentialsAndSaves(): void {
+		$client = $this->registeredClient();
+		$this->clientRequest->expects($this->once())
+			->method('saveApp')
+			->with($this->identicalTo($client));
+
+		$this->service->createApp($client);
+
+		$this->assertMatchesRegularExpression('/^[A-Za-z0-9]{40}$/', $client->getAppClientId());
+		$this->assertMatchesRegularExpression('/^[A-Za-z0-9]{40}$/', $client->getAppClientSecret());
+		$this->assertNotSame($client->getAppClientId(), $client->getAppClientSecret());
+	}
+
+	public function testCreateAppRequiresAName(): void {
+		$client = $this->registeredClient();
+		$client->setAppName('');
+		$this->clientRequest->expects($this->never())->method('saveApp');
+
+		$this->expectException(ClientException::class);
+		$this->expectExceptionMessage('missing client_name');
+		$this->service->createApp($client);
+	}
+
+	public function testCreateAppRequiresRedirectUris(): void {
+		$client = $this->registeredClient();
+		$client->setAppRedirectUris([]);
+		$this->clientRequest->expects($this->never())->method('saveApp');
+
+		$this->expectException(ClientException::class);
+		$this->expectExceptionMessage('missing redirect_uris');
+		$this->service->createApp($client);
+	}
+
+	public function testAuthClientIssuesAnAuthCode(): void {
+		$client = $this->registeredClient();
+		$this->clientRequest->expects($this->once())
+			->method('authClient')
+			->with($this->identicalTo($client));
+
+		$this->service->authClient($client);
+
+		$this->assertMatchesRegularExpression('/^[A-Za-z0-9]{60}$/', $client->getAuthCode());
+	}
+
+	public function testGenerateTokenIssuesABearerToken(): void {
+		$client = $this->registeredClient();
+		$this->clientRequest->expects($this->once())
+			->method('updateToken')
+			->with($this->identicalTo($client));
+
+		$this->service->generateToken($client);
+
+		$this->assertMatchesRegularExpression('/^[A-Za-z0-9]{80}$/', $client->getToken());
+	}
+
+	public function testGetFromClientIdDelegates(): void {
+		$client = $this->registeredClient();
+		$this->clientRequest->expects($this->once())
+			->method('getFromClientId')
+			->with('client-id')
+			->willReturn($client);
+
+		$this->assertSame($client, $this->service->getFromClientId('client-id'));
+	}
+
+	public function testGetFromTokenRefreshesARecentlyUsedToken(): void {
+		$client = $this->registeredClient();
+		$client->setLastUpdate(time() - 60);
+		$this->clientRequest->method('getFromToken')->with('tok')->willReturn($client);
+		$this->clientRequest->expects($this->once())
+			->method('updateTime')
+			->with($this->identicalTo($client));
+		$this->clientRequest->expects($this->never())->method('deprecateToken');
+
+		$this->assertSame($client, $this->service->getFromToken('tok'));
+	}
+
+	public function testGetFromTokenDoesNotTouchAnOlderValidToken(): void {
+		$client = $this->registeredClient();
+		$client->setLastUpdate(time() - ClientService::TIME_TOKEN_REFRESH - 60);
+		$this->clientRequest->method('getFromToken')->willReturn($client);
+		$this->clientRequest->expects($this->never())->method('updateTime');
+
+		$this->assertSame($client, $this->service->getFromToken('tok'));
+	}
+
+	public function testGetFromTokenRejectsAnExpiredTokenAndPurges(): void {
+		$client = $this->registeredClient();
+		$client->setLastUpdate(time() - ClientService::TIME_TOKEN_TTL - 1);
+		$this->clientRequest->method('getFromToken')->willReturn($client);
+		$this->clientRequest->expects($this->once())->method('deprecateToken');
+
+		$this->expectException(ClientNotFoundException::class);
+		$this->service->getFromToken('tok');
+	}
+
+	public function testGetFromTokenStillRejectsWhenPurgingFails(): void {
+		$client = $this->registeredClient();
+		$client->setLastUpdate(0);
+		$this->clientRequest->method('getFromToken')->willReturn($client);
+		$this->clientRequest->method('deprecateToken')->willThrowException(new Exception('db'));
+
+		$this->expectException(ClientNotFoundException::class);
+		$this->service->getFromToken('tok');
+	}
+
+	public function testGetFromTokenPropagatesUnknownToken(): void {
+		$this->clientRequest->method('getFromToken')->willThrowException(new ClientNotFoundException());
+
+		$this->expectException(ClientNotFoundException::class);
+		$this->service->getFromToken('nope');
+	}
+
+	/** @return array<string, array{array}> */
+	public function validDataProvider(): array {
+		return [
+			'nothing to check' => [[]],
+			'known redirect' => [['redirect_uri' => 'https://app.example/callback']],
+			'right secret' => [['client_secret' => 's3cret']],
+			'registered app scopes as array' => [['app_scopes' => ['read']]],
+			'registered app scopes as string' => [['app_scopes' => 'read write']],
+			'granted auth scopes' => [['auth_scopes' => 'read']],
+			'right code' => [['code' => 'c0de']],
+			'everything at once' => [[
+				'redirect_uri' => 'urn:ietf:wg:oauth:2.0:oob',
+				'client_secret' => 's3cret',
+				'app_scopes' => 'write',
+				'auth_scopes' => ['read'],
+				'code' => 'c0de',
+			]],
+		];
+	}
+
+	/** @dataProvider validDataProvider */
+	public function testConfirmDataAcceptsMatchingData(array $data): void {
+		$this->service->confirmData($this->registeredClient(), $data);
+		$this->addToAssertionCount(1);
+	}
+
+	/** @return array<string, array{array, string}> */
+	public function invalidDataProvider(): array {
+		return [
+			'unknown redirect' => [['redirect_uri' => 'https://evil.example/'], 'unknown redirect_uri'],
+			'wrong secret' => [['client_secret' => 'nope'], 'wrong client_secret'],
+			'more app scopes than registered' => [['app_scopes' => 'read write follow'], 'invalid scope'],
+			'more auth scopes than granted' => [['auth_scopes' => ['read', 'write']], 'invalid scope'],
+			'wrong code' => [['code' => 'other'], 'unknown code'],
+		];
+	}
+
+	/** @dataProvider invalidDataProvider */
+	public function testConfirmDataRejectsMismatches(array $data, string $message): void {
+		$this->expectException(ClientException::class);
+		$this->expectExceptionMessage($message);
+		$this->service->confirmData($this->registeredClient(), $data);
+	}
+}

--- a/tests/Service/ConfigServiceTest.php
+++ b/tests/Service/ConfigServiceTest.php
@@ -1,0 +1,367 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use OCA\Social\Exceptions\SocialAppConfigException;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\MiscService;
+use OCA\Social\Tools\Model\NCRequest;
+use OCA\Social\Tools\Model\Request;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ConfigServiceTest extends TestCase {
+	private IConfig|MockObject $config;
+	private IURLGenerator|MockObject $urlGenerator;
+	private ConfigService $service;
+
+	protected function setUp(): void {
+		$this->config = $this->createMock(IConfig::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->service = new ConfigService(
+			'alice',
+			$this->config,
+			$this->createMock(IRequest::class),
+			$this->urlGenerator,
+			$this->createMock(MiscService::class),
+		);
+	}
+
+	/** Serve app values for the 'social' app from a map, falling back to the requested default. */
+	private function withAppValues(array $values): void {
+		$this->config->method('getAppValue')
+			->willReturnCallback(function (string $app, string $key, $default) use ($values) {
+				$this->assertSame('social', $app);
+
+				return $values[$key] ?? $default;
+			});
+	}
+
+	public function testGetAppValuePassesTheKnownDefault(): void {
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->with('social', ConfigService::SOCIAL_MAX_SIZE, 10)
+			->willReturn('20');
+
+		$this->assertSame('20', $this->service->getAppValue(ConfigService::SOCIAL_MAX_SIZE));
+	}
+
+	public function testGetAppValueHasNoDefaultForUnknownKey(): void {
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->with('social', 'installed_version', null)
+			->willReturn('0.9.0');
+
+		$this->assertSame('0.9.0', $this->service->getAppValue('installed_version'));
+	}
+
+	public function testGetAppValueIntCastsTheStoredString(): void {
+		$this->withAppValues([ConfigService::SOCIAL_SERVICE => '3']);
+
+		$this->assertSame(3, $this->service->getAppValueInt(ConfigService::SOCIAL_SERVICE));
+		$this->assertSame(10, $this->service->getAppValueInt(ConfigService::SOCIAL_MAX_SIZE));
+	}
+
+	public function testGetConfigReturnsEveryKnownKeyWithItsDefault(): void {
+		$this->withAppValues([ConfigService::CLOUD_URL => 'https://cloud.example.com']);
+
+		$config = $this->service->getConfig();
+
+		$this->assertSame(array_keys($this->service->defaults), array_keys($config));
+		$this->assertSame('https://cloud.example.com', $config[ConfigService::CLOUD_URL]);
+		$this->assertSame('all_but', $config[ConfigService::SOCIAL_ACCESS_TYPE]);
+		$this->assertSame('[]', $config[ConfigService::SOCIAL_ACCESS_LIST]);
+		$this->assertSame('0', $config[ConfigService::SOCIAL_SELF_SIGNED]);
+	}
+
+	public function testSetAndDeleteAppValueTargetTheSocialApp(): void {
+		$this->config->expects($this->once())
+			->method('setAppValue')
+			->with('social', ConfigService::SOCIAL_ADDRESS, 'social.example.com');
+		$this->config->expects($this->once())
+			->method('deleteAppValue')
+			->with('social', ConfigService::SOCIAL_ADDRESS);
+		$this->config->expects($this->once())
+			->method('deleteAppValues')
+			->with('social');
+
+		$this->service->setAppValue(ConfigService::SOCIAL_ADDRESS, 'social.example.com');
+		$this->service->deleteAppValue(ConfigService::SOCIAL_ADDRESS);
+		$this->service->unsetAppConfig();
+	}
+
+	public function testGetUserValueFallsBackToSessionUserAndKnownDefault(): void {
+		$this->config->expects($this->once())
+			->method('getUserValue')
+			->with('alice', 'social', ConfigService::SOCIAL_MAX_SIZE, 10)
+			->willReturn('5');
+
+		$this->assertSame('5', $this->service->getUserValue(ConfigService::SOCIAL_MAX_SIZE));
+	}
+
+	public function testGetUserValueForAnotherAppHasEmptyDefault(): void {
+		$this->config->expects($this->once())
+			->method('getUserValue')
+			->with('bob', 'avatar', 'version', '')
+			->willReturn('3');
+
+		$this->assertSame('3', $this->service->getUserValue('version', 'bob', 'avatar'));
+	}
+
+	public function testUserValuesAreWrittenForTheRightUser(): void {
+		$this->config->expects($this->exactly(2))
+			->method('setUserValue')
+			->withConsecutive(
+				['alice', 'social', 'key', 'value'],
+				['bob', 'social', 'key', 'other'],
+			);
+		$this->config->expects($this->once())
+			->method('getUserValue')
+			->with('bob', 'social', 'key')
+			->willReturn('other');
+
+		$this->service->setUserValue('key', 'value');
+		$this->service->setValueForUser('bob', 'key', 'other');
+		$this->assertSame('other', $this->service->getValueForUser('bob', 'key'));
+	}
+
+	public function testCoreValuesUseTheCoreAppNamespace(): void {
+		$this->config->expects($this->once())
+			->method('setAppValue')
+			->with('core', 'public_webfinger', 'social/webfinger');
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->with('core', 'public_webfinger', '')
+			->willReturn('social/webfinger');
+		$this->config->expects($this->once())
+			->method('deleteAppValue')
+			->with('core', 'public_webfinger');
+
+		$this->service->setCoreValue('public_webfinger', 'social/webfinger');
+		$this->assertSame('social/webfinger', $this->service->getCoreValue('public_webfinger'));
+		$this->service->unsetCoreValue('public_webfinger');
+	}
+
+	public function testGetSystemValueDefaultsToEmptyString(): void {
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('overwrite.cli.url', '')
+			->willReturn('https://cloud.example.com');
+
+		$this->assertSame('https://cloud.example.com', $this->service->getSystemValue('overwrite.cli.url'));
+	}
+
+	/** @return array<string, array{string, bool, string}> */
+	public function cloudUrlProvider(): array {
+		return [
+			'plain' => ['https://cloud.example.com', false, 'https://cloud.example.com'],
+			'trailing slash removed' => ['https://cloud.example.com/', false, 'https://cloud.example.com'],
+			'index.php kept by default' => ['https://cloud.example.com/index.php', false, 'https://cloud.example.com/index.php'],
+			'index.php stripped' => ['https://cloud.example.com/index.php', true, 'https://cloud.example.com'],
+			'subfolder install keeps folder' => ['https://cloud.example.com/nextcloud/index.php', true, 'https://cloud.example.com/nextcloud'],
+			'subfolder with trailing slash' => ['https://cloud.example.com/nextcloud/index.php/', false, 'https://cloud.example.com/nextcloud/index.php'],
+			'port survives' => ['http://localhost:8080/index.php', true, 'http://localhost:8080'],
+		];
+	}
+
+	/** @dataProvider cloudUrlProvider */
+	public function testGetCloudUrl(string $stored, bool $noPhp, string $expected): void {
+		$this->withAppValues([ConfigService::CLOUD_URL => $stored]);
+
+		$this->assertSame($expected, $this->service->getCloudUrl($noPhp));
+	}
+
+	public function testGetCloudUrlThrowsWhenUnconfigured(): void {
+		$this->withAppValues([]);
+
+		$this->expectException(SocialAppConfigException::class);
+		$this->service->getCloudUrl();
+	}
+
+	public function testGetCloudHostIsTheHostOfTheCloudUrl(): void {
+		$this->withAppValues([ConfigService::CLOUD_URL => 'https://cloud.example.com/nextcloud/index.php']);
+
+		$this->assertSame('cloud.example.com', $this->service->getCloudHost());
+	}
+
+	public function testGetCloudHostDropsThePort(): void {
+		$this->withAppValues([ConfigService::CLOUD_URL => 'http://localhost:8080']);
+
+		$this->assertSame('localhost', $this->service->getCloudHost());
+	}
+
+	public function testGetCloudHostThrowsWhenUnconfigured(): void {
+		$this->withAppValues([]);
+
+		$this->expectException(SocialAppConfigException::class);
+		$this->service->getCloudHost();
+	}
+
+	public function testSetCloudUrlAddsAMissingScheme(): void {
+		$this->config->expects($this->exactly(2))
+			->method('setAppValue')
+			->withConsecutive(
+				['social', ConfigService::CLOUD_URL, 'http://cloud.example.com'],
+				['social', ConfigService::CLOUD_URL, 'https://cloud.example.com/nextcloud'],
+			);
+
+		$this->service->setCloudUrl('cloud.example.com');
+		$this->service->setCloudUrl('https://cloud.example.com/nextcloud');
+	}
+
+	public function testGetSocialAddressPrefersTheConfiguredAddress(): void {
+		$this->withAppValues([
+			ConfigService::SOCIAL_ADDRESS => 'social.example.com',
+			ConfigService::CLOUD_URL => 'https://cloud.example.com',
+		]);
+
+		$this->assertSame('social.example.com', $this->service->getSocialAddress());
+	}
+
+	public function testGetSocialAddressFallsBackToTheCloudHost(): void {
+		$this->withAppValues([ConfigService::CLOUD_URL => 'https://cloud.example.com/index.php']);
+
+		$this->assertSame('cloud.example.com', $this->service->getSocialAddress());
+	}
+
+	public function testGetSocialAddressThrowsWhenNothingIsConfigured(): void {
+		$this->withAppValues([]);
+
+		$this->expectException(SocialAppConfigException::class);
+		$this->service->getSocialAddress();
+	}
+
+	public function testSetSocialAddress(): void {
+		$this->config->expects($this->once())
+			->method('setAppValue')
+			->with('social', ConfigService::SOCIAL_ADDRESS, 'social.example.com');
+
+		$this->service->setSocialAddress('social.example.com');
+	}
+
+	public function testGetSocialUrl(): void {
+		$this->withAppValues([ConfigService::SOCIAL_URL => 'https://cloud.example.com/apps/social/']);
+
+		$this->assertSame('https://cloud.example.com/apps/social/', $this->service->getSocialUrl());
+	}
+
+	public function testGetSocialUrlThrowsWhenUnconfigured(): void {
+		$this->withAppValues([]);
+
+		$this->expectException(SocialAppConfigException::class);
+		$this->service->getSocialUrl();
+	}
+
+	public function testSetSocialUrlDerivesItFromTheNavigationRoute(): void {
+		$this->urlGenerator->expects($this->once())
+			->method('linkToRoute')
+			->with('social.Navigation.navigate')
+			->willReturn('/nextcloud/apps/social/');
+		$this->urlGenerator->expects($this->once())
+			->method('getAbsoluteURL')
+			->with('/nextcloud/apps/social/')
+			->willReturn('https://cloud.example.com/nextcloud/apps/social/');
+		$this->config->expects($this->once())
+			->method('setAppValue')
+			->with('social', ConfigService::SOCIAL_URL, 'https://cloud.example.com/nextcloud/apps/social/');
+
+		$this->service->setSocialUrl();
+	}
+
+	public function testSetSocialUrlAddsAMissingScheme(): void {
+		$this->urlGenerator->expects($this->never())->method('linkToRoute');
+		$this->config->expects($this->once())
+			->method('setAppValue')
+			->with('social', ConfigService::SOCIAL_URL, 'http://cloud.example.com/apps/social/');
+
+		$this->service->setSocialUrl('cloud.example.com/apps/social/');
+	}
+
+	public function testGenerateIdWithoutRandomPartIsTheSocialUrlPlusPath(): void {
+		$this->withAppValues([ConfigService::SOCIAL_URL => 'https://cloud.example.com/apps/social/']);
+
+		$this->assertSame(
+			'https://cloud.example.com/apps/social/users/alice/',
+			$this->service->generateId('/users/alice', false),
+		);
+	}
+
+	public function testGenerateIdAppendsTimestampAndChecksum(): void {
+		$this->withAppValues([ConfigService::SOCIAL_URL => 'https://cloud.example.com/apps/social/']);
+
+		$before = time();
+		$id = $this->service->generateId('documents/avatar');
+
+		$this->assertMatchesRegularExpression(
+			'#^https://cloud\.example\.com/apps/social/documents/avatar/(\d{10})(\d+)$#',
+			$id,
+		);
+		preg_match('#/avatar/(\d{10})#', $id, $m);
+		$this->assertGreaterThanOrEqual($before, (int)$m[1]);
+		$this->assertNotSame($id, $this->service->generateId('documents/avatar'));
+	}
+
+	public function testGenerateIdRequiresTheSocialUrl(): void {
+		$this->withAppValues([]);
+
+		$this->expectException(SocialAppConfigException::class);
+		$this->service->generateId('/users/alice');
+	}
+
+	public function testConfigureRequestAddsActivityPubAcceptHeaderOnGet(): void {
+		$this->withAppValues([]);
+		$request = new NCRequest('/users/bob', Request::TYPE_GET);
+
+		$this->service->configureRequest($request);
+
+		$headers = $request->getHeaders();
+		$this->assertSame(
+			'application/activity+json, application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+			$headers['Accept'],
+		);
+		$this->assertArrayNotHasKey('Content-Type', $headers);
+		$this->assertTrue($request->isVerifyPeer());
+		$this->assertTrue($request->isLocalAddressAllowed());
+		$this->assertTrue($request->isFollowLocation());
+	}
+
+	public function testConfigureRequestAddsContentTypeOnPost(): void {
+		$this->withAppValues([]);
+		$request = new NCRequest('/inbox', Request::TYPE_POST);
+
+		$this->service->configureRequest($request);
+
+		$headers = $request->getHeaders();
+		$this->assertSame('application/activity+json', $headers['Content-Type']);
+		$this->assertArrayNotHasKey('Accept', $headers);
+	}
+
+	public function testConfigureRequestSkipsJsonHeadersWhenAsked(): void {
+		$this->withAppValues([]);
+		$request = new NCRequest('/media/1.png', Request::TYPE_GET);
+		$request->setClientOptions(['ignoreJsonHeaders' => true]);
+
+		$this->service->configureRequest($request);
+
+		$this->assertArrayNotHasKey('Accept', $request->getHeaders());
+	}
+
+	public function testConfigureRequestDisablesPeerVerificationForSelfSigned(): void {
+		$this->withAppValues([ConfigService::SOCIAL_SELF_SIGNED => '1']);
+		$request = new NCRequest('/inbox', Request::TYPE_POST);
+
+		$this->service->configureRequest($request);
+
+		$this->assertFalse($request->isVerifyPeer());
+	}
+}

--- a/tests/Service/CurlServiceTest.php
+++ b/tests/Service/CurlServiceTest.php
@@ -1,0 +1,363 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use OCA\Social\AP;
+use OCA\Social\Exceptions\HostMetaException;
+use OCA\Social\Exceptions\InvalidOriginException;
+use OCA\Social\Exceptions\InvalidResourceException;
+use OCA\Social\Exceptions\ItemUnknownException;
+use OCA\Social\Exceptions\RetrieveAccountFormatException;
+use OCA\Social\Exceptions\UnauthorizedFediverseException;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\CurlService;
+use OCA\Social\Service\FediverseService;
+use OCA\Social\Tools\Exceptions\MalformedArrayException;
+use OCA\Social\Tools\Exceptions\RequestNetworkException;
+use OCA\Social\Tools\Exceptions\RequestResultNotJsonException;
+use OCA\Social\Tools\Model\NCRequest;
+use OCA\Social\Tools\Model\Request;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class CurlServiceTest extends TestCase {
+	private const BOB = 'https://mastodon.example/users/bob';
+
+	private ConfigService|MockObject $configService;
+	private FediverseService|MockObject $fediverseService;
+	private CurlService|MockObject $service;
+	/** @var NCRequest[] every request handed to the (mocked) transport */
+	private array $requests = [];
+
+	protected function setUp(): void {
+		$this->configService = $this->createMock(ConfigService::class);
+		$this->configService->method('getAppValue')
+			->willReturnCallback(fn (string $key) => match ($key) {
+				ConfigService::SOCIAL_MAX_SIZE => '10',
+				'installed_version' => '0.9.1',
+				default => '',
+			});
+		$this->fediverseService = $this->createMock(FediverseService::class);
+	}
+
+	protected function tearDown(): void {
+		AP::$activityPub = null;
+	}
+
+	/** CurlService with the network layer replaced: doRequest is answered by $responder(NCRequest): string. */
+	private function serviceAnsweringWith(callable $responder, string $mocked = 'doRequest'): CurlService {
+		$this->service = $this->getMockBuilder(CurlService::class)
+			->setConstructorArgs([$this->configService, $this->fediverseService, new NullLogger()])
+			->onlyMethods([$mocked])
+			->getMock();
+		$this->service->method($mocked)->willReturnCallback(function (NCRequest $request) use ($responder) {
+			$this->requests[] = $request;
+
+			return $responder($request);
+		});
+
+		return $this->service;
+	}
+
+	private function hostMetaJson(string $template = 'https://mastodon.example/.well-known/webfinger?resource={uri}'): string {
+		return json_encode(['Link' => ['@attributes' => ['rel' => 'lrdd', 'template' => $template]]]);
+	}
+
+	private function jrd(string $subject = 'acct:bob@mastodon.example', ?string $self = self::BOB): string {
+		$links = [['rel' => 'http://webfinger.net/rel/profile-page', 'type' => 'text/html', 'href' => 'https://mastodon.example/@bob']];
+		if ($self !== null) {
+			$links[] = ['rel' => 'self', 'type' => 'application/activity+json', 'href' => $self];
+		}
+
+		return json_encode(['subject' => $subject, 'links' => $links]);
+	}
+
+	public function testConstructorConvertsTheMaxSizeToBytes(): void {
+		$service = new CurlService($this->configService, $this->fediverseService, new NullLogger());
+		$property = new \ReflectionProperty(CurlService::class, 'maxDownloadSize');
+
+		$this->assertSame(10 * 1048576, $property->getValue($service));
+	}
+
+	public function testAssignUserAgentIncludesTheInstalledVersion(): void {
+		$service = new CurlService($this->configService, $this->fediverseService, new NullLogger());
+		$request = new NCRequest('/users/bob');
+
+		$service->assignUserAgent($request);
+
+		$this->assertSame('Nextcloud Social 0.9.1', $request->getUserAgent());
+	}
+
+	public function testDoRequestChecksAuthorizationConfiguresAndTagsTheRequestBeforeSending(): void {
+		$service = $this->serviceAnsweringWith(fn () => 'body', 'doRequestOrig');
+		$request = new NCRequest('/users/bob');
+		$request->setHost('mastodon.example');
+		$this->fediverseService->expects($this->once())->method('authorized')->with('mastodon.example')->willReturn(true);
+		$this->configService->expects($this->once())->method('configureRequest')->with($this->identicalTo($request));
+
+		$this->assertSame('body', $service->doRequest($request));
+		$this->assertSame('Nextcloud Social 0.9.1', $request->getUserAgent());
+		$this->assertSame([$request], $this->requests);
+	}
+
+	public function testDoRequestNeverSendsToABlockedInstance(): void {
+		$service = $this->serviceAnsweringWith(fn () => 'body', 'doRequestOrig');
+		$this->fediverseService->method('authorized')->willThrowException(new UnauthorizedFediverseException());
+		$this->configService->expects($this->never())->method('configureRequest');
+		$request = new NCRequest('/users/bob');
+		$request->setHost('blocked.example');
+
+		try {
+			$service->doRequest($request);
+			$this->fail('expected UnauthorizedFediverseException');
+		} catch (UnauthorizedFediverseException $e) {
+			$this->assertSame([], $this->requests);
+		}
+	}
+
+	public function testHostMetaRedirectsToTheWebfingerTemplate(): void {
+		$service = $this->serviceAnsweringWith(fn () => $this->hostMetaJson('http://api.mastodon.example/wf?resource={uri}'));
+		$host = 'mastodon.example';
+		$protocols = ['https', 'http'];
+
+		$path = $service->hostMeta($host, $protocols);
+
+		$this->assertSame('/wf', $path);
+		$this->assertSame('api.mastodon.example', $host);
+		$this->assertSame(['http'], $protocols);
+		$this->assertSame('/.well-known/host-meta', $this->requests[0]->getPath());
+		$this->assertSame('mastodon.example', $this->requests[0]->getHost());
+		$this->assertSame(['ignoreJsonHeaders' => true], $this->requests[0]->getClientOptions());
+	}
+
+	public function testHostMetaParsesTheXrdDocument(): void {
+		$service = $this->serviceAnsweringWith(function (NCRequest $request) {
+			$request->setContentType('application/xrd+xml; charset=utf-8');
+
+			return '<?xml version="1.0" encoding="UTF-8"?><XRD xmlns="http://docs.oasis-open.org/ns/xri/xrd-1.0">'
+				. '<Link rel="lrdd" template="https://mastodon.example/.well-known/webfinger?resource={uri}"/></XRD>';
+		});
+		$host = 'mastodon.example';
+		$protocols = ['https'];
+
+		$this->assertSame('/.well-known/webfinger', $service->hostMeta($host, $protocols));
+		$this->assertSame(['https'], $protocols);
+	}
+
+	public function testHostMetaFailsWhenTheDocumentHasNoTemplate(): void {
+		$service = $this->serviceAnsweringWith(fn () => '{"Link":{}}');
+		$host = 'mastodon.example';
+		$protocols = ['https'];
+
+		$this->expectException(HostMetaException::class);
+		$this->expectExceptionMessage('Failed to get URL');
+		$service->hostMeta($host, $protocols);
+	}
+
+	public function testHostMetaWrapsTransportErrors(): void {
+		$service = $this->serviceAnsweringWith(function () {
+			throw new RequestNetworkException('timeout');
+		});
+		$host = 'mastodon.example';
+		$protocols = ['https'];
+
+		$this->expectException(HostMetaException::class);
+		$this->expectExceptionMessage('RequestNetworkException - timeout');
+		$service->hostMeta($host, $protocols);
+	}
+
+	public function testWebfingerAccountFollowsHostMetaAndCanonicalisesTheAccount(): void {
+		$service = $this->serviceAnsweringWith(fn (NCRequest $request) => $request->getPath() === '/.well-known/host-meta'
+			? $this->hostMetaJson('https://wf.mastodon.example/.well-known/webfinger?resource={uri}')
+			: $this->jrd('acct:Bob@mastodon.example'));
+		$account = '@bob@mastodon.example';
+
+		$result = $service->webfingerAccount($account);
+
+		$this->assertSame('Bob@mastodon.example', $account, 'the subject of the JRD wins');
+		$this->assertSame('acct:Bob@mastodon.example', $result['subject']);
+		$this->assertCount(2, $this->requests);
+		$webfinger = $this->requests[1];
+		$this->assertSame('/.well-known/webfinger', $webfinger->getPath());
+		$this->assertSame('wf.mastodon.example', $webfinger->getHost());
+		$this->assertSame(['https'], $webfinger->getProtocols());
+		$this->assertSame(['resource' => 'acct:bob@mastodon.example'], $webfinger->getParams());
+		$this->assertSame(['ignoreJsonHeaders' => true], $webfinger->getClientOptions());
+	}
+
+	public function testWebfingerAccountFallsBackToTheDefaultPathWithoutHostMeta(): void {
+		$service = $this->serviceAnsweringWith(function (NCRequest $request) {
+			if ($request->getPath() === '/.well-known/host-meta') {
+				throw new RequestNetworkException('404');
+			}
+
+			return $this->jrd();
+		});
+		$account = 'bob@mastodon.example';
+
+		$service->webfingerAccount($account);
+
+		$webfinger = $this->requests[1];
+		$this->assertSame('/.well-known/webfinger', $webfinger->getPath());
+		$this->assertSame('mastodon.example', $webfinger->getHost());
+		$this->assertSame(['https', 'http'], $webfinger->getProtocols());
+	}
+
+	public function testWebfingerAccountRequiresAHost(): void {
+		$service = $this->serviceAnsweringWith(fn () => '{}');
+		$account = 'bob';
+
+		$this->expectException(InvalidResourceException::class);
+		$service->webfingerAccount($account);
+		$this->assertSame([], $this->requests);
+	}
+
+	public function testWebfingerAccountRejectsNonJsonAnswers(): void {
+		$service = $this->serviceAnsweringWith(fn (NCRequest $request) => $request->getPath() === '/.well-known/host-meta' ? $this->hostMetaJson() : '<html>');
+		$account = 'bob@mastodon.example';
+
+		$this->expectException(RequestResultNotJsonException::class);
+		$service->webfingerAccount($account);
+	}
+
+	public function testRetrieveObjectFetchesActivityJsonAndAnnotatesTheResult(): void {
+		$service = $this->serviceAnsweringWith(function (NCRequest $request) {
+			$request->setResultCode(200);
+
+			return json_encode(['id' => self::BOB, 'type' => 'Person']);
+		});
+
+		$result = $service->retrieveObject(self::BOB . '?page=2&min_id=7');
+
+		$this->assertSame(['id' => self::BOB, 'type' => 'Person', '_host' => 'mastodon.example', '_resultCode' => 200], $result);
+		$request = $this->requests[0];
+		$this->assertSame('/users/bob', $request->getPath());
+		$this->assertSame('mastodon.example', $request->getHost());
+		$this->assertSame(['https'], $request->getProtocols());
+		$this->assertSame(Request::TYPE_GET, $request->getType());
+		$this->assertSame(['page' => '2', 'min_id' => '7'], $request->getParams());
+		$this->assertSame('application/activity+json', $request->getHeaders()['Accept']);
+	}
+
+	public function testRetrieveObjectCanSkipTheActivityJsonAcceptHeader(): void {
+		$service = $this->serviceAnsweringWith(fn () => '{}');
+
+		$service->retrieveObject(self::BOB, false);
+
+		$this->assertArrayNotHasKey('Accept', $this->requests[0]->getHeaders());
+	}
+
+	public function testRetrieveObjectRejectsRelativeIds(): void {
+		$service = $this->serviceAnsweringWith(fn () => '{}');
+
+		$this->expectException(MalformedArrayException::class);
+		$service->retrieveObject('/users/bob');
+	}
+
+	private function useActivityPubReturning(?Person $actor): void {
+		$ap = $this->createMock(AP::class);
+		$ap->method('getItemFromData')->willReturn($actor ?? new Note());
+		$ap->method('isActor')->willReturnCallback(fn ($item) => $item instanceof Person);
+		AP::$activityPub = $ap;
+	}
+
+	private function webfingerThenActor(array $actorData): CurlService {
+		return $this->serviceAnsweringWith(fn (NCRequest $request) => match ($request->getPath()) {
+			'/.well-known/host-meta' => $this->hostMetaJson(),
+			'/.well-known/webfinger' => $this->jrd(),
+			default => json_encode($actorData),
+		});
+	}
+
+	public function testRetrieveAccountResolvesTheSelfLinkToAnActor(): void {
+		$service = $this->webfingerThenActor(['id' => self::BOB, 'type' => 'Person']);
+		$bob = new Person();
+		$bob->setId(self::BOB);
+		$this->useActivityPubReturning($bob);
+		$account = 'bob@mastodon.example';
+
+		$this->assertSame($bob, $service->retrieveAccount($account));
+		$this->assertSame('/users/bob', end($this->requests)->getPath());
+	}
+
+	public function testRetrieveAccountAcceptsCaseDifferencesInTheActorId(): void {
+		$service = $this->webfingerThenActor(['id' => strtoupper(self::BOB)]);
+		$bob = new Person();
+		$bob->setId(strtoupper(self::BOB));
+		$this->useActivityPubReturning($bob);
+		$account = 'bob@mastodon.example';
+
+		$this->assertSame($bob, $service->retrieveAccount($account));
+	}
+
+	public function testRetrieveAccountRejectsAnActorClaimingAnotherId(): void {
+		$service = $this->webfingerThenActor(['id' => 'https://evil.example/users/bob']);
+		$impostor = new Person();
+		$impostor->setId('https://evil.example/users/bob');
+		$this->useActivityPubReturning($impostor);
+		$account = 'bob@mastodon.example';
+
+		$this->expectException(InvalidOriginException::class);
+		$service->retrieveAccount($account);
+	}
+
+	public function testRetrieveAccountRejectsANonActorDocument(): void {
+		$service = $this->webfingerThenActor(['type' => 'Note']);
+		$this->useActivityPubReturning(null);
+		$account = 'bob@mastodon.example';
+
+		$this->expectException(ItemUnknownException::class);
+		$service->retrieveAccount($account);
+	}
+
+	public function testRetrieveAccountRequiresASelfLink(): void {
+		$service = $this->serviceAnsweringWith(fn (NCRequest $request) => $request->getPath() === '/.well-known/host-meta'
+			? $this->hostMetaJson()
+			: $this->jrd('acct:bob@mastodon.example', null));
+		$account = 'bob@mastodon.example';
+
+		$this->expectException(RetrieveAccountFormatException::class);
+		$service->retrieveAccount($account);
+	}
+
+	public function testRetrieveJsonRejectsEmptyBodies(): void {
+		$service = $this->serviceAnsweringWith(fn () => '');
+
+		$this->expectException(RequestResultNotJsonException::class);
+		$service->retrieveJson(new NCRequest('/x'));
+	}
+
+	public function testAsyncWithTokenPostsToTheLocalAsyncEndpoint(): void {
+		$this->configService->method('getSocialUrl')->willReturn('https://cloud.example.com/nextcloud/apps/social/');
+		$this->configService->method('getCloudHost')->willReturn('cloud.example.com');
+		$service = $this->serviceAnsweringWith(fn () => 'not json');
+
+		$service->asyncWithToken('abc-123');
+
+		$request = $this->requests[0];
+		$this->assertSame('/nextcloud/apps/social/async/request/abc-123', $request->getPath());
+		$this->assertSame('cloud.example.com', $request->getHost());
+		$this->assertSame(['https'], $request->getProtocols());
+		$this->assertSame(Request::TYPE_POST, $request->getType());
+	}
+
+	public function testAsyncWithTokenSwallowsTransportErrors(): void {
+		$this->configService->method('getSocialUrl')->willReturn('https://cloud.example.com/apps/social/');
+		$service = $this->serviceAnsweringWith(function () {
+			throw new RequestNetworkException('refused');
+		});
+
+		$service->asyncWithToken('abc-123');
+		$this->assertCount(1, $this->requests);
+	}
+}

--- a/tests/Service/DetailsServiceTest.php
+++ b/tests/Service/DetailsServiceTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use OCA\Social\Exceptions\ActorDoesNotExistException;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Follow;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Model\ActivityPub\Stream;
+use OCA\Social\Service\AccountService;
+use OCA\Social\Service\CacheActorService;
+use OCA\Social\Service\DetailsService;
+use OCA\Social\Service\FollowService;
+use OCA\Social\Service\StreamService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class DetailsServiceTest extends TestCase {
+	private const ALICE = 'https://cloud.example.com/apps/social/@alice';
+	private const ALICE_FOLLOWERS = 'https://cloud.example.com/apps/social/@alice/followers';
+	private const BOB = 'https://cloud.example.com/apps/social/@bob';
+
+	private StreamService|MockObject $streamService;
+	private AccountService|MockObject $accountService;
+	private FollowService|MockObject $followService;
+	private DetailsService $service;
+
+	protected function setUp(): void {
+		$this->streamService = $this->createMock(StreamService::class);
+		$this->accountService = $this->createMock(AccountService::class);
+		$this->followService = $this->createMock(FollowService::class);
+		$this->service = new DetailsService(
+			$this->streamService,
+			$this->accountService,
+			$this->followService,
+			$this->createMock(CacheActorService::class),
+		);
+	}
+
+	private function person(string $id): Person {
+		$person = new Person();
+		$person->setId($id);
+
+		return $person;
+	}
+
+	private function follower(string $actorId): Follow {
+		$follow = new Follow();
+		$follow->setActor($this->person($actorId));
+
+		return $follow;
+	}
+
+	public function testPublicLocalPostIsFlaggedPublicAndReachesFollowers(): void {
+		$stream = new Note();
+		$stream->setId('https://cloud.example.com/apps/social/@alice/1');
+		$stream->setLocal(true);
+		$stream->setTimeline(Stream::TYPE_PUBLIC);
+		$stream->setTo(ACore::CONTEXT_PUBLIC);
+		$stream->setCcArray([self::ALICE_FOLLOWERS]);
+		$this->streamService->expects($this->once())->method('detectType')->with($this->identicalTo($stream));
+		$this->accountService->method('getFromId')
+			->with(self::ALICE_FOLLOWERS)
+			->willThrowException(new ActorDoesNotExistException());
+		$this->followService->expects($this->once())
+			->method('getFollowersFromFollowId')
+			->with(self::ALICE_FOLLOWERS)
+			->willReturn([$this->follower(self::BOB), new Follow()]);
+
+		$details = $this->service->generateDetailsFromStream($stream);
+
+		$this->assertSame($stream, $details->getStream());
+		$this->assertTrue($details->isPublic());
+		$this->assertFalse($details->isFederated());
+		$this->assertSame([], $details->getDirectViewers());
+		$this->assertCount(1, $details->getHomeViewers(), 'follows without a loaded actor are skipped');
+		$this->assertSame(self::BOB, $details->getHomeViewers()[0]->getId());
+	}
+
+	public function testPublicRemotePostIsFederated(): void {
+		$stream = new Note();
+		$stream->setLocal(false);
+		$stream->setTimeline(Stream::TYPE_PUBLIC);
+		$stream->setTo(ACore::CONTEXT_PUBLIC);
+		$this->accountService->expects($this->never())->method('getFromId');
+		$this->followService->expects($this->never())->method('getFollowersFromFollowId');
+
+		$details = $this->service->generateDetailsFromStream($stream);
+
+		$this->assertFalse($details->isPublic());
+		$this->assertTrue($details->isFederated());
+	}
+
+	public function testDirectMessageListsTheRecipientAsDirectViewer(): void {
+		$stream = new Note();
+		$stream->setTimeline(Stream::TYPE_DIRECT);
+		$stream->setTo(self::BOB);
+		$bob = $this->person(self::BOB);
+		$this->accountService->expects($this->once())
+			->method('getFromId')
+			->with(self::BOB)
+			->willReturn($bob);
+		$this->followService->method('getFollowersFromFollowId')->with(self::BOB)->willReturn([]);
+
+		$details = $this->service->generateDetailsFromStream($stream);
+
+		$this->assertSame([$bob], $details->getDirectViewers());
+		$this->assertSame([], $details->getHomeViewers());
+		$this->assertFalse($details->isPublic());
+		$this->assertFalse($details->isFederated());
+	}
+
+	public function testFollowersOnlyPostSkipsThePublicCollectionAndKeepsHomeViewers(): void {
+		$stream = new Note();
+		$stream->setTimeline(Stream::TYPE_FOLLOWERS);
+		$stream->setTo(self::ALICE_FOLLOWERS);
+		$stream->setCcArray([ACore::CONTEXT_PUBLIC]);
+		$this->accountService->method('getFromId')->willThrowException(new ActorDoesNotExistException());
+		$this->followService->expects($this->once())
+			->method('getFollowersFromFollowId')
+			->with(self::ALICE_FOLLOWERS)
+			->willReturn([$this->follower(self::BOB), $this->follower(self::ALICE)]);
+
+		$details = $this->service->generateDetailsFromStream($stream);
+
+		$this->assertCount(2, $details->getHomeViewers());
+		$this->assertFalse($details->isPublic());
+	}
+}

--- a/tests/Service/DocumentServiceTest.php
+++ b/tests/Service/DocumentServiceTest.php
@@ -1,0 +1,356 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use OCA\Social\AP;
+use OCA\Social\Db\ActorsRequest;
+use OCA\Social\Db\CacheDocumentsRequest;
+use OCA\Social\Db\StreamRequest;
+use OCA\Social\Exceptions\CacheContentMimeTypeException;
+use OCA\Social\Exceptions\CacheDocumentDoesNotExistException;
+use OCA\Social\Exceptions\UnauthorizedFediverseException;
+use OCA\Social\Interfaces\Object\ImageInterface;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Document;
+use OCA\Social\Model\ActivityPub\Object\Image;
+use OCA\Social\Service\CacheDocumentService;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\DocumentService;
+use OCA\Social\Service\MiscService;
+use OCA\Social\Tools\Exceptions\RequestContentException;
+use OCA\Social\Tools\Exceptions\RequestNetworkException;
+use OCA\Social\Tools\Exceptions\RequestResultSizeException;
+use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
+use OCP\Files\SimpleFS\ISimpleFile;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class DocumentServiceTest extends TestCase {
+	private const DOC_ID = 'https://remote.example/media/1';
+	private const UUID = '2b5a7a87-8db1-445f-a17b-405790f91c80';
+
+	private IURLGenerator|MockObject $urlGenerator;
+	private CacheDocumentsRequest|MockObject $cacheDocumentsRequest;
+	private ActorsRequest|MockObject $actorsRequest;
+	private StreamRequest|MockObject $streamRequest;
+	private CacheDocumentService|MockObject $cacheService;
+	private ConfigService|MockObject $configService;
+	private MiscService|MockObject $miscService;
+	private DocumentService $service;
+
+	protected function setUp(): void {
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->cacheDocumentsRequest = $this->createMock(CacheDocumentsRequest::class);
+		$this->actorsRequest = $this->createMock(ActorsRequest::class);
+		$this->streamRequest = $this->createMock(StreamRequest::class);
+		$this->cacheService = $this->createMock(CacheDocumentService::class);
+		$this->configService = $this->createMock(ConfigService::class);
+		$this->miscService = $this->createMock(MiscService::class);
+
+		$this->service = new DocumentService(
+			$this->urlGenerator,
+			$this->cacheDocumentsRequest,
+			$this->actorsRequest,
+			$this->streamRequest,
+			$this->cacheService,
+			$this->configService,
+			$this->miscService,
+		);
+	}
+
+	protected function tearDown(): void {
+		AP::$activityPub = null;
+	}
+
+	private function document(string $localCopy = '', int $error = 0): Document {
+		$document = new Document();
+		$document->setId(self::DOC_ID);
+		$document->setUrl('https://remote.example/files/pic.png');
+		$document->setMimeType('image/png');
+		$document->setLocalCopy($localCopy);
+		$document->setResizedCopy($localCopy === '' ? '' : 'resized-' . $localCopy);
+		$document->setError($error);
+
+		return $document;
+	}
+
+	public function testGetMediaFromArrayDelegates(): void {
+		$doc = $this->document();
+		$this->cacheDocumentsRequest->expects($this->once())
+			->method('getFromArray')
+			->with(['1', '2'], 'alice@cloud.example.com')
+			->willReturn([$doc]);
+
+		$this->assertSame([$doc], $this->service->getMediaFromArray(['1', '2'], 'alice@cloud.example.com'));
+	}
+
+	public function testGetFromUuidRejectsMalformedIds(): void {
+		$this->cacheService->expects($this->never())->method('getFromUuid');
+
+		$this->expectException(NotFoundException::class);
+		$this->expectExceptionMessage('invalid document');
+		$this->service->getFromUuid('../../etc/passwd');
+	}
+
+	public function testGetFromUuidDelegatesForAWellFormedId(): void {
+		$file = $this->createMock(ISimpleFile::class);
+		$this->cacheService->expects($this->once())->method('getFromUuid')->with(self::UUID)->willReturn($file);
+
+		$this->assertSame($file, $this->service->getFromUuid(self::UUID));
+	}
+
+	public function testCacheRemoteDocumentReturnsAnAlreadyCachedDocument(): void {
+		$doc = $this->document('local-1');
+		$this->cacheDocumentsRequest->method('getById')->with(self::DOC_ID, true)->willReturn($doc);
+		$this->cacheDocumentsRequest->expects($this->never())->method('initCaching');
+		$this->cacheService->expects($this->never())->method('saveRemoteFileToCache');
+
+		$this->assertSame($doc, $this->service->cacheRemoteDocument(self::DOC_ID, true));
+	}
+
+	public function testCacheRemoteDocumentHidesDocumentsInError(): void {
+		$this->cacheDocumentsRequest->method('getById')->willReturn($this->document('', DocumentService::ERROR_MIMETYPE));
+
+		$this->expectException(CacheDocumentDoesNotExistException::class);
+		$this->service->cacheRemoteDocument(self::DOC_ID);
+	}
+
+	public function testCacheRemoteDocumentDoesNotRetryWhileACachingIsInProgress(): void {
+		$doc = $this->document();
+		$doc->setCaching(time() - 60);
+		$this->cacheDocumentsRequest->method('getById')->willReturn($doc);
+		$this->cacheDocumentsRequest->expects($this->never())->method('initCaching');
+
+		$this->assertSame($doc, $this->service->cacheRemoteDocument(self::DOC_ID));
+	}
+
+	public function testCacheRemoteDocumentDownloadsAndAttachesTheFile(): void {
+		$doc = $this->document();
+		$doc->setCaching(time() - CacheDocumentsRequest::CACHING_TIMEOUT * 60 - 10);
+		$this->cacheDocumentsRequest->method('getById')->willReturn($doc);
+		$this->cacheDocumentsRequest->expects($this->once())->method('initCaching')->with($this->identicalTo($doc));
+		$this->cacheService->expects($this->once())
+			->method('saveRemoteFileToCache')
+			->with($this->identicalTo($doc))
+			->willReturnCallback(function (Document $document) {
+				$document->setLocalCopy('fresh');
+			});
+		$this->cacheDocumentsRequest->expects($this->once())->method('endCaching')->with($this->identicalTo($doc));
+		$this->streamRequest->expects($this->once())->method('updateAttachments')->with($this->identicalTo($doc));
+
+		$this->assertSame($doc, $this->service->cacheRemoteDocument(self::DOC_ID));
+		$this->assertSame('fresh', $doc->getLocalCopy());
+	}
+
+	/** @return array<string, array{\Exception, int}> */
+	public function cachingErrorProvider(): array {
+		return [
+			'wrong mime type' => [new CacheContentMimeTypeException(), DocumentService::ERROR_MIMETYPE],
+			'too big' => [new RequestResultSizeException(), DocumentService::ERROR_SIZE],
+			'storage not found' => [new NotFoundException(), DocumentService::ERROR_PERMISSION],
+			'storage not permitted' => [new NotPermittedException(), DocumentService::ERROR_PERMISSION],
+		];
+	}
+
+	/** @dataProvider cachingErrorProvider */
+	public function testCacheRemoteDocumentRecordsPermanentErrors(\Exception $failure, int $error): void {
+		$doc = $this->document();
+		$this->cacheDocumentsRequest->method('getById')->willReturn($doc);
+		$this->cacheService->method('saveRemoteFileToCache')->willThrowException($failure);
+		$this->cacheDocumentsRequest->expects($this->once())->method('endCaching')->with($this->identicalTo($doc));
+		$this->cacheDocumentsRequest->expects($this->never())->method('deleteById');
+		$this->streamRequest->expects($this->never())->method('updateAttachments');
+
+		try {
+			$this->service->cacheRemoteDocument(self::DOC_ID);
+			$this->fail('expected CacheDocumentDoesNotExistException');
+		} catch (CacheDocumentDoesNotExistException $e) {
+			$this->assertSame($error, $doc->getError());
+		}
+	}
+
+	/** @return array<string, array{\Exception}> */
+	public function goneProvider(): array {
+		return [
+			'remote says gone' => [new RequestContentException('gone', 410)],
+			'blocked instance' => [new UnauthorizedFediverseException()],
+		];
+	}
+
+	/** @dataProvider goneProvider */
+	public function testCacheRemoteDocumentDeletesUnreachableDocuments(\Exception $failure): void {
+		$doc = $this->document();
+		$this->cacheDocumentsRequest->method('getById')->willReturn($doc);
+		$this->cacheService->method('saveRemoteFileToCache')->willThrowException($failure);
+		$this->cacheDocumentsRequest->expects($this->once())->method('deleteById')->with(self::DOC_ID);
+		$this->cacheDocumentsRequest->expects($this->never())->method('endCaching');
+
+		$this->expectException(CacheDocumentDoesNotExistException::class);
+		$this->service->cacheRemoteDocument(self::DOC_ID);
+	}
+
+	public function testCacheRemoteDocumentLeavesTransientErrorsRetryable(): void {
+		$doc = $this->document();
+		$this->cacheDocumentsRequest->method('getById')->willReturn($doc);
+		$this->cacheService->method('saveRemoteFileToCache')->willThrowException(new RequestNetworkException('timeout'));
+		$this->cacheDocumentsRequest->expects($this->once())->method('endCaching');
+		$this->cacheDocumentsRequest->expects($this->never())->method('deleteById');
+
+		try {
+			$this->service->cacheRemoteDocument(self::DOC_ID);
+			$this->fail('expected CacheDocumentDoesNotExistException');
+		} catch (CacheDocumentDoesNotExistException $e) {
+			$this->assertSame(0, $doc->getError());
+		}
+	}
+
+	public function testGetFromCacheReturnsTheLocalCopyAndItsMimeType(): void {
+		$doc = $this->document('local-1');
+		$this->cacheDocumentsRequest->method('getById')->with(self::DOC_ID, false)->willReturn($doc);
+		$file = $this->createMock(ISimpleFile::class);
+		$this->cacheService->expects($this->once())->method('getContentFromCache')->with('local-1')->willReturn($file);
+
+		$mime = '';
+		$this->assertSame($file, $this->service->getFromCache(self::DOC_ID, $mime));
+		$this->assertSame('image/png', $mime);
+	}
+
+	public function testGetResizedFromCacheReturnsTheResizedCopy(): void {
+		$doc = $this->document('local-1');
+		$this->cacheDocumentsRequest->method('getById')->with(self::DOC_ID, true)->willReturn($doc);
+		$file = $this->createMock(ISimpleFile::class);
+		$this->cacheService->expects($this->once())->method('getContentFromCache')->with('resized-local-1')->willReturn($file);
+
+		$mime = '';
+		$this->assertSame($file, $this->service->getResizedFromCache(self::DOC_ID, $mime, true));
+		$this->assertSame('image/png', $mime);
+	}
+
+	public function testGetFromCachePropagatesAMissingDocument(): void {
+		$this->cacheDocumentsRequest->method('getById')->willThrowException(new CacheDocumentDoesNotExistException());
+
+		$this->expectException(CacheDocumentDoesNotExistException::class);
+		$this->service->getFromCache(self::DOC_ID);
+	}
+
+	public function testManageCacheDocumentsSkipsLocalAvatarsAndCountsSuccesses(): void {
+		$avatar = $this->document('avatar');
+		$header = $this->document('header');
+		$pending = $this->document();
+		$pending->setId('https://remote.example/media/2');
+		$failing = $this->document();
+		$failing->setId('https://remote.example/media/3');
+		$this->cacheDocumentsRequest->method('getNotCachedDocuments')->willReturn([$avatar, $header, $pending, $failing]);
+		$this->cacheDocumentsRequest->method('getById')->willReturnCallback(fn (string $id) => $id === $pending->getId() ? $pending : $failing);
+		$this->cacheService->method('saveRemoteFileToCache')->willReturnCallback(function (Document $document) {
+			if ($document->getId() === 'https://remote.example/media/3') {
+				throw new RequestNetworkException('timeout');
+			}
+		});
+
+		$this->assertSame(1, $this->service->manageCacheDocuments());
+	}
+
+	private function alice(int $avatarVersion): Person {
+		$alice = new Person();
+		$alice->setId('https://cloud.example.com/apps/social/@alice');
+		$alice->setUserId('alice');
+		$alice->setAvatarVersion($avatarVersion);
+
+		return $alice;
+	}
+
+	private function avatarUrl(): string {
+		$url = 'https://cloud.example.com/avatar/alice/128';
+		$this->urlGenerator->method('linkToRouteAbsolute')
+			->with('core.avatar.getAvatar', ['userId' => 'alice', 'size' => 128])
+			->willReturn($url);
+
+		return $url;
+	}
+
+	public function testCacheLocalAvatarCreatesANewImageWhenTheAvatarChanged(): void {
+		$url = $this->avatarUrl();
+		$alice = $this->alice(1);
+		$this->configService->method('getUserValue')->with('version', 'alice', 'avatar')->willReturn('2');
+		$icon = new Image();
+		$icon->setUrlCloud('https://cloud.example.com');
+		$ap = $this->createMock(AP::class);
+		$ap->method('getItemFromType')->with(Image::TYPE)->willReturn($icon);
+		$imageInterface = $this->createMock(ImageInterface::class);
+		$imageInterface->expects($this->once())->method('save')->with($this->identicalTo($icon));
+		$ap->method('getInterfaceFromType')->with(Image::TYPE)->willReturn($imageInterface);
+		AP::$activityPub = $ap;
+		$this->actorsRequest->expects($this->once())->method('update')->with($this->identicalTo($alice));
+		$this->cacheDocumentsRequest->expects($this->never())->method('getByUrl');
+
+		$id = $this->service->cacheLocalAvatarByUsername($alice);
+
+		$this->assertSame($icon->getId(), $id);
+		$this->assertStringStartsWith('https://cloud.example.com/documents/avatar/', $id);
+		$this->assertSame($url, $icon->getUrl());
+		$this->assertSame('avatar', $icon->getLocalCopy());
+		$this->assertSame(2, $alice->getAvatarVersion());
+	}
+
+	public function testCacheLocalAvatarReusesTheCachedImageWhenUnchanged(): void {
+		$url = $this->avatarUrl();
+		$alice = $this->alice(2);
+		$this->configService->method('getUserValue')->willReturn('2');
+		$cached = new Image();
+		$cached->setId('https://cloud.example.com/documents/avatar/existing');
+		$this->cacheDocumentsRequest->expects($this->once())->method('getByUrl')->with($url)->willReturn($cached);
+		$this->actorsRequest->expects($this->never())->method('update');
+
+		$this->assertSame('https://cloud.example.com/documents/avatar/existing', $this->service->cacheLocalAvatarByUsername($alice));
+	}
+
+	public function testCacheLocalAvatarIsEmptyWhenNothingIsCachedYet(): void {
+		$this->avatarUrl();
+		$this->configService->method('getUserValue')->willReturn('0');
+		$this->cacheDocumentsRequest->method('getByUrl')->willThrowException(new CacheDocumentDoesNotExistException());
+
+		$this->assertSame('', $this->service->cacheLocalAvatarByUsername($this->alice(0)));
+	}
+
+	public function testCacheLocalHeaderStoresTheUploadAndPointsTheActorAtIt(): void {
+		$alice = $this->alice(0);
+		$image = new Image();
+		$image->setUrlCloud('https://cloud.example.com');
+		$ap = $this->createMock(AP::class);
+		$ap->method('getItemFromType')->with(Image::TYPE)->willReturn($image);
+		$imageInterface = $this->createMock(ImageInterface::class);
+		$imageInterface->expects($this->once())->method('save')->with($this->identicalTo($image));
+		$ap->method('getInterfaceFromType')->willReturn($imageInterface);
+		AP::$activityPub = $ap;
+		$this->urlGenerator->method('linkToRouteAbsolute')
+			->willReturnCallback(fn (string $route, array $args) => match ($route) {
+				'social.Local.globalActorHeader' => 'https://cloud.example.com/apps/social/header/' . rawurlencode($args['id']),
+				'social.Api.mediaOpen' => 'https://cloud.example.com/apps/social/media/' . $args['uuid'],
+			});
+		$this->cacheService->expects($this->once())
+			->method('saveFromTempToCache')
+			->with($this->identicalTo($image), '/tmp/upload.jpg')
+			->willReturnCallback(function (Image $image) {
+				$image->setLocalCopy('stored-uuid');
+			});
+
+		$id = $this->service->cacheLocalHeaderByUsername($alice, '/tmp/upload.jpg', 'image/jpeg');
+
+		$this->assertSame($image->getId(), $id);
+		$this->assertStringStartsWith('https://cloud.example.com/documents/header/', $id);
+		$this->assertSame('image/jpeg', $image->getMimeType());
+		$this->assertTrue($image->isPublic());
+		$this->assertSame('https://cloud.example.com/apps/social/media/stored-uuid.jpeg', $image->getUrl());
+		$this->assertSame($image->getUrl(), $alice->getHeader());
+	}
+}

--- a/tests/Service/FediverseServiceTest.php
+++ b/tests/Service/FediverseServiceTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use Exception;
+use OCA\Social\Exceptions\UnauthorizedFediverseException;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\FediverseService;
+use OCA\Social\Service\MiscService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class FediverseServiceTest extends TestCase {
+	private ConfigService|MockObject $configService;
+	private FediverseService $service;
+
+	protected function setUp(): void {
+		$this->configService = $this->createMock(ConfigService::class);
+		$this->service = new FediverseService($this->configService, $this->createMock(MiscService::class));
+	}
+
+	private function withAccess(string $type, array $list, string $cloudHost = 'cloud.example.com'): void {
+		$this->configService->method('getAppValue')
+			->willReturnCallback(fn (string $key) => match ($key) {
+				ConfigService::SOCIAL_ACCESS_TYPE => $type,
+				ConfigService::SOCIAL_ACCESS_LIST => json_encode($list),
+				default => '',
+			});
+		$this->configService->method('getCloudHost')->willReturn($cloudHost);
+	}
+
+	public function testEmptyOriginIsNeverAuthorized(): void {
+		$this->withAccess('all_but', []);
+
+		$this->expectException(UnauthorizedFediverseException::class);
+		$this->expectExceptionMessage('Empty Origin');
+		$this->service->authorized('');
+	}
+
+	public function testBlacklistModeAuthorizesUnlistedAddresses(): void {
+		$this->withAccess('all_but', ['spam.example']);
+
+		$this->assertTrue($this->service->authorized('mastodon.example'));
+	}
+
+	public function testBlacklistModeBlocksListedAddresses(): void {
+		$this->withAccess('all_but', ['spam.example']);
+
+		$this->expectException(UnauthorizedFediverseException::class);
+		$this->expectExceptionMessage('Unauthorized Fediverse');
+		$this->service->authorized('spam.example');
+	}
+
+	public function testWhitelistModeAuthorizesListedAddresses(): void {
+		$this->withAccess('none_but', ['friend.example']);
+
+		$this->assertTrue($this->service->authorized('friend.example'));
+	}
+
+	public function testWhitelistModeAlwaysAuthorizesTheLocalHost(): void {
+		$this->withAccess('none_but', []);
+
+		$this->assertTrue($this->service->authorized('cloud.example.com'));
+	}
+
+	public function testWhitelistModeBlocksEverythingElse(): void {
+		$this->withAccess('none_but', ['friend.example']);
+
+		$this->expectException(UnauthorizedFediverseException::class);
+		$this->service->authorized('mastodon.example');
+	}
+
+	public function testJailedThrowsForAnEmptyWhitelist(): void {
+		$this->withAccess('none_but', []);
+
+		$this->expectException(UnauthorizedFediverseException::class);
+		$this->expectExceptionMessage('Jailed Fediverse');
+		$this->service->jailed();
+	}
+
+	public function testJailedIsQuietWithAPopulatedWhitelist(): void {
+		$this->withAccess('none_but', ['friend.example']);
+
+		$this->service->jailed();
+		$this->addToAssertionCount(1);
+	}
+
+	public function testJailedIsQuietInBlacklistMode(): void {
+		$this->withAccess('all_but', []);
+
+		$this->service->jailed();
+		$this->addToAssertionCount(1);
+	}
+
+	public function testGetAccessTypeReadsTheConfig(): void {
+		$this->withAccess('none_but', []);
+
+		$this->assertSame('none_but', $this->service->getAccessType());
+	}
+
+	public function testSetAccessTypePersistsAKnownType(): void {
+		$this->configService->expects($this->once())
+			->method('setAppValue')
+			->with(ConfigService::SOCIAL_ACCESS_TYPE, 'none_but');
+
+		$this->service->setAccessType('none_but');
+	}
+
+	public function testSetAccessTypeRejectsUnknownTypes(): void {
+		$this->configService->expects($this->never())->method('setAppValue');
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('invalid type');
+		$this->service->setAccessType('whitelist');
+	}
+
+	public function testIsLocalComparesAgainstTheCloudHost(): void {
+		$this->withAccess('all_but', []);
+
+		$this->assertTrue($this->service->isLocal('cloud.example.com'));
+		$this->assertFalse($this->service->isLocal('mastodon.example'));
+	}
+
+	public function testListedAddressesAreDecodedFromConfig(): void {
+		$this->withAccess('all_but', ['a.example', 'b.example']);
+
+		$this->assertSame(['a.example', 'b.example'], $this->service->getListedAddresses());
+		$this->assertTrue($this->service->isListed('b.example'));
+		$this->assertFalse($this->service->isListed('c.example'));
+	}
+
+	public function testResetAddressesStoresAnEmptyList(): void {
+		$this->configService->expects($this->once())
+			->method('setAppValue')
+			->with(ConfigService::SOCIAL_ACCESS_LIST, '[]');
+
+		$this->service->resetAddresses();
+	}
+
+	public function testAddAddressAppendsAndPersists(): void {
+		$this->withAccess('all_but', ['a.example']);
+		$this->configService->expects($this->once())
+			->method('setAppValue')
+			->with(ConfigService::SOCIAL_ACCESS_LIST, '["a.example","b.example"]');
+
+		$this->service->addAddress('b.example');
+	}
+
+	public function testAddAddressIgnoresDuplicates(): void {
+		$this->withAccess('all_but', ['a.example']);
+		$this->configService->expects($this->never())->method('setAppValue');
+
+		$this->service->addAddress('a.example');
+	}
+
+	public function testRemoveAddressPersistsTheRemainingList(): void {
+		$this->withAccess('all_but', ['a.example', 'b.example']);
+		$this->configService->expects($this->once())
+			->method('setAppValue')
+			->with(ConfigService::SOCIAL_ACCESS_LIST, '["a.example"]');
+
+		$this->service->removeAddress('b.example');
+	}
+
+	public function testKnownAddressesIsEmpty(): void {
+		$this->assertSame([], $this->service->getKnownAddresses());
+	}
+}

--- a/tests/Service/FollowServiceTest.php
+++ b/tests/Service/FollowServiceTest.php
@@ -1,0 +1,418 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use OCA\Social\AP;
+use OCA\Social\Db\FollowsRequest;
+use OCA\Social\Exceptions\CacheActorDoesNotExistException;
+use OCA\Social\Exceptions\FollowNotFoundException;
+use OCA\Social\Exceptions\FollowSameAccountException;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Activity\Undo;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Follow;
+use OCA\Social\Model\InstancePath;
+use OCA\Social\Service\ActivityService;
+use OCA\Social\Service\CacheActorService;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\FollowService;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use ReflectionClass;
+
+class FollowServiceTest extends TestCase {
+	private const CLOUD_URL = 'https://cloud.example';
+	private const ALICE_ID = 'https://social.example/@alice';
+	private const BOB_ID = 'https://remote.example/users/bob';
+	private const CAROL_ID = 'https://other.example/users/carol';
+
+	private IURLGenerator|MockObject $urlGenerator;
+	private FollowsRequest|MockObject $followsRequest;
+	private ActivityService|MockObject $activityService;
+	private CacheActorService|MockObject $cacheActorService;
+	private FollowService $service;
+
+	protected function setUp(): void {
+		$this->bootActivityPub();
+
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->followsRequest = $this->createMock(FollowsRequest::class);
+		$this->activityService = $this->createMock(ActivityService::class);
+		$this->cacheActorService = $this->createMock(CacheActorService::class);
+
+		$this->service = new FollowService(
+			$this->urlGenerator,
+			$this->followsRequest,
+			$this->activityService,
+			$this->cacheActorService,
+			$this->createMock(ConfigService::class),
+			new NullLogger()
+		);
+	}
+
+	protected function tearDown(): void {
+		AP::$activityPub = null;
+	}
+
+	/**
+	 * A real AP with every ActivityPub interface mocked, so getItemFromType()
+	 * behaves as in production (including the cloud url needed for ids).
+	 */
+	private function bootActivityPub(): void {
+		$args = [];
+		foreach ((new ReflectionClass(AP::class))->getConstructor()->getParameters() as $parameter) {
+			$class = $parameter->getType()->getName();
+			$mock = $this->createMock($class);
+			if ($class === ConfigService::class) {
+				$mock->method('getCloudUrl')->willReturn(self::CLOUD_URL);
+			}
+			$args[] = $mock;
+		}
+		AP::$activityPub = new AP(...$args);
+	}
+
+	private function person(string $id, string $username, int $nid = 0): Person {
+		$person = new Person();
+		$person->setId($id);
+		$person->setNid($nid);
+		$person->setPreferredUsername($username);
+		$person->setInbox($id . '/inbox');
+		$person->setFollowers($id . '/followers');
+		$person->setFollowing($id . '/following');
+
+		return $person;
+	}
+
+	private function alice(): Person {
+		$alice = $this->person(self::ALICE_ID, 'alice', 1);
+		$alice->setLocal(true);
+
+		return $alice;
+	}
+
+	private function follow(string $actorId, string $objectId, bool $accepted): Follow {
+		$follow = new Follow();
+		$follow->setId(self::CLOUD_URL . '/follow/' . md5($actorId . $objectId));
+		$follow->setActorId($actorId);
+		$follow->setObjectId($objectId);
+		$follow->setAccepted($accepted);
+
+		return $follow;
+	}
+
+
+	// followAccount()
+
+	public function testFollowAccountSavesFollowAndSendsItToTargetInbox(): void {
+		$bob = $this->person(self::BOB_ID, 'bob');
+		$this->cacheActorService->expects($this->once())
+			->method('getFromAccount')
+			->with('bob@remote.example')
+			->willReturn($bob);
+		$this->followsRequest->expects($this->once())
+			->method('getByPersons')
+			->with(self::ALICE_ID, self::BOB_ID)
+			->willThrowException(new FollowNotFoundException());
+
+		$saved = null;
+		$this->followsRequest->expects($this->once())
+			->method('save')
+			->with($this->callback(function (Follow $follow) use (&$saved): bool {
+				$saved = $follow;
+
+				return true;
+			}));
+		$sent = null;
+		$this->activityService->expects($this->once())
+			->method('request')
+			->with($this->callback(function (ACore $item) use (&$sent): bool {
+				$sent = $item;
+
+				return true;
+			}))
+			->willReturn('token');
+
+		$this->service->followAccount($this->alice(), 'bob@remote.example');
+
+		$this->assertInstanceOf(Follow::class, $saved);
+		$this->assertSame($saved, $sent);
+		$this->assertSame(Follow::TYPE, $saved->getType());
+		$this->assertStringStartsWith(self::CLOUD_URL . '/', $saved->getId());
+		$this->assertSame(self::ALICE_ID, $saved->getActorId());
+		$this->assertSame(self::BOB_ID, $saved->getObjectId());
+		$this->assertSame(self::BOB_ID . '/followers', $saved->getFollowId());
+		$this->assertFalse($saved->isAccepted());
+
+		$paths = $sent->getInstancePaths();
+		$this->assertCount(1, $paths);
+		$this->assertSame(self::BOB_ID . '/inbox', $paths[0]->getUri());
+		$this->assertSame(InstancePath::TYPE_INBOX, $paths[0]->getType());
+		$this->assertSame(InstancePath::PRIORITY_TOP, $paths[0]->getPriority());
+	}
+
+	public function testFollowAccountRefusesFollowingYourself(): void {
+		$this->cacheActorService->method('getFromAccount')->willReturn($this->alice());
+		$this->followsRequest->expects($this->never())->method('save');
+		$this->activityService->expects($this->never())->method('request');
+
+		$this->expectException(FollowSameAccountException::class);
+		$this->service->followAccount($this->alice(), 'alice@social.example');
+	}
+
+	public function testFollowAccountIgnoresAnExistingFollow(): void {
+		$this->cacheActorService->method('getFromAccount')->willReturn($this->person(self::BOB_ID, 'bob'));
+		$this->followsRequest->method('getByPersons')->willReturn($this->follow(self::ALICE_ID, self::BOB_ID, true));
+		$this->followsRequest->expects($this->never())->method('save');
+		$this->activityService->expects($this->never())->method('request');
+
+		$this->service->followAccount($this->alice(), 'bob@remote.example');
+	}
+
+	public function testFollowAccountKeepsTheFollowWhenFederationFails(): void {
+		$this->cacheActorService->method('getFromAccount')->willReturn($this->person(self::BOB_ID, 'bob'));
+		$this->followsRequest->method('getByPersons')->willThrowException(new FollowNotFoundException());
+		$this->followsRequest->expects($this->once())->method('save');
+		$this->activityService->method('request')->willThrowException(new \RuntimeException('queue down'));
+
+		$this->service->followAccount($this->alice(), 'bob@remote.example');
+	}
+
+	public function testFollowAccountFailsForUnknownAccount(): void {
+		$this->cacheActorService->method('getFromAccount')->willThrowException(new CacheActorDoesNotExistException());
+		$this->followsRequest->expects($this->never())->method('save');
+
+		$this->expectException(CacheActorDoesNotExistException::class);
+		$this->service->followAccount($this->alice(), 'nobody@remote.example');
+	}
+
+
+	// unfollowAccount()
+
+	public function testUnfollowAccountDeletesFollowAndSendsUndo(): void {
+		$bob = $this->person(self::BOB_ID, 'bob');
+		$follow = $this->follow(self::ALICE_ID, self::BOB_ID, true);
+		$this->cacheActorService->method('getFromAccount')->with('bob@remote.example')->willReturn($bob);
+		$this->followsRequest->method('getByPersons')->with(self::ALICE_ID, self::BOB_ID)->willReturn($follow);
+		$this->followsRequest->expects($this->once())->method('delete')->with($this->identicalTo($follow));
+
+		$sent = null;
+		$this->activityService->expects($this->once())
+			->method('request')
+			->with($this->callback(function (ACore $item) use (&$sent): bool {
+				$sent = $item;
+
+				return true;
+			}))
+			->willReturn('token');
+
+		$this->service->unfollowAccount($this->alice(), 'bob@remote.example');
+
+		$this->assertInstanceOf(Undo::class, $sent);
+		$this->assertStringContainsString('#undo/follows/', $sent->getId());
+		$this->assertSame(self::ALICE_ID, $sent->getActorId());
+		$this->assertSame($follow, $sent->getObject());
+		$this->assertSame($sent, $follow->getParent());
+		$this->assertSame($follow->getId(), $sent->getObjectId());
+
+		$paths = $sent->getInstancePaths();
+		$this->assertCount(1, $paths);
+		$this->assertSame(self::BOB_ID . '/inbox', $paths[0]->getUri());
+		$this->assertSame(InstancePath::TYPE_INBOX, $paths[0]->getType());
+		$this->assertSame(InstancePath::PRIORITY_TOP, $paths[0]->getPriority());
+	}
+
+	public function testUnfollowAccountIsANoopWhenNotFollowing(): void {
+		$this->cacheActorService->method('getFromAccount')->willReturn($this->person(self::BOB_ID, 'bob'));
+		$this->followsRequest->method('getByPersons')->willThrowException(new FollowNotFoundException());
+		$this->followsRequest->expects($this->never())->method('delete');
+		$this->activityService->expects($this->never())->method('request');
+
+		$this->service->unfollowAccount($this->alice(), 'bob@remote.example');
+	}
+
+
+	// getLinksBetweenPersons()
+
+	/**
+	 * @return array<string, array{bool, bool}>
+	 */
+	public function linksProvider(): array {
+		return [
+			'no relation' => [false, false],
+			'local follows actor' => [true, false],
+			'actor follows local' => [false, true],
+			'mutual' => [true, true],
+		];
+	}
+
+	/**
+	 * @dataProvider linksProvider
+	 */
+	public function testGetLinksBetweenPersonsReportsBothDirections(bool $following, bool $follower): void {
+		$this->followsRequest->method('getByPersons')
+			->willReturnCallback(function (string $actorId, string $remoteId) use ($following, $follower): Follow {
+				if ($actorId === self::ALICE_ID && $remoteId === self::BOB_ID && $following) {
+					return $this->follow($actorId, $remoteId, true);
+				}
+				if ($actorId === self::BOB_ID && $remoteId === self::ALICE_ID && $follower) {
+					return $this->follow($actorId, $remoteId, true);
+				}
+				throw new FollowNotFoundException();
+			});
+
+		$links = $this->service->getLinksBetweenPersons($this->alice(), $this->person(self::BOB_ID, 'bob'));
+
+		$this->assertSame(['follower' => $follower, 'following' => $following], $links);
+	}
+
+
+	// followers / following
+
+	public function testGetFollowersAndFollowingDelegateWithActorId(): void {
+		$followers = [$this->follow(self::BOB_ID, self::ALICE_ID, true)];
+		$following = [$this->follow(self::ALICE_ID, self::CAROL_ID, true)];
+		$this->followsRequest->method('getFollowersByActorId')->with(self::ALICE_ID)->willReturn($followers);
+		$this->followsRequest->method('getFollowingByActorId')->with(self::ALICE_ID)->willReturn($following);
+
+		$this->assertSame($followers, $this->service->getFollowers($this->alice()));
+		$this->assertSame($following, $this->service->getFollowing($this->alice()));
+	}
+
+	public function testGetFollowersFromFollowIdDelegates(): void {
+		$followers = [$this->follow(self::BOB_ID, self::ALICE_ID, true)];
+		$this->followsRequest->method('getFollowersByFollowId')
+			->with(self::ALICE_ID . '/followers')
+			->willReturn($followers);
+
+		$this->assertSame($followers, $this->service->getFollowersFromFollowId(self::ALICE_ID . '/followers'));
+	}
+
+	public function testGetFollowersCollectionDescribesFollowersEndpoint(): void {
+		$alice = $this->alice();
+		$alice->setDetailArray('count', ['followers' => 12, 'following' => 4]);
+		$this->urlGenerator->expects($this->once())
+			->method('linkToRouteAbsolute')
+			->with('social.ActivityPub.followers', ['username' => 'alice'])
+			->willReturn('https://cloud.example/apps/social/@alice/followers');
+
+		$collection = $this->service->getFollowersCollection($alice);
+
+		$this->assertSame('OrderedCollection', $collection->getType());
+		$this->assertSame(self::ALICE_ID . '/followers', $collection->getId());
+		$this->assertSame(12, $collection->getTotalItems());
+		$this->assertSame('https://cloud.example/apps/social/@alice/followers?page=1', $collection->getFirst());
+		$this->assertSame('', $collection->getLast());
+	}
+
+	public function testGetFollowingCollectionDescribesFollowingEndpoint(): void {
+		$alice = $this->alice();
+		$alice->setDetailArray('count', ['followers' => 12, 'following' => 4]);
+		$this->urlGenerator->expects($this->once())
+			->method('linkToRouteAbsolute')
+			->with('social.ActivityPub.following', ['username' => 'alice'])
+			->willReturn('https://cloud.example/apps/social/@alice/following');
+
+		$collection = $this->service->getFollowingCollection($alice);
+
+		$this->assertSame(self::ALICE_ID . '/following', $collection->getId());
+		$this->assertSame(4, $collection->getTotalItems());
+		$this->assertSame('https://cloud.example/apps/social/@alice/following?page=1', $collection->getFirst());
+	}
+
+	public function testCollectionsWithoutCachedCountsReportZero(): void {
+		$this->urlGenerator->method('linkToRouteAbsolute')->willReturn('https://cloud.example/x');
+
+		$this->assertSame(0, $this->service->getFollowersCollection($this->alice())->getTotalItems());
+		$this->assertSame(0, $this->service->getFollowingCollection($this->alice())->getTotalItems());
+	}
+
+
+	// setViewer() / getRelationships()
+
+	public function testSetViewerIsPassedToFollowsRequest(): void {
+		$alice = $this->alice();
+		$this->followsRequest->expects($this->once())->method('setViewer')->with($this->identicalTo($alice));
+
+		$this->service->setViewer($alice);
+	}
+
+	public function testGetRelationshipsResolvesNidsAndUrlsAndSkipsTheViewer(): void {
+		$alice = $this->alice();
+		$bob = $this->person(self::BOB_ID, 'bob', 2);
+		$carol = $this->person(self::CAROL_ID, 'carol', 3);
+		$this->service->setViewer($alice);
+
+		$this->cacheActorService->expects($this->once())
+			->method('getFromNids')
+			->with([2, 1])
+			->willReturn([$bob, $alice]);
+		$this->cacheActorService->expects($this->once())
+			->method('getFromId')
+			->with(self::CAROL_ID)
+			->willReturn($carol);
+		$this->followsRequest->method('getByPersons')
+			->willReturnCallback(function (string $actorId, string $remoteId): Follow {
+				// alice follows bob (accepted), bob follows alice (accepted),
+				// alice asked to follow carol (pending), carol does not follow alice
+				return match ([$actorId, $remoteId]) {
+					[self::ALICE_ID, self::BOB_ID] => $this->follow($actorId, $remoteId, true),
+					[self::BOB_ID, self::ALICE_ID] => $this->follow($actorId, $remoteId, true),
+					[self::ALICE_ID, self::CAROL_ID] => $this->follow($actorId, $remoteId, false),
+					default => throw new FollowNotFoundException(),
+				};
+			});
+
+		$relationships = $this->service->getRelationships(['2', self::CAROL_ID, '1']);
+
+		$this->assertCount(2, $relationships);
+
+		$this->assertSame(2, $relationships[0]->getId());
+		$this->assertTrue($relationships[0]->isFollowing());
+		$this->assertTrue($relationships[0]->isFollowedBy());
+		$this->assertFalse($relationships[0]->isRequested());
+
+		$this->assertSame(3, $relationships[1]->getId());
+		$this->assertFalse($relationships[1]->isFollowing());
+		$this->assertFalse($relationships[1]->isFollowedBy());
+		$this->assertTrue($relationships[1]->isRequested());
+	}
+
+	public function testGetRelationshipsSkipsUnknownActors(): void {
+		$this->service->setViewer($this->alice());
+		$this->cacheActorService->method('getFromNids')->with([])->willReturn([]);
+		$this->cacheActorService->method('getFromId')->willThrowException(new CacheActorDoesNotExistException());
+		$this->followsRequest->expects($this->never())->method('getByPersons');
+
+		$this->assertSame([], $this->service->getRelationships(['https://gone.example/users/x', '0', 'abc']));
+	}
+
+	public function testGetRelationshipsDoesNotFlagPendingFollowerAsFollowedBy(): void {
+		$alice = $this->alice();
+		$bob = $this->person(self::BOB_ID, 'bob', 2);
+		$this->service->setViewer($alice);
+		$this->cacheActorService->method('getFromNids')->willReturn([$bob]);
+		$this->followsRequest->method('getByPersons')
+			->willReturnCallback(function (string $actorId, string $remoteId): Follow {
+				if ($actorId === self::BOB_ID) {
+					return $this->follow($actorId, $remoteId, false);
+				}
+				throw new FollowNotFoundException();
+			});
+
+		$relationships = $this->service->getRelationships([2]);
+
+		$this->assertCount(1, $relationships);
+		$this->assertFalse($relationships[0]->isFollowedBy());
+		$this->assertFalse($relationships[0]->isFollowing());
+		$this->assertFalse($relationships[0]->isRequested());
+	}
+}

--- a/tests/Service/HashtagServiceTest.php
+++ b/tests/Service/HashtagServiceTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use OCA\Social\Db\HashtagsRequest;
+use OCA\Social\Db\StreamRequest;
+use OCA\Social\Exceptions\HashtagDoesNotExistException;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\HashtagService;
+use OCA\Social\Service\MiscService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class HashtagServiceTest extends TestCase {
+	private HashtagsRequest|MockObject $hashtagsRequest;
+	private StreamRequest|MockObject $streamRequest;
+	private HashtagService $service;
+
+	protected function setUp(): void {
+		$this->hashtagsRequest = $this->createMock(HashtagsRequest::class);
+		$this->streamRequest = $this->createMock(StreamRequest::class);
+		$this->service = new HashtagService(
+			$this->hashtagsRequest,
+			$this->streamRequest,
+			$this->createMock(ConfigService::class),
+			$this->createMock(MiscService::class),
+		);
+	}
+
+	private function note(array $hashtags, int $publishedTime): Note {
+		$note = new Note();
+		$note->setHashtags($hashtags);
+		$note->setPublishedTime($publishedTime);
+
+		return $note;
+	}
+
+	public function testManageHashtagsComputesTrendPerWindowAndUpsertsEachTag(): void {
+		$now = time();
+		$notes = [
+			$this->note(['nextcloud', 'social'], $now - 1800),
+			$this->note(['nextcloud'], $now - 2 * 86400),
+			$this->note(['php'], $now - 5 * 86400),
+		];
+		$requestedSince = [];
+		$this->streamRequest->method('getNoteSince')
+			->willReturnCallback(function (int $since) use ($notes, &$requestedSince) {
+				$requestedSince[] = $since;
+
+				return array_values(array_filter($notes, fn (Note $n) => $n->getPublishedTime() >= $since));
+			});
+		$this->hashtagsRequest->method('getAll')->willReturn([['hashtag' => 'nextcloud', 'trend' => []]]);
+
+		$updated = [];
+		$this->hashtagsRequest->expects($this->once())
+			->method('update')
+			->willReturnCallback(function (string $hashtag, array $trend) use (&$updated) {
+				$updated[$hashtag] = $trend;
+			});
+		$saved = [];
+		$this->hashtagsRequest->expects($this->exactly(2))
+			->method('save')
+			->willReturnCallback(function (string $hashtag, array $trend) use (&$saved) {
+				$saved[$hashtag] = $trend;
+			});
+
+		$count = $this->service->manageHashtags();
+
+		$this->assertSame(3, $count);
+		$this->assertCount(5, $requestedSince);
+		$windows = [HashtagService::TREND_1H, HashtagService::TREND_12H, HashtagService::TREND_1D, HashtagService::TREND_3D, HashtagService::TREND_10D];
+		foreach ($windows as $i => $window) {
+			$this->assertEqualsWithDelta($now - $window, $requestedSince[$i], 2);
+		}
+		$this->assertSame(['1h' => 1, '12h' => 1, '1d' => 1, '3d' => 2, '10d' => 2], $updated['nextcloud']);
+		$this->assertSame(['1h' => 1, '12h' => 1, '1d' => 1, '3d' => 1, '10d' => 1], $saved['social']);
+		$this->assertSame(['1h' => 0, '12h' => 0, '1d' => 0, '3d' => 0, '10d' => 1], $saved['php']);
+	}
+
+	public function testManageHashtagsWithoutRecentNotesTouchesNothing(): void {
+		$this->streamRequest->method('getNoteSince')->willReturn([]);
+		$this->hashtagsRequest->method('getAll')->willReturn([['hashtag' => 'old']]);
+		$this->hashtagsRequest->expects($this->never())->method('save');
+		$this->hashtagsRequest->expects($this->never())->method('update');
+
+		$this->assertSame(0, $this->service->manageHashtags());
+	}
+
+	public function testGetHashtagPrependsTheHashSign(): void {
+		$this->hashtagsRequest->expects($this->exactly(2))
+			->method('getHashtag')
+			->with('#nextcloud')
+			->willReturn(['hashtag' => '#nextcloud']);
+
+		$this->assertSame(['hashtag' => '#nextcloud'], $this->service->getHashtag('nextcloud'));
+		$this->assertSame(['hashtag' => '#nextcloud'], $this->service->getHashtag('#nextcloud'));
+	}
+
+	public function testGetHashtagPropagatesMisses(): void {
+		$this->hashtagsRequest->method('getHashtag')->willThrowException(new HashtagDoesNotExistException());
+
+		$this->expectException(HashtagDoesNotExistException::class);
+		$this->service->getHashtag('missing');
+	}
+
+	public function testSearchHashtagsDelegatesWithTheAllFlag(): void {
+		$this->hashtagsRequest->expects($this->exactly(2))
+			->method('searchHashtags')
+			->withConsecutive(['next', false], ['next', true])
+			->willReturnOnConsecutiveCalls([['hashtag' => '#nextcloud']], []);
+
+		$this->assertSame([['hashtag' => '#nextcloud']], $this->service->searchHashtags('next'));
+		$this->assertSame([], $this->service->searchHashtags('next', true));
+	}
+}

--- a/tests/Service/ImportServiceTest.php
+++ b/tests/Service/ImportServiceTest.php
@@ -1,0 +1,272 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use Exception;
+use OCA\Social\AP;
+use OCA\Social\Exceptions\ActivityPubFormatException;
+use OCA\Social\Exceptions\InvalidOriginException;
+use OCA\Social\Exceptions\ItemUnknownException;
+use OCA\Social\Interfaces\Activity\AcceptInterface;
+use OCA\Social\Interfaces\Activity\AddInterface;
+use OCA\Social\Interfaces\Activity\BlockInterface;
+use OCA\Social\Interfaces\Activity\CreateInterface;
+use OCA\Social\Interfaces\Activity\DeleteInterface;
+use OCA\Social\Interfaces\Activity\MoveInterface;
+use OCA\Social\Interfaces\Activity\RejectInterface;
+use OCA\Social\Interfaces\Activity\RemoveInterface;
+use OCA\Social\Interfaces\Activity\UndoInterface;
+use OCA\Social\Interfaces\Activity\UpdateInterface;
+use OCA\Social\Interfaces\Actor\ApplicationInterface;
+use OCA\Social\Interfaces\Actor\GroupInterface;
+use OCA\Social\Interfaces\Actor\OrganizationInterface;
+use OCA\Social\Interfaces\Actor\PersonInterface;
+use OCA\Social\Interfaces\Actor\ServiceInterface;
+use OCA\Social\Interfaces\Internal\SocialAppNotificationInterface;
+use OCA\Social\Interfaces\Object\AnnounceInterface;
+use OCA\Social\Interfaces\Object\DocumentInterface;
+use OCA\Social\Interfaces\Object\FollowInterface;
+use OCA\Social\Interfaces\Object\ImageInterface;
+use OCA\Social\Interfaces\Object\LikeInterface;
+use OCA\Social\Interfaces\Object\NoteInterface;
+use OCA\Social\Model\ActivityPub\Activity\Create;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Follow;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\ImportService;
+use OCA\Social\Service\MiscService;
+use OCA\Social\Service\SignatureService;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ImportServiceTest extends TestCase {
+	private const CLOUD_URL = 'https://cloud.example.com';
+
+	private MiscService|MockObject $miscService;
+	private ImportService $service;
+
+	protected function setUp(): void {
+		$this->miscService = $this->createMock(MiscService::class);
+		$configService = $this->createMock(ConfigService::class);
+		$configService->method('getCloudUrl')->willReturn(self::CLOUD_URL);
+		$this->service = new ImportService($configService, $this->miscService);
+	}
+
+	protected function tearDown(): void {
+		AP::$activityPub = null;
+		\OC::$server->reset();
+	}
+
+	/** A real AP dispatcher over mocked persistence interfaces, so JSON is parsed into the real models. */
+	private function useRealActivityPub(): AP {
+		$configService = $this->createMock(ConfigService::class);
+		$configService->method('getCloudUrl')->willReturn(self::CLOUD_URL);
+		// Stream::import resolves the URL generator statically for attachment links
+		\OC::$server->register(IURLGenerator::class, $this->createMock(IURLGenerator::class));
+
+		$ap = new AP(
+			$this->createMock(AcceptInterface::class),
+			$this->createMock(AddInterface::class),
+			$this->createMock(AnnounceInterface::class),
+			$this->createMock(BlockInterface::class),
+			$this->createMock(CreateInterface::class),
+			$this->createMock(DeleteInterface::class),
+			$this->createMock(DocumentInterface::class),
+			$this->createMock(FollowInterface::class),
+			$this->createMock(ImageInterface::class),
+			$this->createMock(LikeInterface::class),
+			$this->createMock(MoveInterface::class),
+			$this->createMock(NoteInterface::class),
+			$this->createMock(SocialAppNotificationInterface::class),
+			$this->createMock(PersonInterface::class),
+			$this->createMock(ServiceInterface::class),
+			$this->createMock(GroupInterface::class),
+			$this->createMock(OrganizationInterface::class),
+			$this->createMock(ApplicationInterface::class),
+			$this->createMock(RejectInterface::class),
+			$this->createMock(RemoveInterface::class),
+			$this->createMock(UndoInterface::class),
+			$this->createMock(UpdateInterface::class),
+			$configService,
+		);
+		AP::$activityPub = $ap;
+
+		return $ap;
+	}
+
+	/** @return array<string, array{string}> */
+	public function notAnObjectProvider(): array {
+		return [
+			'garbage' => ['not json at all'],
+			'empty' => [''],
+			'scalar' => ['"Note"'],
+			'number' => ['42'],
+			'null' => ['null'],
+		];
+	}
+
+	/** @dataProvider notAnObjectProvider */
+	public function testImportFromJsonRejectsAnythingButAnObject(string $json): void {
+		$this->useRealActivityPub();
+
+		$this->expectException(ActivityPubFormatException::class);
+		$this->service->importFromJson($json);
+	}
+
+	public function testImportFromJsonBuildsTheTypedModel(): void {
+		$this->useRealActivityPub();
+		$data = [
+			'@context' => 'https://www.w3.org/ns/activitystreams',
+			'id' => 'https://remote.example/notes/1',
+			'type' => 'Note',
+			'attributedTo' => 'https://remote.example/users/bob',
+			'content' => '<p>hello</p>',
+			'to' => ['https://www.w3.org/ns/activitystreams#Public'],
+			'published' => '2026-09-07T10:00:00Z',
+		];
+
+		$item = $this->service->importFromJson(json_encode($data));
+
+		$this->assertInstanceOf(Note::class, $item);
+		$this->assertSame('https://remote.example/notes/1', $item->getId());
+		$this->assertSame('<p>hello</p>', $item->getContent());
+		$this->assertSame('https://remote.example/users/bob', $item->getAttributedTo());
+		$this->assertSame(['https://www.w3.org/ns/activitystreams#Public'], $item->getToArray());
+		$this->assertSame(json_encode($data, JSON_UNESCAPED_SLASHES), $item->getSource());
+		$this->assertSame(self::CLOUD_URL, $item->getUrlCloud());
+	}
+
+	public function testImportFromJsonNestsTheObjectAndActor(): void {
+		$this->useRealActivityPub();
+		$json = json_encode([
+			'id' => 'https://remote.example/activities/1',
+			'type' => 'Create',
+			'actor' => 'https://remote.example/users/bob',
+			'object' => [
+				'id' => 'https://remote.example/notes/1',
+				'type' => 'Note',
+				'content' => 'nested',
+			],
+		]);
+
+		$item = $this->service->importFromJson($json);
+
+		$this->assertInstanceOf(Create::class, $item);
+		$this->assertSame('https://remote.example/users/bob', $item->getActorId());
+		$this->assertTrue($item->hasObject());
+		$this->assertInstanceOf(Note::class, $item->getObject());
+		$this->assertSame('nested', $item->getObject()->getContent());
+		$this->assertSame($item, $item->getObject()->getParent());
+		$this->assertSame('https://remote.example/notes/1', $item->getObjectId());
+	}
+
+	public function testImportFromJsonKeepsAnObjectReferenceAsId(): void {
+		$this->useRealActivityPub();
+
+		$item = $this->service->importFromJson(json_encode([
+			'type' => 'Follow',
+			'actor' => 'https://remote.example/users/bob',
+			'object' => 'https://cloud.example.com/apps/social/@alice',
+		]));
+
+		$this->assertInstanceOf(Follow::class, $item);
+		$this->assertFalse($item->hasObject());
+		$this->assertSame('https://cloud.example.com/apps/social/@alice', $item->getObjectId());
+	}
+
+	public function testImportFromJsonRejectsUnknownTypes(): void {
+		$this->useRealActivityPub();
+
+		$this->expectException(ItemUnknownException::class);
+		$this->service->importFromJson('{"type":"Teapot","id":"https://remote.example/1"}');
+	}
+
+	public function testImportFromJsonRejectsMissingType(): void {
+		$this->useRealActivityPub();
+
+		$this->expectException(ItemUnknownException::class);
+		$this->service->importFromJson('{"id":"https://remote.example/1"}');
+	}
+
+	private function incomingNote(string $origin): Note {
+		$note = new Note();
+		$note->setId('https://remote.example/notes/1');
+		$note->setOrigin($origin, SignatureService::ORIGIN_HEADER, time());
+
+		return $note;
+	}
+
+	public function testParseIncomingRequestDispatchesToTheInterfaceWithARequestToken(): void {
+		$ap = $this->createMock(AP::class);
+		AP::$activityPub = $ap;
+		$note = $this->incomingNote('remote.example');
+		$interface = $this->createMock(NoteInterface::class);
+		$ap->expects($this->once())->method('getInterfaceForItem')->with($this->identicalTo($note))->willReturn($interface);
+		$interface->expects($this->once())
+			->method('processIncomingRequest')
+			->with($this->callback(function (Note $item) use ($note) {
+				$this->assertSame($note, $item);
+				$this->assertMatchesRegularExpression('/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/', $item->getRequestToken());
+
+				return true;
+			}));
+		$this->miscService->expects($this->never())->method('log');
+
+		$this->service->parseIncomingRequest($note);
+	}
+
+	public function testParseIncomingRequestLogsProcessingFailures(): void {
+		$ap = $this->createMock(AP::class);
+		AP::$activityPub = $ap;
+		$interface = $this->createMock(NoteInterface::class);
+		$interface->method('processIncomingRequest')->willThrowException(new Exception('boom'));
+		$ap->method('getInterfaceForItem')->willReturn($interface);
+		$this->miscService->expects($this->once())
+			->method('log')
+			->with($this->logicalAnd(
+				$this->stringContains('Cannot parse Note'),
+				$this->stringContains('Exception boom'),
+			));
+
+		$this->service->parseIncomingRequest($this->incomingNote('remote.example'));
+	}
+
+	public function testParseIncomingRequestRefusesAnIdFromAnotherOrigin(): void {
+		$ap = $this->createMock(AP::class);
+		AP::$activityPub = $ap;
+		$ap->expects($this->never())->method('getInterfaceForItem');
+
+		$this->expectException(InvalidOriginException::class);
+		$this->service->parseIncomingRequest($this->incomingNote('evil.example'));
+	}
+
+	public function testParseIncomingRequestRefusesAnItemWithoutOrigin(): void {
+		AP::$activityPub = $this->createMock(AP::class);
+		$note = new Note();
+		$note->setId('https://remote.example/notes/1');
+
+		$this->expectException(InvalidOriginException::class);
+		$this->service->parseIncomingRequest($note);
+	}
+
+	public function testParseIncomingRequestRejectsUnknownInterface(): void {
+		$ap = $this->createMock(AP::class);
+		AP::$activityPub = $ap;
+		$ap->method('getInterfaceForItem')->willThrowException(new ItemUnknownException());
+		$person = new Person();
+		$person->setId('https://remote.example/users/bob');
+		$person->setOrigin('remote.example', SignatureService::ORIGIN_HEADER, time());
+
+		$this->expectException(ItemUnknownException::class);
+		$this->service->parseIncomingRequest($person);
+	}
+}

--- a/tests/Service/InstanceServiceTest.php
+++ b/tests/Service/InstanceServiceTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use OCA\Social\Db\InstancesRequest;
+use OCA\Social\Exceptions\InstanceDoesNotExistException;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\Instance;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\InstanceService;
+use OCA\Social\Service\MiscService;
+use OCP\IConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class InstanceServiceTest extends TestCase {
+	private InstancesRequest|MockObject $instancesRequest;
+	private IConfig|MockObject $config;
+	private InstanceService $service;
+
+	protected function setUp(): void {
+		$this->instancesRequest = $this->createMock(InstancesRequest::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->service = new InstanceService(
+			$this->instancesRequest,
+			$this->createMock(ConfigService::class),
+			$this->createMock(MiscService::class),
+			$this->config,
+		);
+	}
+
+	public function testCreateLocalBuildsTheInstanceFromAppAndThemingConfig(): void {
+		$this->config->method('getAppValue')
+			->willReturnCallback(fn (string $app, string $key, $default) => match ([$app, $key]) {
+				['social', 'installed_version'] => '0.9.1',
+				['theming', 'slogan'] => 'Our slogan',
+				['theming', 'name'] => 'Our Cloud',
+				default => $default,
+			});
+		$saved = null;
+		$this->instancesRequest->expects($this->once())
+			->method('save')
+			->willReturnCallback(function (Instance $instance) use (&$saved) {
+				$saved = $instance;
+			});
+
+		$instance = $this->service->createLocal();
+
+		$this->assertSame($saved, $instance);
+		$this->assertTrue($instance->isLocal());
+		$this->assertSame('0.9.1', $instance->getVersion());
+		$this->assertSame('Our slogan', $instance->getDescription());
+		$this->assertSame('Our Cloud', $instance->getTitle());
+		$this->assertFalse($instance->isApprovalRequired());
+	}
+
+	public function testCreateLocalUsesNextcloudDefaultsWhenThemingIsUnset(): void {
+		$this->config->method('getAppValue')
+			->willReturnCallback(fn (string $app, string $key, $default) => $default);
+
+		$instance = $this->service->createLocal();
+
+		$this->assertSame('0.0', $instance->getVersion());
+		$this->assertSame('a safe home for your data', $instance->getDescription());
+		$this->assertSame('Nextcloud Social', $instance->getTitle());
+		$this->assertSame('Nextcloud Social', $instance->jsonSerialize()['title']);
+	}
+
+	public function testGetLocalReturnsTheStoredInstanceInTheRequestedFormat(): void {
+		$stored = (new Instance())->setTitle('stored');
+		$this->instancesRequest->expects($this->once())
+			->method('getLocal')
+			->with(ACore::FORMAT_ACTIVITYPUB)
+			->willReturn($stored);
+		$this->instancesRequest->expects($this->never())->method('save');
+
+		$this->assertSame($stored, $this->service->getLocal(ACore::FORMAT_ACTIVITYPUB));
+	}
+
+	public function testGetLocalCreatesTheInstanceWhenMissing(): void {
+		$this->instancesRequest->method('getLocal')
+			->with(ACore::FORMAT_LOCAL)
+			->willThrowException(new InstanceDoesNotExistException());
+		$this->config->method('getAppValue')
+			->willReturnCallback(fn (string $app, string $key, $default) => $default);
+		$this->instancesRequest->expects($this->once())->method('save');
+
+		$instance = $this->service->getLocal();
+
+		$this->assertTrue($instance->isLocal());
+		$this->assertSame('Nextcloud Social', $instance->getTitle());
+	}
+}

--- a/tests/Service/LikeServiceTest.php
+++ b/tests/Service/LikeServiceTest.php
@@ -1,0 +1,347 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use DateTime;
+use OCA\Social\AP;
+use OCA\Social\Db\StreamRequest;
+use OCA\Social\Exceptions\CacheActorDoesNotExistException;
+use OCA\Social\Exceptions\ItemAlreadyExistsException;
+use OCA\Social\Exceptions\ItemNotFoundException;
+use OCA\Social\Exceptions\StreamNotFoundException;
+use OCA\Social\Interfaces\Object\LikeInterface;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Activity\Undo;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Announce;
+use OCA\Social\Model\ActivityPub\Object\Like;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Model\ActivityPub\Stream;
+use OCA\Social\Model\InstancePath;
+use OCA\Social\Model\StreamAction;
+use OCA\Social\Service\ActivityService;
+use OCA\Social\Service\CacheActorService;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\LikeService;
+use OCA\Social\Service\MiscService;
+use OCA\Social\Service\SignatureService;
+use OCA\Social\Service\StreamActionService;
+use OCA\Social\Service\StreamQueueService;
+use OCA\Social\Service\StreamService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use ReflectionClass;
+
+class LikeServiceTest extends TestCase {
+	private const CLOUD_URL = 'https://cloud.example';
+	private const ALICE_ID = 'https://social.example/@alice';
+	private const BOB_ID = 'https://remote.example/users/bob';
+	private const POST_ID = 'https://remote.example/notes/1';
+
+	private StreamRequest|MockObject $streamRequest;
+	private StreamService|MockObject $streamService;
+	private SignatureService|MockObject $signatureService;
+	private ActivityService|MockObject $activityService;
+	private StreamActionService|MockObject $streamActionService;
+	private CacheActorService|MockObject $cacheActorService;
+	private LikeInterface|MockObject $likeInterface;
+	private LikeService $service;
+
+	protected function setUp(): void {
+		$this->likeInterface = $this->createMock(LikeInterface::class);
+		$this->bootActivityPub([LikeInterface::class => $this->likeInterface]);
+
+		$this->streamRequest = $this->createMock(StreamRequest::class);
+		$this->streamService = $this->createMock(StreamService::class);
+		$this->signatureService = $this->createMock(SignatureService::class);
+		$this->activityService = $this->createMock(ActivityService::class);
+		$this->streamActionService = $this->createMock(StreamActionService::class);
+		$this->cacheActorService = $this->createMock(CacheActorService::class);
+
+		$this->service = new LikeService(
+			$this->streamRequest,
+			$this->streamService,
+			$this->signatureService,
+			$this->activityService,
+			$this->streamActionService,
+			$this->createMock(StreamQueueService::class),
+			$this->cacheActorService,
+			$this->createMock(MiscService::class),
+			new NullLogger()
+		);
+	}
+
+	protected function tearDown(): void {
+		AP::$activityPub = null;
+	}
+
+	/**
+	 * @param array<class-string, object> $interfaces
+	 */
+	private function bootActivityPub(array $interfaces): void {
+		$args = [];
+		foreach ((new ReflectionClass(AP::class))->getConstructor()->getParameters() as $parameter) {
+			$class = $parameter->getType()->getName();
+			if (isset($interfaces[$class])) {
+				$args[] = $interfaces[$class];
+				continue;
+			}
+			$mock = $this->createMock($class);
+			if ($class === ConfigService::class) {
+				$mock->method('getCloudUrl')->willReturn(self::CLOUD_URL);
+			}
+			$args[] = $mock;
+		}
+		AP::$activityPub = new AP(...$args);
+	}
+
+	private function alice(): Person {
+		$alice = new Person();
+		$alice->setId(self::ALICE_ID);
+		$alice->setPreferredUsername('alice');
+		$alice->setFollowers(self::ALICE_ID . '/followers');
+		$alice->setLocal(true);
+
+		return $alice;
+	}
+
+	private function bob(): Person {
+		$bob = new Person();
+		$bob->setId(self::BOB_ID);
+		$bob->setPreferredUsername('bob');
+		$bob->setInbox(self::BOB_ID . '/inbox');
+		$bob->setSharedInbox('https://remote.example/inbox');
+
+		return $bob;
+	}
+
+	private function note(): Note {
+		$note = new Note();
+		$note->setId(self::POST_ID);
+		$note->setAttributedTo(self::BOB_ID);
+		$note->setTo(ACore::CONTEXT_PUBLIC);
+
+		return $note;
+	}
+
+	private function existingLike(): Like {
+		$like = new Like();
+		$like->setId(self::ALICE_ID . '#like/abcd1234');
+		$like->setActorId(self::ALICE_ID);
+		$like->setObjectId(self::POST_ID);
+
+		return $like;
+	}
+
+
+	// create()
+
+	public function testCreateBuildsLikeSavesFlagsAndFederatesIt(): void {
+		$alice = $this->alice();
+		$bob = $this->bob();
+		$this->streamService->expects($this->once())
+			->method('getStreamById')
+			->with(self::POST_ID, true)
+			->willReturn($this->note());
+		$this->cacheActorService->method('getFromId')->with(self::BOB_ID)->willReturn($bob);
+
+		$this->signatureService->expects($this->once())
+			->method('signObject')
+			->with($this->identicalTo($alice), $this->isInstanceOf(Like::class));
+		$saved = null;
+		$this->likeInterface->expects($this->once())
+			->method('save')
+			->with($this->callback(function (ACore $item) use (&$saved): bool {
+				$saved = $item;
+
+				return true;
+			}));
+		$this->streamActionService->expects($this->once())
+			->method('setActionBool')
+			->with(self::ALICE_ID, self::POST_ID, StreamAction::LIKED, true);
+		$this->activityService->expects($this->once())
+			->method('request')
+			->with($this->isInstanceOf(Like::class))
+			->willReturn('token-like');
+
+		$token = '';
+		$like = $this->service->create($alice, self::POST_ID, $token);
+
+		$this->assertSame('token-like', $token);
+		$this->assertSame($saved, $like);
+		$this->assertInstanceOf(Like::class, $like);
+		$this->assertStringStartsWith(self::ALICE_ID . '#like/', $like->getId());
+		$this->assertSame(8, strlen(substr($like->getId(), strlen(self::ALICE_ID . '#like/'))));
+		$this->assertSame($alice, $like->getActor());
+		$this->assertSame(self::POST_ID, $like->getObjectId());
+		$this->assertSame(self::BOB_ID, $like->getTo());
+		$this->assertSame(self::CLOUD_URL, $like->getUrlCloud());
+		$this->assertEqualsWithDelta(time(), (new DateTime($like->getPublished()))->getTimestamp(), 5);
+
+		$paths = $like->getInstancePaths();
+		$this->assertCount(1, $paths);
+		$this->assertSame(self::BOB_ID . '/inbox', $paths[0]->getUri());
+		$this->assertSame(InstancePath::TYPE_INBOX, $paths[0]->getType());
+		$this->assertSame(InstancePath::PRIORITY_LOW, $paths[0]->getPriority());
+	}
+
+	public function testCreateFallsBackToAuthorIdWhenActorCannotBeResolved(): void {
+		$this->streamService->method('getStreamById')->willReturn($this->note());
+		$this->cacheActorService->method('getFromId')->willThrowException(new CacheActorDoesNotExistException());
+		$this->activityService->method('request')->willReturn('token');
+
+		$like = $this->service->create($this->alice(), self::POST_ID);
+
+		$paths = $like->getInstancePaths();
+		$this->assertCount(1, $paths);
+		$this->assertSame(self::BOB_ID, $paths[0]->getUri());
+		$this->assertSame(InstancePath::TYPE_INBOX, $paths[0]->getType());
+	}
+
+	public function testCreateRefusesToLikeSomethingThatIsNotANote(): void {
+		$announce = new Announce();
+		$announce->setId(self::POST_ID);
+		$this->streamService->method('getStreamById')->willReturn($announce);
+		$this->likeInterface->expects($this->never())->method('save');
+		$this->streamActionService->expects($this->never())->method('setActionBool');
+		$this->activityService->expects($this->never())->method('request');
+
+		$this->expectException(StreamNotFoundException::class);
+		$this->expectExceptionMessage('Stream is not a Note');
+		$this->service->create($this->alice(), self::POST_ID);
+	}
+
+	public function testCreateFailsForUnknownPost(): void {
+		$this->streamService->method('getStreamById')->willThrowException(new StreamNotFoundException('Stream not found'));
+		$this->likeInterface->expects($this->never())->method('save');
+		$this->streamActionService->expects($this->never())->method('setActionBool');
+
+		$this->expectException(StreamNotFoundException::class);
+		$this->service->create($this->alice(), 'https://remote.example/notes/missing');
+	}
+
+	public function testCreateDoesNotFlagOrFederateWhenTheLikeAlreadyExists(): void {
+		$this->streamService->method('getStreamById')->willReturn($this->note());
+		$this->cacheActorService->method('getFromId')->willReturn($this->bob());
+		$this->likeInterface->method('save')->willThrowException(new ItemAlreadyExistsException());
+		$this->streamActionService->expects($this->never())->method('setActionBool');
+		$this->activityService->expects($this->never())->method('request');
+
+		$this->expectException(ItemAlreadyExistsException::class);
+		$this->service->create($this->alice(), self::POST_ID);
+	}
+
+
+	// get()
+
+	public function testGetLooksUpLikeByLikedObject(): void {
+		$stored = new Stream();
+		$stored->setType(Like::TYPE);
+		$stored->setObjectId(self::POST_ID);
+		$this->streamRequest->expects($this->once())
+			->method('getStreamByObjectId')
+			->with(self::POST_ID, Like::TYPE)
+			->willReturn($stored);
+
+		$this->assertSame($stored, $this->service->get(self::POST_ID));
+	}
+
+	public function testGetPropagatesMissingLike(): void {
+		$this->streamRequest->method('getStreamByObjectId')->willThrowException(new StreamNotFoundException());
+
+		$this->expectException(StreamNotFoundException::class);
+		$this->service->get(self::POST_ID);
+	}
+
+
+	// delete()
+
+	public function testDeleteSendsUndoRemovesLikeAndClearsFlag(): void {
+		$alice = $this->alice();
+		$existing = $this->existingLike();
+		$this->streamService->method('getStreamById')->with(self::POST_ID, true)->willReturn($this->note());
+		$this->cacheActorService->method('getFromId')->willReturn($this->bob());
+
+		$this->likeInterface->expects($this->once())
+			->method('getItem')
+			->with($this->callback(function (ACore $probe): bool {
+				return $probe instanceof Like
+					&& $probe->getActorId() === self::ALICE_ID
+					&& $probe->getObjectId() === self::POST_ID;
+			}))
+			->willReturn($existing);
+		$this->likeInterface->expects($this->once())->method('delete')->with($this->identicalTo($existing));
+		$this->signatureService->expects($this->once())
+			->method('signObject')
+			->with($this->identicalTo($alice), $this->isInstanceOf(Undo::class));
+		$this->activityService->expects($this->once())
+			->method('request')
+			->with($this->isInstanceOf(Undo::class))
+			->willReturn('token-undo');
+		$this->streamActionService->expects($this->once())
+			->method('setActionBool')
+			->with(self::ALICE_ID, self::POST_ID, StreamAction::LIKED, false);
+
+		$token = '';
+		$undo = $this->service->delete($alice, self::POST_ID, $token);
+
+		$this->assertSame('token-undo', $token);
+		$this->assertInstanceOf(Undo::class, $undo);
+		$this->assertSame($existing->getId() . '/undo', $undo->getId());
+		$this->assertSame($alice, $undo->getActor());
+		$this->assertSame($existing, $undo->getObject());
+		$this->assertSame($undo, $existing->getParent());
+		$this->assertEqualsWithDelta(time(), (new DateTime($undo->getPublished()))->getTimestamp(), 5);
+
+		$paths = $undo->getInstancePaths();
+		$this->assertCount(1, $paths);
+		$this->assertSame(self::BOB_ID . '/inbox', $paths[0]->getUri());
+		$this->assertSame(InstancePath::PRIORITY_LOW, $paths[0]->getPriority());
+	}
+
+	public function testDeleteStillClearsFlagWhenNoLikeIsStored(): void {
+		$this->streamService->method('getStreamById')->willReturn($this->note());
+		$this->cacheActorService->method('getFromId')->willReturn($this->bob());
+		$this->likeInterface->method('getItem')->willThrowException(new ItemNotFoundException());
+		$this->likeInterface->expects($this->never())->method('delete');
+		$this->signatureService->expects($this->never())->method('signObject');
+		$this->activityService->expects($this->never())->method('request');
+		$this->streamActionService->expects($this->once())
+			->method('setActionBool')
+			->with(self::ALICE_ID, self::POST_ID, StreamAction::LIKED, false);
+
+		$token = 'untouched';
+		$undo = $this->service->delete($this->alice(), self::POST_ID, $token);
+
+		$this->assertSame('untouched', $token);
+		$this->assertInstanceOf(Undo::class, $undo);
+		$this->assertFalse($undo->hasObject());
+	}
+
+	public function testDeleteRefusesSomethingThatIsNotANote(): void {
+		$announce = new Announce();
+		$announce->setId(self::POST_ID);
+		$this->streamService->method('getStreamById')->willReturn($announce);
+		$this->streamActionService->expects($this->never())->method('setActionBool');
+
+		$this->expectException(StreamNotFoundException::class);
+		$this->service->delete($this->alice(), self::POST_ID);
+	}
+
+	public function testDeleteFailsForUnknownPost(): void {
+		$this->streamService->method('getStreamById')->willThrowException(new StreamNotFoundException());
+		$this->likeInterface->expects($this->never())->method('getItem');
+		$this->streamActionService->expects($this->never())->method('setActionBool');
+
+		$this->expectException(StreamNotFoundException::class);
+		$this->service->delete($this->alice(), 'https://remote.example/notes/missing');
+	}
+}

--- a/tests/Service/MiscServiceTest.php
+++ b/tests/Service/MiscServiceTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use OCA\Social\Service\MiscService;
+use OCP\IUserManager;
+use OCP\ServerVersion;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class MiscServiceTest extends TestCase {
+	protected function tearDown(): void {
+		\OC::$server->reset();
+	}
+
+	public function testLogTagsTheMessageWithAppAndLevel(): void {
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->once())
+			->method('log')
+			->with(3, 'something happened', ['app' => 'social', 'level' => 3]);
+
+		$service = new MiscService($logger, $this->createMock(IUserManager::class));
+		$service->log('something happened', 3);
+	}
+
+	public function testLogDefaultsToLevelTwo(): void {
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->once())
+			->method('log')
+			->with(2, 'default level', ['app' => 'social', 'level' => 2]);
+
+		$service = new MiscService($logger, $this->createMock(IUserManager::class));
+		$service->log('default level');
+	}
+
+	public function testGetNcVersionReturnsTheMajorVersion(): void {
+		$version = $this->createMock(ServerVersion::class);
+		$version->method('getVersion')->willReturn([31, 0, 2]);
+		\OC::$server->register(ServerVersion::class, $version);
+
+		$service = new MiscService($this->createMock(LoggerInterface::class), $this->createMock(IUserManager::class));
+
+		$this->assertSame(31, $service->getNcVersion());
+	}
+}

--- a/tests/Service/PostServiceTest.php
+++ b/tests/Service/PostServiceTest.php
@@ -1,0 +1,456 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use DateTime;
+use OCA\Social\Db\StreamRequest;
+use OCA\Social\Exceptions\StreamNotFoundException;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Activity\Create;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Model\ActivityPub\Stream;
+use OCA\Social\Model\InstancePath;
+use OCA\Social\Model\Post;
+use OCA\Social\Service\AccountService;
+use OCA\Social\Service\ActivityService;
+use OCA\Social\Service\CacheActorService;
+use OCA\Social\Service\CacheDocumentService;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\CurlService;
+use OCA\Social\Service\MiscService;
+use OCA\Social\Service\PostService;
+use OCA\Social\Service\StreamService;
+use OCA\Social\Tools\Exceptions\RequestNetworkException;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * PostService is exercised with a real StreamService (the Note it builds is
+ * what matters) and a mocked ActivityService that records what it is handed.
+ */
+class PostServiceTest extends TestCase {
+	private const SOCIAL_URL = 'https://social.example/';
+	private const ACTOR_ID = 'https://social.example/@alice';
+	private const ACTOR_FOLLOWERS = 'https://social.example/@alice/followers';
+	private const GENERATED_ID = 'https://social.example/@alice/1234567890';
+	private const BOB_ID = 'https://remote.example/users/bob';
+
+	private StreamRequest|MockObject $streamRequest;
+	private AccountService|MockObject $accountService;
+	private ActivityService|MockObject $activityService;
+	private CacheActorService|MockObject $cacheActorService;
+	private PostService $service;
+
+	protected function setUp(): void {
+		$this->streamRequest = $this->createMock(StreamRequest::class);
+		$this->accountService = $this->createMock(AccountService::class);
+		$this->activityService = $this->createMock(ActivityService::class);
+		$this->cacheActorService = $this->createMock(CacheActorService::class);
+
+		$configService = $this->createMock(ConfigService::class);
+		$configService->method('generateId')->willReturn(self::GENERATED_ID);
+		$configService->method('getSocialUrl')->willReturn(self::SOCIAL_URL);
+
+		$streamService = new StreamService(
+			$this->createMock(IURLGenerator::class),
+			$this->streamRequest,
+			$this->activityService,
+			$this->cacheActorService,
+			$configService,
+			$this->createMock(CurlService::class),
+			new NullLogger()
+		);
+
+		$this->service = new PostService(
+			$this->streamRequest,
+			$streamService,
+			$this->accountService,
+			$this->activityService,
+			$this->createMock(CacheDocumentService::class),
+			$configService,
+			$this->createMock(MiscService::class),
+			new NullLogger()
+		);
+	}
+
+	private function actor(): Person {
+		$actor = new Person();
+		$actor->setId(self::ACTOR_ID);
+		$actor->setPreferredUsername('alice');
+		$actor->setFollowers(self::ACTOR_FOLLOWERS);
+		$actor->setLocal(true);
+
+		return $actor;
+	}
+
+	private function bob(): Person {
+		$bob = new Person();
+		$bob->setId(self::BOB_ID);
+		$bob->setPreferredUsername('bob');
+		$bob->setAccount('bob@remote.example');
+		$bob->setInbox(self::BOB_ID . '/inbox');
+		$bob->setSharedInbox('https://remote.example/inbox');
+
+		return $bob;
+	}
+
+	private function post(string $content, string $type = Stream::TYPE_PUBLIC): Post {
+		$post = new Post($this->actor());
+		$post->setContent($content);
+		$post->setType($type);
+
+		return $post;
+	}
+
+	/**
+	 * Records the Note handed to ActivityService::createActivity() and hands
+	 * back a Create wrapping it, the way the real service does.
+	 */
+	private function expectCreateActivity(?Note &$captured, string $token = 'token-1'): void {
+		$this->activityService->expects($this->once())
+			->method('createActivity')
+			->willReturnCallback(function (Person $actor, ACore $item, ?ACore &$activity = null) use (&$captured, $token): string {
+				$captured = $item;
+				$activity = new Create();
+				$activity->setId($item->getId() . '/activity');
+				$activity->setObject($item);
+				$activity->setActor($actor);
+
+				return $token;
+			});
+	}
+
+
+	// createPost()
+
+	public function testCreatePostBuildsNoteAndWrapsItInCreateActivity(): void {
+		$this->cacheActorService->method('getFromAccount')->with('bob@remote.example', true)->willReturn($this->bob());
+		$this->accountService->expects($this->once())
+			->method('cacheLocalActorDetailCount')
+			->with($this->callback(fn (Person $p): bool => $p->getId() === self::ACTOR_ID));
+		$this->expectCreateActivity($note);
+
+		$token = '';
+		$activity = $this->service->createPost(
+			$this->post('Hello @bob@remote.example it\'s "great" #Nextcloud'), $token
+		);
+
+		$this->assertSame('token-1', $token);
+		$this->assertInstanceOf(Create::class, $activity);
+		$this->assertSame(self::GENERATED_ID . '/activity', $activity->getId());
+		$this->assertSame($note, $activity->getObject());
+		$this->assertSame(self::ACTOR_ID, $activity->getActor()->getId());
+
+		$this->assertInstanceOf(Note::class, $note);
+		$this->assertSame(self::GENERATED_ID, $note->getId());
+		$this->assertTrue($note->isLocal());
+		$this->assertSame(self::ACTOR_ID, $note->getAttributedTo());
+		$this->assertSame(Stream::TYPE_PUBLIC, $note->getVisibility());
+		$this->assertSame('Hello @bob@remote.example it&#039;s &quot;great&quot; #Nextcloud', $note->getContent());
+		$this->assertEqualsWithDelta(time(), (new DateTime($note->getPublished()))->getTimestamp(), 5);
+		$this->assertSame(['Nextcloud'], $note->getHashtags());
+		$this->assertSame(
+			[
+				['type' => 'Mention', 'href' => self::BOB_ID, 'name' => '@bob@remote.example'],
+				['type' => 'Hashtag', 'href' => self::SOCIAL_URL . 'tag/nextcloud', 'name' => '#Nextcloud'],
+			],
+			$note->getTags()
+		);
+		$this->assertSame('', $note->getInReplyTo());
+		$this->assertSame([], $note->getAttachments());
+	}
+
+	/**
+	 * @return array<string, array{string, string, string[], string[]}>
+	 */
+	public function visibilityProvider(): array {
+		return [
+			'public' => [Stream::TYPE_PUBLIC, ACore::CONTEXT_PUBLIC, [], [self::ACTOR_FOLLOWERS, self::BOB_ID]],
+			'unlisted' => [Stream::TYPE_UNLISTED, self::ACTOR_FOLLOWERS, [], [ACore::CONTEXT_PUBLIC, self::BOB_ID]],
+			'followers' => [Stream::TYPE_FOLLOWERS, self::ACTOR_FOLLOWERS, [], [self::BOB_ID]],
+			'direct' => [Stream::TYPE_DIRECT, '', [self::BOB_ID], []],
+		];
+	}
+
+	/**
+	 * @dataProvider visibilityProvider
+	 */
+	public function testCreatePostAddressesMentionPerVisibility(
+		string $type,
+		string $expectedTo,
+		array $expectedToArray,
+		array $expectedCc,
+	): void {
+		$this->cacheActorService->method('getFromAccount')->willReturn($this->bob());
+		$this->expectCreateActivity($note);
+
+		$this->service->createPost($this->post('Hi @bob@remote.example', $type));
+
+		$this->assertSame($type, $note->getVisibility());
+		$this->assertSame($expectedTo, $note->getTo());
+		$this->assertSame($expectedToArray, $note->getToArray());
+		$this->assertSame($expectedCc, $note->getCcArray());
+		$this->assertSame($type === Stream::TYPE_PUBLIC || $type === Stream::TYPE_UNLISTED, $note->isPublic());
+		$this->assertCount(1, $note->getTags('Mention'));
+	}
+
+	public function testCreatePostDirectMessageFederatesOnlyToMentionedInboxes(): void {
+		$this->cacheActorService->method('getFromAccount')->willReturn($this->bob());
+		$this->expectCreateActivity($note);
+
+		$this->service->createPost($this->post('psst @bob@remote.example', Stream::TYPE_DIRECT));
+
+		$paths = $note->getInstancePaths();
+		$this->assertCount(1, $paths);
+		$this->assertSame(self::BOB_ID . '/inbox', $paths[0]->getUri());
+		$this->assertSame(InstancePath::TYPE_INBOX, $paths[0]->getType());
+		$this->assertSame(InstancePath::PRIORITY_HIGH, $paths[0]->getPriority());
+		$this->assertTrue($note->isFilterDuplicate());
+	}
+
+	public function testCreatePostPublicFederatesToFollowersAndMentionedInboxes(): void {
+		$this->cacheActorService->method('getFromAccount')->willReturn($this->bob());
+		$this->expectCreateActivity($note);
+
+		$this->service->createPost($this->post('hey @bob@remote.example'));
+
+		$paths = $note->getInstancePaths();
+		$this->assertCount(2, $paths);
+		$this->assertSame(self::ACTOR_ID, $paths[0]->getUri());
+		$this->assertSame(InstancePath::TYPE_FOLLOWERS, $paths[0]->getType());
+		$this->assertSame(self::BOB_ID . '/inbox', $paths[1]->getUri());
+		$this->assertSame(InstancePath::PRIORITY_MEDIUM, $paths[1]->getPriority());
+	}
+
+	public function testCreatePostWithoutMentionsOrTagsNeedsNoLookup(): void {
+		$this->cacheActorService->expects($this->never())->method('getFromAccount');
+		$this->expectCreateActivity($note);
+
+		$this->service->createPost($this->post('just words'));
+
+		$this->assertSame([], $note->getTags());
+		$this->assertSame([], $note->getHashtags());
+		$this->assertSame(ACore::CONTEXT_PUBLIC, $note->getTo());
+		$this->assertSame([], $note->getToArray());
+		$this->assertSame([self::ACTOR_FOLLOWERS], $note->getCcArray());
+	}
+
+	public function testCreatePostReplyWiresParentAndAddressesItsAuthor(): void {
+		$parentId = 'https://remote.example/notes/parent';
+		$parent = new Note();
+		$parent->setId($parentId);
+		$parent->setAttributedTo(self::BOB_ID);
+		$this->streamRequest->method('getStreamById')->with($parentId)->willReturn($parent);
+		$this->cacheActorService->method('getFromId')->with(self::BOB_ID)->willReturn($this->bob());
+		$this->expectCreateActivity($note);
+
+		$post = $this->post('I agree');
+		$post->setReplyTo($parentId);
+		$this->service->createPost($post);
+
+		$this->assertSame($parentId, $note->getInReplyTo());
+		$paths = $note->getInstancePaths();
+		$this->assertCount(2, $paths);
+		$this->assertSame('https://remote.example/inbox', $paths[1]->getUri());
+		$this->assertSame(InstancePath::TYPE_INBOX, $paths[1]->getType());
+		$this->assertSame(InstancePath::PRIORITY_HIGH, $paths[1]->getPriority());
+	}
+
+	public function testCreatePostToUnknownReplyTargetFailsBeforeAnythingIsSent(): void {
+		$this->streamRequest->method('getStreamById')->willThrowException(new StreamNotFoundException());
+		$this->activityService->expects($this->never())->method('createActivity');
+		$this->accountService->expects($this->never())->method('cacheLocalActorDetailCount');
+
+		$post = $this->post('I agree');
+		$post->setReplyTo('https://remote.example/notes/missing');
+
+		$this->expectException(StreamNotFoundException::class);
+		$this->service->createPost($post);
+	}
+
+	public function testCreatePostToUnreachableReplyAuthorFails(): void {
+		$parent = new Note();
+		$parent->setId('https://remote.example/notes/parent');
+		$parent->setAttributedTo(self::BOB_ID);
+		$this->streamRequest->method('getStreamById')->willReturn($parent);
+		$this->cacheActorService->method('getFromId')->willThrowException(new RequestNetworkException());
+		$this->activityService->expects($this->never())->method('createActivity');
+
+		$post = $this->post('I agree');
+		$post->setReplyTo('https://remote.example/notes/parent');
+
+		$this->expectException(RequestNetworkException::class);
+		$this->service->createPost($post);
+	}
+
+	public function testCreatePostCarriesMediaAttachments(): void {
+		$medias = [['id' => '1', 'type' => 'image', 'url' => 'https://social.example/media/1.png']];
+		$this->expectCreateActivity($note);
+
+		$post = $this->post('look');
+		$post->setMedias($medias);
+		$this->service->createPost($post);
+
+		$this->assertSame($medias, $note->getAttachments());
+	}
+
+	public function testCreatePostMergesExplicitAndInlineRecipients(): void {
+		$carol = new Person();
+		$carol->setId('https://other.example/users/carol');
+		$carol->setInbox('https://other.example/users/carol/inbox');
+		$this->cacheActorService->method('getFromAccount')->willReturnMap([
+			['carol@other.example', true, $carol],
+			['bob@remote.example', true, $this->bob()],
+		]);
+		$this->expectCreateActivity($note);
+
+		$post = $this->post('hi @bob@remote.example', Stream::TYPE_DIRECT);
+		$post->addTo('carol@other.example');
+		$this->service->createPost($post);
+
+		$this->assertSame([$carol->getId(), self::BOB_ID], $note->getToArray());
+	}
+
+
+	// fixRecipientAndHashtags()
+
+	/**
+	 * @return array<string, array{string, string[], string[]}>
+	 */
+	public function inlineTokensProvider(): array {
+		return [
+			'mention and hashtag' => ['hi @bob@remote.example #Nextcloud', ['bob@remote.example'], ['Nextcloud']],
+			'several of each, deduplicated' => [
+				'@a@x.tld @b@y.tld @a@x.tld #one #two #one', ['a@x.tld', 'b@y.tld'], ['one', 'two'],
+			],
+			'email-like text is not a mention' => ['write to frank@example.org', [], []],
+			'hash inside a word is not a tag' => ['issue#42 is fixed', [], []],
+			'leading tokens' => ['#first @bob@remote.example', ['bob@remote.example'], ['first']],
+			'nothing' => ['plain words', [], []],
+		];
+	}
+
+	/**
+	 * @dataProvider inlineTokensProvider
+	 */
+	public function testFixRecipientAndHashtagsExtractsInlineTokens(string $content, array $to, array $hashtags): void {
+		$post = $this->post($content);
+
+		$this->service->fixRecipientAndHashtags($post);
+
+		$this->assertSame($to, $post->getTo());
+		$this->assertSame($hashtags, $post->getHashtags());
+	}
+
+	public function testFixRecipientAndHashtagsKeepsExplicitRecipientsFirst(): void {
+		$post = $this->post('hi @bob@remote.example #tag');
+		$post->addTo('carol@other.example');
+		$post->addHashtag('Existing');
+
+		$this->service->fixRecipientAndHashtags($post);
+
+		$this->assertSame(['carol@other.example', 'bob@remote.example'], $post->getTo());
+		$this->assertSame(['Existing', 'tag'], $post->getHashtags());
+	}
+
+
+	// editPost()
+
+	private function storedNote(string $attributedTo = self::ACTOR_ID): Note {
+		$note = new Note();
+		$note->setNid(7);
+		$note->setId('https://social.example/@alice/7');
+		$note->setAttributedTo($attributedTo);
+		$note->setContent('old');
+		$note->setSpoilerText('old cw');
+		$note->setSensitive(false);
+		$note->setPublished('2020-01-01T00:00:00+00:00');
+		$note->setLocal(true);
+
+		return $note;
+	}
+
+	public function testEditPostUpdatesOwnPostAndFederatesAnUpdate(): void {
+		$stored = $this->storedNote();
+		$reloaded = $this->storedNote();
+		$reloaded->setContent('new');
+		$this->streamRequest->expects($this->exactly(2))
+			->method('getStreamByNid')
+			->with(7)
+			->willReturnOnConsecutiveCalls($stored, $reloaded);
+		$this->streamRequest->expects($this->once())
+			->method('update')
+			->with($this->identicalTo($stored));
+		$this->activityService->expects($this->once())
+			->method('updateActivity')
+			->with(
+				$this->callback(fn (Person $p): bool => $p->getId() === self::ACTOR_ID),
+				$this->identicalTo($reloaded)
+			)
+			->willReturn('token');
+
+		$result = $this->service->editPost(7, $this->actor(), 'new', 'new cw', true);
+
+		$this->assertSame($reloaded, $result);
+		$this->assertSame('new', $stored->getContent());
+		$this->assertSame('new cw', $stored->getSpoilerText());
+		$this->assertTrue($stored->isSensitive());
+		$this->assertEqualsWithDelta(time(), (new DateTime($stored->getPublished()))->getTimestamp(), 5);
+
+		$paths = $reloaded->getInstancePaths();
+		$this->assertCount(1, $paths);
+		$this->assertSame(self::ACTOR_ID, $paths[0]->getUri());
+		$this->assertSame(InstancePath::TYPE_FOLLOWERS, $paths[0]->getType());
+		$this->assertSame(InstancePath::PRIORITY_LOW, $paths[0]->getPriority());
+	}
+
+	public function testEditPostLeavesSpoilerAndSensitivityAloneWhenNotProvided(): void {
+		$stored = $this->storedNote();
+		$stored->setSensitive(true);
+		$this->streamRequest->method('getStreamByNid')->willReturnOnConsecutiveCalls($stored, $this->storedNote());
+		$this->activityService->method('updateActivity')->willReturn('token');
+
+		$this->service->editPost(7, $this->actor(), 'new');
+
+		$this->assertSame('new', $stored->getContent());
+		$this->assertSame('old cw', $stored->getSpoilerText());
+		$this->assertTrue($stored->isSensitive());
+	}
+
+	public function testEditPostRefusesSomeoneElsesPost(): void {
+		$this->streamRequest->method('getStreamByNid')->willReturn($this->storedNote(self::BOB_ID));
+		$this->streamRequest->expects($this->never())->method('update');
+		$this->activityService->expects($this->never())->method('updateActivity');
+
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('Not authorized to edit this post');
+		$this->service->editPost(7, $this->actor(), 'hijack');
+	}
+
+	public function testEditPostOfUnknownPostFails(): void {
+		$this->streamRequest->method('getStreamByNid')->willThrowException(new StreamNotFoundException());
+		$this->streamRequest->expects($this->never())->method('update');
+
+		$this->expectException(StreamNotFoundException::class);
+		$this->service->editPost(404, $this->actor(), 'new');
+	}
+
+	public function testEditPostKeepsLocalChangeWhenFederationFails(): void {
+		$reloaded = $this->storedNote();
+		$this->streamRequest->method('getStreamByNid')->willReturnOnConsecutiveCalls($this->storedNote(), $reloaded);
+		$this->streamRequest->expects($this->once())->method('update');
+		$this->activityService->method('updateActivity')->willThrowException(new \RuntimeException('remote down'));
+
+		$this->assertSame($reloaded, $this->service->editPost(7, $this->actor(), 'new'));
+	}
+}

--- a/tests/Service/RequestQueueServiceTest.php
+++ b/tests/Service/RequestQueueServiceTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use OCA\Social\Db\RequestQueueRequest;
+use OCA\Social\Exceptions\EmptyQueueException;
+use OCA\Social\Exceptions\NoHighPriorityRequestException;
+use OCA\Social\Exceptions\QueueStatusException;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Model\InstancePath;
+use OCA\Social\Model\RequestQueue;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\MiscService;
+use OCA\Social\Service\RequestQueueService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class RequestQueueServiceTest extends TestCase {
+	private const AUTHOR = 'https://cloud.example.com/apps/social/@alice';
+
+	private RequestQueueRequest|MockObject $requestQueueRequest;
+	private RequestQueueService $service;
+
+	protected function setUp(): void {
+		$this->requestQueueRequest = $this->createMock(RequestQueueRequest::class);
+		$this->service = new RequestQueueService(
+			$this->requestQueueRequest,
+			$this->createMock(ConfigService::class),
+			$this->createMock(MiscService::class),
+		);
+	}
+
+	private function queued(int $priority, int $status = RequestQueue::STATUS_STANDBY): RequestQueue {
+		$queue = new RequestQueue('{}', new InstancePath('https://remote.example/inbox', InstancePath::TYPE_INBOX, $priority), self::AUTHOR);
+		$queue->setStatus($status);
+
+		return $queue;
+	}
+
+	public function testGenerateRequestQueueCreatesOneEntryPerInstanceSharingAToken(): void {
+		$note = new Note();
+		$note->setId('https://cloud.example.com/apps/social/@alice/1');
+		$note->setContent('hello');
+		$inbox = new InstancePath('https://remote.example/users/bob/inbox', InstancePath::TYPE_INBOX, InstancePath::PRIORITY_HIGH);
+		$shared = new InstancePath('https://other.example/inbox', InstancePath::TYPE_GLOBAL, InstancePath::PRIORITY_LOW);
+		$stored = [];
+		$this->requestQueueRequest->expects($this->once())
+			->method('multiple')
+			->willReturnCallback(function (array $requests) use (&$stored) {
+				$stored = $requests;
+			});
+
+		$token = $this->service->generateRequestQueue([$inbox, $shared], $note, self::AUTHOR);
+
+		$this->assertMatchesRegularExpression('/^[0-9a-f-]{36}$/', $token);
+		$this->assertCount(2, $stored);
+		foreach ($stored as $request) {
+			$this->assertInstanceOf(RequestQueue::class, $request);
+			$this->assertSame($token, $request->getToken());
+			$this->assertSame(self::AUTHOR, $request->getAuthor());
+			$this->assertSame(json_encode($note, JSON_UNESCAPED_SLASHES), $request->getActivity());
+			$this->assertSame(RequestQueue::STATUS_STANDBY, $request->getStatus());
+		}
+		$this->assertSame($inbox, $stored[0]->getInstance());
+		$this->assertSame(InstancePath::PRIORITY_HIGH, $stored[0]->getPriority());
+		$this->assertSame($shared, $stored[1]->getInstance());
+		$this->assertSame(InstancePath::PRIORITY_LOW, $stored[1]->getPriority());
+	}
+
+	public function testGenerateRequestQueueWithoutInstancesStoresNothingAndHasNoToken(): void {
+		$this->requestQueueRequest->expects($this->once())->method('multiple')->with([]);
+
+		$this->assertSame('', $this->service->generateRequestQueue([], new Note(), self::AUTHOR));
+	}
+
+	public function testGetPriorityRequestOnEmptyQueueThrows(): void {
+		$this->requestQueueRequest->method('getFromToken')->with('tok')->willReturn([]);
+
+		$this->expectException(EmptyQueueException::class);
+		$this->service->getPriorityRequest('tok');
+	}
+
+	public function testTopPriorityIsAlwaysRunInline(): void {
+		$top = $this->queued(InstancePath::PRIORITY_TOP);
+		$this->requestQueueRequest->method('getFromToken')
+			->willReturn([$top, $this->queued(InstancePath::PRIORITY_TOP)]);
+
+		$this->assertSame($top, $this->service->getPriorityRequest('tok'));
+	}
+
+	public function testSingleHighPriorityRequestIsRunInline(): void {
+		$high = $this->queued(InstancePath::PRIORITY_HIGH);
+		$this->requestQueueRequest->method('getFromToken')->willReturn([$high]);
+
+		$this->assertSame($high, $this->service->getPriorityRequest('tok'));
+	}
+
+	public function testHighPriorityFollowedByAStandbyRequestIsRunInline(): void {
+		$high = $this->queued(InstancePath::PRIORITY_HIGH);
+		$this->requestQueueRequest->method('getFromToken')
+			->willReturn([$high, $this->queued(InstancePath::PRIORITY_LOW, RequestQueue::STATUS_STANDBY)]);
+
+		$this->assertSame($high, $this->service->getPriorityRequest('tok'));
+	}
+
+	public function testSingleMediumPriorityRequestIsRunInline(): void {
+		$medium = $this->queued(InstancePath::PRIORITY_MEDIUM);
+		$this->requestQueueRequest->method('getFromToken')->willReturn([$medium]);
+
+		$this->assertSame($medium, $this->service->getPriorityRequest('tok'));
+	}
+
+	public function testSeveralMediumPriorityRequestsAreDeferred(): void {
+		$this->requestQueueRequest->method('getFromToken')
+			->willReturn([$this->queued(InstancePath::PRIORITY_MEDIUM), $this->queued(InstancePath::PRIORITY_MEDIUM)]);
+
+		$this->expectException(NoHighPriorityRequestException::class);
+		$this->service->getPriorityRequest('tok');
+	}
+
+	public function testLowPriorityIsAlwaysDeferred(): void {
+		$this->requestQueueRequest->method('getFromToken')->willReturn([$this->queued(InstancePath::PRIORITY_LOW)]);
+
+		$this->expectException(NoHighPriorityRequestException::class);
+		$this->service->getPriorityRequest('tok');
+	}
+
+	public function testGetRequestStandbyAppliesTheRetryBackoff(): void {
+		$now = time();
+		$fresh = $this->queued(InstancePath::PRIORITY_LOW)->setTries(0)->setLast($now - 1);
+		$retriedRecently = $this->queued(InstancePath::PRIORITY_LOW)->setTries(3)->setLast($now - 10); // delay 27s
+		$retriedLongAgo = $this->queued(InstancePath::PRIORITY_LOW)->setTries(3)->setLast($now - 60);
+		$this->requestQueueRequest->method('getStandby')->willReturn([$fresh, $retriedRecently, $retriedLongAgo]);
+
+		$total = 0;
+		$ready = $this->service->getRequestStandby($total);
+
+		$this->assertSame(3, $total);
+		$this->assertSame([$fresh, $retriedLongAgo], $ready);
+	}
+
+	public function testGetRequestFromTokenSkipsTheDatabaseForAnEmptyToken(): void {
+		$this->requestQueueRequest->expects($this->never())->method('getFromToken');
+
+		$this->assertSame([], $this->service->getRequestFromToken(''));
+	}
+
+	public function testGetRequestFromTokenForwardsTheStatusFilter(): void {
+		$queue = $this->queued(InstancePath::PRIORITY_LOW);
+		$this->requestQueueRequest->expects($this->once())
+			->method('getFromToken')
+			->with('tok', RequestQueue::STATUS_STANDBY)
+			->willReturn([$queue]);
+
+		$this->assertSame([$queue], $this->service->getRequestFromToken('tok', RequestQueue::STATUS_STANDBY));
+	}
+
+	public function testInitRequestMarksTheQueueRunning(): void {
+		$queue = $this->queued(InstancePath::PRIORITY_LOW);
+		$this->requestQueueRequest->expects($this->once())->method('setAsRunning')->with($this->identicalTo($queue));
+
+		$this->service->initRequest($queue);
+	}
+
+	public function testInitRequestPropagatesAStatusConflict(): void {
+		$this->requestQueueRequest->method('setAsRunning')->willThrowException(new QueueStatusException());
+
+		$this->expectException(QueueStatusException::class);
+		$this->service->initRequest($this->queued(InstancePath::PRIORITY_LOW));
+	}
+
+	public function testEndRequestOnSuccess(): void {
+		$queue = $this->queued(InstancePath::PRIORITY_LOW);
+		$this->requestQueueRequest->expects($this->once())->method('setAsSuccess')->with($this->identicalTo($queue));
+		$this->requestQueueRequest->expects($this->never())->method('setAsFailure');
+
+		$this->service->endRequest($queue, true);
+	}
+
+	public function testEndRequestOnFailure(): void {
+		$queue = $this->queued(InstancePath::PRIORITY_LOW);
+		$this->requestQueueRequest->expects($this->once())->method('setAsFailure')->with($this->identicalTo($queue));
+		$this->requestQueueRequest->expects($this->never())->method('setAsSuccess');
+
+		$this->service->endRequest($queue, false);
+	}
+
+	public function testEndRequestSwallowsStatusConflicts(): void {
+		$this->requestQueueRequest->method('setAsSuccess')->willThrowException(new QueueStatusException());
+
+		$this->service->endRequest($this->queued(InstancePath::PRIORITY_LOW), true);
+		$this->addToAssertionCount(1);
+	}
+
+	public function testDeleteRequestDelegates(): void {
+		$queue = $this->queued(InstancePath::PRIORITY_LOW);
+		$this->requestQueueRequest->expects($this->once())->method('delete')->with($this->identicalTo($queue));
+
+		$this->service->deleteRequest($queue);
+	}
+}

--- a/tests/Service/SearchServiceTest.php
+++ b/tests/Service/SearchServiceTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use OCA\Social\Exceptions\CacheActorDoesNotExistException;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Service\CacheActorService;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\HashtagService;
+use OCA\Social\Service\SearchService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class SearchServiceTest extends TestCase {
+	private CacheActorService|MockObject $cacheActorService;
+	private HashtagService|MockObject $hashtagService;
+	private SearchService $service;
+
+	protected function setUp(): void {
+		$this->cacheActorService = $this->createMock(CacheActorService::class);
+		$this->hashtagService = $this->createMock(HashtagService::class);
+		$this->service = new SearchService(
+			$this->cacheActorService,
+			$this->hashtagService,
+			$this->createMock(ConfigService::class),
+			new NullLogger(),
+		);
+	}
+
+	public function testSearchUriResolvesAnActorUrl(): void {
+		$bob = new Person();
+		$this->cacheActorService->expects($this->once())
+			->method('getFromId')
+			->with('https://remote.example/users/bob')
+			->willReturn($bob);
+
+		$this->assertSame([$bob], $this->service->searchUri('https://remote.example/users/bob'));
+	}
+
+	public function testSearchUriSwallowsResolutionFailures(): void {
+		$this->cacheActorService->method('getFromId')->willThrowException(new CacheActorDoesNotExistException());
+
+		$this->assertSame([], $this->service->searchUri('https://remote.example/users/nobody'));
+	}
+
+	/** @return array<string, array{string}> */
+	public function nonUriSearchProvider(): array {
+		return [
+			'empty' => [''],
+			'account' => ['@bob@remote.example'],
+			'hashtag' => ['#nextcloud'],
+		];
+	}
+
+	/** @dataProvider nonUriSearchProvider */
+	public function testSearchUriIgnoresNonUriSearches(string $search): void {
+		$this->cacheActorService->expects($this->never())->method('getFromId');
+
+		$this->assertSame([], $this->service->searchUri($search));
+	}
+
+	public function testSearchAccountsCachesTheExactMatchThenSearchesTheCache(): void {
+		$bob = new Person();
+		$this->cacheActorService->expects($this->once())
+			->method('getFromAccount')
+			->with('bob@remote.example');
+		$this->cacheActorService->expects($this->once())
+			->method('searchCachedAccounts')
+			->with('bob@remote.example')
+			->willReturn([$bob]);
+
+		$this->assertSame([$bob], $this->service->searchAccounts('@bob@remote.example'));
+	}
+
+	public function testSearchAccountsStillSearchesTheCacheWhenTheExactLookupFails(): void {
+		$this->cacheActorService->method('getFromAccount')->willThrowException(new CacheActorDoesNotExistException());
+		$this->cacheActorService->expects($this->once())
+			->method('searchCachedAccounts')
+			->with('bob')
+			->willReturn([]);
+
+		$this->assertSame([], $this->service->searchAccounts('bob'));
+	}
+
+	public function testSearchAccountsWithEmptySearchDoesNothing(): void {
+		$this->cacheActorService->expects($this->never())->method($this->anything());
+
+		$this->assertSame([], $this->service->searchAccounts(''));
+	}
+
+	public function testSearchHashtagsStripsTheHashSign(): void {
+		$this->hashtagService->expects($this->once())
+			->method('searchHashtags')
+			->with('nextcloud', true)
+			->willReturn([['hashtag' => '#nextcloud']]);
+
+		$this->assertSame([['hashtag' => '#nextcloud']], $this->service->searchHashtags('#nextcloud'));
+	}
+
+	public function testSearchHashtagsAcceptsFreeText(): void {
+		$this->hashtagService->expects($this->once())
+			->method('searchHashtags')
+			->with('next', true)
+			->willReturn([]);
+
+		$this->assertSame([], $this->service->searchHashtags('next'));
+	}
+
+	public function testSearchHashtagsWithEmptySearchDoesNothing(): void {
+		$this->hashtagService->expects($this->never())->method('searchHashtags');
+
+		$this->assertSame([], $this->service->searchHashtags(''));
+	}
+
+	public function testSearchStreamContentIsNotImplemented(): void {
+		$this->assertSame([], $this->service->searchStreamContent('anything'));
+		$this->assertSame([], $this->service->searchStreamContent(''));
+	}
+}

--- a/tests/Service/SignatureServiceTest.php
+++ b/tests/Service/SignatureServiceTest.php
@@ -1,0 +1,430 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use DateTime;
+use OCA\Social\Db\ActorsRequest;
+use OCA\Social\Exceptions\InvalidOriginException;
+use OCA\Social\Exceptions\SignatureException;
+use OCA\Social\Exceptions\SignatureIsGoneException;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Model\InstancePath;
+use OCA\Social\Model\RequestQueue;
+use OCA\Social\Service\CacheActorService;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\CurlService;
+use OCA\Social\Service\SignatureService;
+use OCA\Social\Tools\Exceptions\DateTimeException;
+use OCA\Social\Tools\Exceptions\MalformedArrayException;
+use OCA\Social\Tools\Exceptions\RequestContentException;
+use OCA\Social\Tools\Model\NCRequest;
+use OCA\Social\Tools\Model\Request;
+use OCP\Files\AppData\IAppDataFactory;
+use OCP\Files\IAppData;
+use OCP\Files\NotFoundException;
+use OCP\Files\SimpleFS\ISimpleFile;
+use OCP\Files\SimpleFS\ISimpleFolder;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class SignatureServiceTest extends TestCase {
+	private const CLOUD_HOST = 'cloud.example.com';
+	private const LOCAL_ACTOR = 'https://cloud.example.com/apps/social/@alice';
+	private const REMOTE_ACTOR = 'https://remote.example/users/bob';
+	private const REMOTE_KEY_ID = self::REMOTE_ACTOR . '#main-key';
+
+	/** One RSA key pair for the whole class: generating 2048-bit keys per test is slow. */
+	private static string $privateKey;
+	private static string $publicKey;
+	private static string $otherPublicKey;
+
+	private ActorsRequest|MockObject $actorsRequest;
+	private CacheActorService|MockObject $cacheActorService;
+	private SignatureService $service;
+
+	public static function setUpBeforeClass(): void {
+		[self::$privateKey, self::$publicKey] = self::keyPair();
+		[, self::$otherPublicKey] = self::keyPair();
+	}
+
+	/** @return array{string, string} private and public PEM */
+	private static function keyPair(): array {
+		$res = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+		openssl_pkey_export($res, $private);
+
+		return [$private, openssl_pkey_get_details($res)['key']];
+	}
+
+	protected function setUp(): void {
+		$this->actorsRequest = $this->createMock(ActorsRequest::class);
+		$this->cacheActorService = $this->createMock(CacheActorService::class);
+		$configService = $this->createMock(ConfigService::class);
+		$configService->method('getCloudHost')->willReturn(self::CLOUD_HOST);
+
+		$this->service = new SignatureService(
+			$this->actorsRequest,
+			$this->cacheActorService,
+			$this->createMock(CurlService::class),
+			$configService,
+			new NullLogger(),
+		);
+	}
+
+	protected function tearDown(): void {
+		\OC::$server->reset();
+	}
+
+	private function person(string $id, string $publicKey = '', string $privateKey = ''): Person {
+		$person = new Person();
+		$person->setId($id);
+		$person->setPublicKey($publicKey);
+		$person->setPrivateKey($privateKey);
+
+		return $person;
+	}
+
+	public function testGenerateKeysGivesTheActorAMatchingRsaPair(): void {
+		$actor = new Person();
+
+		$this->service->generateKeys($actor);
+
+		$this->assertStringStartsWith('-----BEGIN PRIVATE KEY-----', $actor->getPrivateKey());
+		$this->assertStringStartsWith('-----BEGIN PUBLIC KEY-----', $actor->getPublicKey());
+		$details = openssl_pkey_get_details(openssl_pkey_get_private($actor->getPrivateKey()));
+		$this->assertSame(2048, $details['bits']);
+		$this->assertSame(OPENSSL_KEYTYPE_RSA, $details['type']);
+		$this->assertSame($actor->getPublicKey(), $details['key'], 'public key belongs to the private key');
+	}
+
+	public function testSignRequestAddsDigestDateHostContentLengthAndSignature(): void {
+		$request = new NCRequest('/users/bob/inbox', Request::TYPE_POST);
+		$request->setData(['type' => 'Create', 'id' => 'https://cloud.example.com/apps/social/@alice/1']);
+		$body = $request->getDataBody();
+		$queue = new RequestQueue('{}', new InstancePath('https://remote.example/users/bob/inbox', InstancePath::TYPE_INBOX), self::LOCAL_ACTOR);
+		$this->actorsRequest->expects($this->once())
+			->method('getFromId')
+			->with(self::LOCAL_ACTOR)
+			->willReturn($this->person(self::LOCAL_ACTOR, self::$publicKey, self::$privateKey));
+
+		$this->service->signRequest($request, $queue);
+
+		$headers = $request->getHeaders();
+		$this->assertSame((string)strlen($body), $headers['content-length']);
+		$this->assertSame('remote.example', $headers['host']);
+		$this->assertSame('SHA-256=' . base64_encode(hash('sha256', $body, true)), $headers['digest']);
+		$this->assertNotFalse(DateTime::createFromFormat(SignatureService::DATE_HEADER, $headers['date']));
+		$this->assertEqualsWithDelta(time(), (new DateTime($headers['date']))->getTimestamp(), 5);
+
+		$this->assertMatchesRegularExpression(
+			'/^keyId="' . preg_quote(self::LOCAL_ACTOR, '/') . '#main-key",algorithm="rsa-sha256",'
+			. 'headers="\(request-target\) content-length date host digest",signature="[A-Za-z0-9+\/=]+"$/',
+			$headers['Signature'],
+		);
+
+		preg_match('/signature="([^"]+)"/', $headers['Signature'], $m);
+		$signingString = implode("\n", [
+			'(request-target): post /users/bob/inbox',
+			'content-length: ' . strlen($body),
+			'date: ' . $headers['date'],
+			'host: remote.example',
+			'digest: ' . $headers['digest'],
+		]);
+		$this->assertSame(1, openssl_verify($signingString, base64_decode($m[1]), self::$publicKey, OPENSSL_ALGO_SHA256));
+	}
+
+	/**
+	 * Build the headers of an HTTP-signed inbox POST, the way a remote server would send them.
+	 *
+	 * @return array<string, string> lower-cased header names
+	 */
+	private function signedHeaders(
+		string $body,
+		string $privateKey,
+		array $overrides = [],
+		string $headerList = '(request-target) host date digest content-length',
+		string $algorithm = 'rsa-sha256',
+		string $keyId = self::REMOTE_KEY_ID,
+	): array {
+		$headers = array_merge([
+			'date' => gmdate(SignatureService::DATE_HEADER),
+			'host' => self::CLOUD_HOST,
+			'digest' => 'SHA-256=' . base64_encode(hash('sha256', $body, true)),
+			'content-length' => (string)strlen($body),
+		], $overrides);
+
+		$lines = [];
+		foreach (explode(' ', $headerList) as $key) {
+			$lines[] = $key === '(request-target)' ? '(request-target): post /apps/social/@alice/inbox' : $key . ': ' . $headers[$key];
+		}
+		openssl_sign(implode("\n", $lines), $signed, $privateKey, $algorithm === 'rsa-sha512' ? OPENSSL_ALGO_SHA512 : OPENSSL_ALGO_SHA256);
+
+		$headers['signature'] = sprintf(
+			'keyId="%s",algorithm="%s",headers="%s",signature="%s"',
+			$keyId,
+			$algorithm,
+			$headerList,
+			base64_encode($signed),
+		);
+
+		return $headers;
+	}
+
+	private function incomingRequest(array $headers): IRequest|MockObject {
+		$request = $this->createMock(IRequest::class);
+		$request->method('getHeader')->willReturnCallback(fn (string $name) => $headers[strtolower($name)] ?? '');
+		$request->method('getMethod')->willReturn('POST');
+		$request->method('getRequestUri')->willReturn('/apps/social/@alice/inbox');
+
+		return $request;
+	}
+
+	public function testCheckRequestAcceptsAValidSignatureAndReturnsTheKeyOrigin(): void {
+		$body = '{"type":"Follow"}';
+		$headers = $this->signedHeaders($body, self::$privateKey);
+		$this->cacheActorService->expects($this->once())
+			->method('getFromId')
+			->with(self::REMOTE_KEY_ID, false)
+			->willReturn($this->person(self::REMOTE_ACTOR, self::$publicKey));
+
+		$time = 0;
+		$origin = $this->service->checkRequest($this->incomingRequest($headers), $body, $time);
+
+		$this->assertSame('remote.example', $origin);
+		$this->assertSame((new DateTime($headers['date']))->getTimestamp(), $time);
+	}
+
+	public function testCheckRequestAcceptsRsaSha512(): void {
+		$body = '{"type":"Follow"}';
+		$headers = $this->signedHeaders($body, self::$privateKey, [], '(request-target) host date digest', 'rsa-sha512');
+		$this->cacheActorService->method('getFromId')->willReturn($this->person(self::REMOTE_ACTOR, self::$publicKey));
+
+		$this->assertSame('remote.example', $this->service->checkRequest($this->incomingRequest($headers), $body));
+	}
+
+	public function testCheckRequestRejectsATamperedBody(): void {
+		$headers = $this->signedHeaders('{"type":"Follow"}', self::$privateKey);
+		$tampered = '{"type":"Delete"}';
+		$this->cacheActorService->expects($this->never())->method('getFromId');
+
+		$this->expectException(SignatureException::class);
+		$this->expectExceptionMessage('issue with digest');
+		$this->service->checkRequest($this->incomingRequest($headers), $tampered);
+	}
+
+	public function testCheckRequestRejectsAWrongContentLength(): void {
+		$body = '{"type":"Follow"}';
+		$headers = $this->signedHeaders($body, self::$privateKey, ['content-length' => '3']);
+
+		$this->expectException(SignatureException::class);
+		$this->expectExceptionMessage('content-length');
+		$this->service->checkRequest($this->incomingRequest($headers), $body);
+	}
+
+	public function testCheckRequestRejectsAnExpiredDate(): void {
+		$body = '{"type":"Follow"}';
+		$expired = gmdate(SignatureService::DATE_HEADER, time() - SignatureService::DATE_DELAY - 30);
+		$headers = $this->signedHeaders($body, self::$privateKey, ['date' => $expired]);
+
+		$this->expectException(SignatureException::class);
+		$this->expectExceptionMessage('too old');
+		$this->service->checkRequest($this->incomingRequest($headers), $body);
+	}
+
+	public function testCheckRequestRejectsAnUnparsableDate(): void {
+		$body = '{"type":"Follow"}';
+		$headers = $this->signedHeaders($body, self::$privateKey, ['date' => 'not a date']);
+
+		$this->expectException(DateTimeException::class);
+		$this->service->checkRequest($this->incomingRequest($headers), $body);
+	}
+
+	public function testCheckRequestRejectsAMissingSignatureHeader(): void {
+		$body = '{"type":"Follow"}';
+		$headers = $this->signedHeaders($body, self::$privateKey);
+		unset($headers['signature']);
+
+		$this->expectException(MalformedArrayException::class);
+		$this->service->checkRequest($this->incomingRequest($headers), $body);
+	}
+
+	public function testCheckRequestRefreshesTheKeyOnceBeforeGivingUp(): void {
+		$body = '{"type":"Follow"}';
+		$headers = $this->signedHeaders($body, self::$privateKey);
+		$this->cacheActorService->expects($this->exactly(2))
+			->method('getFromId')
+			->withConsecutive([self::REMOTE_KEY_ID, false], [self::REMOTE_KEY_ID, true])
+			->willReturn($this->person(self::REMOTE_ACTOR, self::$otherPublicKey));
+
+		$this->assertSame('', $this->service->checkRequest($this->incomingRequest($headers), $body));
+	}
+
+	public function testCheckRequestAcceptsAfterRefreshingAStaleCachedKey(): void {
+		$body = '{"type":"Follow"}';
+		$headers = $this->signedHeaders($body, self::$privateKey);
+		$this->cacheActorService->expects($this->exactly(2))
+			->method('getFromId')
+			->willReturnOnConsecutiveCalls(
+				$this->person(self::REMOTE_ACTOR, self::$otherPublicKey),
+				$this->person(self::REMOTE_ACTOR, self::$publicKey),
+			);
+
+		$this->assertSame('remote.example', $this->service->checkRequest($this->incomingRequest($headers), $body));
+	}
+
+	public function testCheckRequestWithAnUnknownActorYieldsNoOrigin(): void {
+		$body = '{"type":"Follow"}';
+		$headers = $this->signedHeaders($body, self::$privateKey);
+		$this->cacheActorService->method('getFromId')->willThrowException(new RequestContentException('not found', 404));
+
+		$this->assertSame('', $this->service->checkRequest($this->incomingRequest($headers), $body));
+	}
+
+	public function testCheckRequestSignalsAGoneActor(): void {
+		$body = '{"type":"Delete"}';
+		$headers = $this->signedHeaders($body, self::$privateKey);
+		$this->cacheActorService->method('getFromId')->willThrowException(new RequestContentException('gone', 410));
+
+		$this->expectException(SignatureIsGoneException::class);
+		$this->service->checkRequest($this->incomingRequest($headers), $body);
+	}
+
+	public function testCheckRequestRequiresRequestTargetAndDateToBeSigned(): void {
+		$body = '{"type":"Follow"}';
+		$headers = $this->signedHeaders($body, self::$privateKey, [], 'host digest');
+		$this->cacheActorService->expects($this->never())->method('getFromId');
+
+		$this->assertSame('', $this->service->checkRequest($this->incomingRequest($headers), $body));
+	}
+
+	public function testCheckRequestRejectsAKeyIdWithoutHost(): void {
+		$body = '{"type":"Follow"}';
+		$headers = $this->signedHeaders($body, self::$privateKey, [], '(request-target) host date digest', 'rsa-sha256', 'main-key');
+
+		$this->expectException(InvalidOriginException::class);
+		$this->service->checkRequest($this->incomingRequest($headers), $body);
+	}
+
+	/**
+	 * JSON-LD normalization loads the @context documents through
+	 * SignatureService::documentLoader, which reads them from the app data
+	 * folder. Serve the copies shipped in context/ so nothing hits the network.
+	 */
+	private function registerContextCache(): void {
+		$folder = $this->createMock(ISimpleFolder::class);
+		$folder->method('getFile')->willReturnCallback(function (string $name) {
+			$path = __DIR__ . '/../../context/' . $name;
+			if (!is_file($path)) {
+				throw new NotFoundException($name);
+			}
+			$file = $this->createMock(ISimpleFile::class);
+			$file->method('getMTime')->willReturn(time());
+			$file->method('getContent')->willReturn(file_get_contents($path));
+
+			return $file;
+		});
+		$appData = $this->createMock(IAppData::class);
+		$appData->method('getFolder')->with('context')->willReturn($folder);
+		$factory = $this->createMock(IAppDataFactory::class);
+		$factory->method('get')->with('social')->willReturn($appData);
+		\OC::$server->register(IAppDataFactory::class, $factory);
+	}
+
+	private function note(): Note {
+		$note = new Note();
+		$note->setId('https://cloud.example.com/apps/social/@alice/1');
+		$note->setActorId(self::LOCAL_ACTOR);
+		$note->setAttributedTo(self::LOCAL_ACTOR);
+		$note->setContent('<p>Hello fediverse</p>');
+		$note->setPublished('2026-09-07T10:00:00Z');
+		$note->setTo(ACore::CONTEXT_PUBLIC);
+
+		return $note;
+	}
+
+	public function testSignObjectAttachesAnRsaSignature2017(): void {
+		$this->registerContextCache();
+		$actor = $this->person(self::LOCAL_ACTOR, self::$publicKey, self::$privateKey);
+		$note = $this->note();
+
+		$this->service->signObject($actor, $note);
+
+		$this->assertTrue($note->hasSignature());
+		$signature = $note->getSignature();
+		$this->assertSame('RsaSignature2017', $signature->getType());
+		$this->assertSame(self::LOCAL_ACTOR . '#main-key', $signature->getCreator());
+		$this->assertNotFalse(DateTime::createFromFormat(SignatureService::DATE_OBJECT, $signature->getCreated()));
+		$this->assertNotSame('', $signature->getSignatureValue());
+		$this->assertNotFalse(base64_decode($signature->getSignatureValue(), true));
+
+		$json = json_decode(json_encode($note), true);
+		$this->assertContains(ACore::CONTEXT_SECURITY, $json['@context']);
+		$this->assertSame($signature->getSignatureValue(), $json['signature']['signatureValue']);
+	}
+
+	public function testCheckObjectVerifiesASignedObjectAndStampsItsOrigin(): void {
+		$this->registerContextCache();
+		$signed = $this->note();
+		$this->service->signObject($this->person(self::LOCAL_ACTOR, self::$publicKey, self::$privateKey), $signed);
+		$received = new Note();
+		$received->setSource(json_encode($signed, JSON_UNESCAPED_SLASHES));
+		$received->setActorId(self::LOCAL_ACTOR);
+		$this->cacheActorService->expects($this->once())
+			->method('getFromId')
+			->with(self::LOCAL_ACTOR, false)
+			->willReturn($this->person(self::LOCAL_ACTOR, self::$publicKey));
+
+		$this->assertTrue($this->service->checkObject($received));
+		$this->assertSame(self::CLOUD_HOST, $received->getOrigin());
+		$this->assertSame(SignatureService::ORIGIN_SIGNATURE, $received->getOriginSource());
+		$this->assertSame((new DateTime($signed->getSignature()->getCreated()))->getTimestamp(), $received->getOriginCreationTime());
+	}
+
+	public function testCheckObjectRejectsATamperedObjectAfterRefreshingTheKey(): void {
+		$this->registerContextCache();
+		$signed = $this->note();
+		$this->service->signObject($this->person(self::LOCAL_ACTOR, self::$publicKey, self::$privateKey), $signed);
+		$json = json_decode(json_encode($signed, JSON_UNESCAPED_SLASHES), true);
+		$json['content'] = '<p>Tampered</p>';
+		$received = new Note();
+		$received->setSource(json_encode($json, JSON_UNESCAPED_SLASHES));
+		$received->setActorId(self::LOCAL_ACTOR);
+		$this->cacheActorService->expects($this->exactly(2))
+			->method('getFromId')
+			->withConsecutive([self::LOCAL_ACTOR, false], [self::LOCAL_ACTOR, true])
+			->willReturn($this->person(self::LOCAL_ACTOR, self::$publicKey));
+
+		$this->assertFalse($this->service->checkObject($received));
+		$this->assertSame('', $received->getOrigin());
+	}
+
+	public function testCheckObjectRejectsASignatureFromAnotherKey(): void {
+		$this->registerContextCache();
+		$signed = $this->note();
+		$this->service->signObject($this->person(self::LOCAL_ACTOR, self::$publicKey, self::$privateKey), $signed);
+		$received = new Note();
+		$received->setSource(json_encode($signed, JSON_UNESCAPED_SLASHES));
+		$received->setActorId(self::LOCAL_ACTOR);
+		$this->cacheActorService->method('getFromId')->willReturn($this->person(self::LOCAL_ACTOR, self::$otherPublicKey));
+
+		$this->assertFalse($this->service->checkObject($received));
+	}
+
+	public function testCheckObjectWithoutSignatureIsFalse(): void {
+		$received = $this->note();
+		$received->setSource(json_encode($received, JSON_UNESCAPED_SLASHES));
+		$this->cacheActorService->expects($this->never())->method('getFromId');
+
+		$this->assertFalse($this->service->checkObject($received));
+	}
+}

--- a/tests/Service/StreamActionServiceTest.php
+++ b/tests/Service/StreamActionServiceTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use OCA\Social\Db\StreamActionsRequest;
+use OCA\Social\Exceptions\StreamActionDoesNotExistException;
+use OCA\Social\Model\StreamAction;
+use OCA\Social\Service\MiscService;
+use OCA\Social\Service\StreamActionService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class StreamActionServiceTest extends TestCase {
+	private const ACTOR = 'https://cloud.example.com/apps/social/@alice';
+	private const STREAM = 'https://remote.example/notes/1';
+
+	private StreamActionsRequest|MockObject $streamActionsRequest;
+	private StreamActionService $service;
+
+	protected function setUp(): void {
+		$this->streamActionsRequest = $this->createMock(StreamActionsRequest::class);
+		$this->service = new StreamActionService($this->streamActionsRequest, $this->createMock(MiscService::class));
+	}
+
+	public function testSetActionUpdatesAnExistingRow(): void {
+		$existing = new StreamAction(self::ACTOR, self::STREAM);
+		$existing->setId(12);
+		$this->streamActionsRequest->method('getAction')
+			->with(self::ACTOR, self::STREAM)
+			->willReturn($existing);
+		$this->streamActionsRequest->expects($this->once())
+			->method('update')
+			->with($this->identicalTo($existing))
+			->willReturn(1);
+		$this->streamActionsRequest->expects($this->never())->method('create');
+
+		$this->service->setAction(self::ACTOR, self::STREAM, 'note', 'hello');
+
+		$this->assertSame('hello', $existing->getValue('note'));
+		$this->assertSame([], $existing->getAffected(), 'unknown keys are not tracked as affected');
+	}
+
+	public function testSetActionCreatesTheRowWhenNoneExists(): void {
+		$this->streamActionsRequest->method('getAction')
+			->willThrowException(new StreamActionDoesNotExistException());
+		$this->streamActionsRequest->method('update')->willReturn(0);
+		$created = null;
+		$this->streamActionsRequest->expects($this->once())
+			->method('create')
+			->willReturnCallback(function (StreamAction $action) use (&$created) {
+				$created = $action;
+			});
+
+		$this->service->setAction(self::ACTOR, self::STREAM, StreamAction::LIKED, '1');
+
+		$this->assertSame(self::ACTOR, $created->getActorId());
+		$this->assertSame(self::STREAM, $created->getStreamId());
+		$this->assertSame('1', $created->getValue(StreamAction::LIKED));
+		$this->assertSame([StreamAction::LIKED], $created->getAffected());
+	}
+
+	public function testSetActionCreatesWhenTheUpdateTouchedNoRow(): void {
+		$existing = new StreamAction(self::ACTOR, self::STREAM);
+		$this->streamActionsRequest->method('getAction')->willReturn($existing);
+		$this->streamActionsRequest->method('update')->willReturn(0);
+		$this->streamActionsRequest->expects($this->once())
+			->method('create')
+			->with($this->identicalTo($existing));
+
+		$this->service->setAction(self::ACTOR, self::STREAM, StreamAction::REPLIED, 'yes');
+	}
+
+	public function testSetActionIntStoresAnInteger(): void {
+		$this->streamActionsRequest->method('getAction')
+			->willThrowException(new StreamActionDoesNotExistException());
+		$this->streamActionsRequest->method('update')->willReturn(1);
+		$this->streamActionsRequest->expects($this->once())
+			->method('update')
+			->with($this->callback(function (StreamAction $action) {
+				$this->assertSame(3, $action->getValueInt('count'));
+
+				return true;
+			}));
+
+		$this->service->setActionInt(self::ACTOR, self::STREAM, 'count', 3);
+	}
+
+	public function testSetActionBoolTracksAcceptedKeysAsAffected(): void {
+		$this->streamActionsRequest->method('getAction')
+			->willThrowException(new StreamActionDoesNotExistException());
+		$this->streamActionsRequest->expects($this->once())
+			->method('update')
+			->with($this->callback(function (StreamAction $action) {
+				$this->assertTrue($action->getValueBool(StreamAction::BOOSTED));
+				$this->assertSame([StreamAction::BOOSTED], $action->getAffected());
+
+				return true;
+			}))
+			->willReturn(1);
+
+		$this->service->setActionBool(self::ACTOR, self::STREAM, StreamAction::BOOSTED, true);
+	}
+}

--- a/tests/Service/StreamQueueServiceTest.php
+++ b/tests/Service/StreamQueueServiceTest.php
@@ -1,0 +1,301 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use OCA\Social\AP;
+use OCA\Social\Db\StreamQueueRequest;
+use OCA\Social\Db\StreamRequest;
+use OCA\Social\Exceptions\QueueStatusException;
+use OCA\Social\Exceptions\StreamNotFoundException;
+use OCA\Social\Interfaces\Object\NoteInterface;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Model\StreamQueue;
+use OCA\Social\Service\CacheActorService;
+use OCA\Social\Service\CurlService;
+use OCA\Social\Service\ImportService;
+use OCA\Social\Service\MiscService;
+use OCA\Social\Service\SignatureService;
+use OCA\Social\Service\StreamQueueService;
+use OCA\Social\Tools\Exceptions\RequestContentException;
+use OCA\Social\Tools\Exceptions\RequestNetworkException;
+use OCA\Social\Tools\Model\Cache;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class StreamQueueServiceTest extends TestCase {
+	private const STREAM_ID = 'https://cloud.example.com/apps/social/@alice/1';
+	private const REPLY_URL = 'https://remote.example/notes/99';
+	private const BOB = 'https://remote.example/users/bob';
+
+	private StreamRequest|MockObject $streamRequest;
+	private StreamQueueRequest|MockObject $streamQueueRequest;
+	private CacheActorService|MockObject $cacheActorService;
+	private CurlService|MockObject $curlService;
+	private MiscService|MockObject $miscService;
+	private AP|MockObject $ap;
+	private StreamQueueService $service;
+
+	protected function setUp(): void {
+		$this->streamRequest = $this->createMock(StreamRequest::class);
+		$this->streamQueueRequest = $this->createMock(StreamQueueRequest::class);
+		$this->cacheActorService = $this->createMock(CacheActorService::class);
+		$this->curlService = $this->createMock(CurlService::class);
+		$this->miscService = $this->createMock(MiscService::class);
+		$this->ap = $this->createMock(AP::class);
+		AP::$activityPub = $this->ap;
+
+		$this->service = new StreamQueueService(
+			$this->streamRequest,
+			$this->streamQueueRequest,
+			$this->cacheActorService,
+			$this->createMock(ImportService::class),
+			$this->curlService,
+			$this->miscService,
+		);
+	}
+
+	protected function tearDown(): void {
+		AP::$activityPub = null;
+	}
+
+	private function queue(string $type = StreamQueue::TYPE_CACHE): StreamQueue {
+		return new StreamQueue('tok', $type, self::STREAM_ID);
+	}
+
+	/** A local note whose cache is waiting for one remote reply. */
+	private function streamWithCache(): Note {
+		$note = new Note();
+		$note->setId(self::STREAM_ID);
+		$note->addCacheItem(self::REPLY_URL);
+
+		return $note;
+	}
+
+	public function testGenerateStreamQueueCreatesAStandbyEntry(): void {
+		$this->streamQueueRequest->expects($this->once())
+			->method('create')
+			->with($this->callback(function (StreamQueue $queue) {
+				$this->assertSame('tok', $queue->getToken());
+				$this->assertSame(StreamQueue::TYPE_CACHE, $queue->getType());
+				$this->assertSame(self::STREAM_ID, $queue->getStreamId());
+				$this->assertSame(StreamQueue::STATUS_STANDBY, $queue->getStatus());
+
+				return true;
+			}));
+
+		$this->service->generateStreamQueue('tok', StreamQueue::TYPE_CACHE, self::STREAM_ID);
+	}
+
+	public function testGetRequestStandbyAppliesTheRetryBackoff(): void {
+		$now = time();
+		$fresh = $this->queue()->setTries(0)->setLast($now - 1);
+		$recent = $this->queue()->setTries(3)->setLast($now - 10); // delay 27s
+		$old = $this->queue()->setTries(3)->setLast($now - 60);
+		$this->streamQueueRequest->method('getStandby')->willReturn([$fresh, $recent, $old]);
+
+		$total = 0;
+		$ready = $this->service->getRequestStandby($total);
+
+		$this->assertSame(3, $total);
+		$this->assertSame([$fresh, $old], $ready);
+	}
+
+	public function testManageStreamQueueStopsWhenTheEntryIsAlreadyRunning(): void {
+		$this->streamQueueRequest->method('setAsRunning')->willThrowException(new QueueStatusException());
+		$this->streamRequest->expects($this->never())->method('getStreamById');
+		$this->streamQueueRequest->expects($this->never())->method('delete');
+
+		$this->service->manageStreamQueue($this->queue());
+	}
+
+	public function testUnknownQueueTypesAreDropped(): void {
+		$queue = $this->queue('Signature');
+		$this->streamQueueRequest->expects($this->once())->method('setAsRunning');
+		$this->streamQueueRequest->expects($this->once())->method('delete')->with($this->identicalTo($queue));
+		$this->streamRequest->expects($this->never())->method('getStreamById');
+
+		$this->service->manageStreamQueue($queue);
+	}
+
+	public function testCacheEntryForAMissingStreamIsDropped(): void {
+		$queue = $this->queue();
+		$this->streamRequest->method('getStreamById')->with(self::STREAM_ID)->willThrowException(new StreamNotFoundException());
+		$this->streamQueueRequest->expects($this->once())->method('delete')->with($this->identicalTo($queue));
+
+		$this->service->manageStreamQueue($queue);
+	}
+
+	public function testCacheEntryForAStreamWithoutCacheIsDropped(): void {
+		$queue = $this->queue();
+		$note = new Note();
+		$note->setId(self::STREAM_ID);
+		$this->streamRequest->method('getStreamById')->willReturn($note);
+		$this->streamQueueRequest->expects($this->once())->method('delete')->with($this->identicalTo($queue));
+		$this->streamQueueRequest->expects($this->never())->method('setAsSuccess');
+
+		$this->service->manageStreamQueue($queue);
+	}
+
+	public function testAlreadyKnownReplyIsCachedFromTheDatabase(): void {
+		$queue = $this->queue();
+		$stream = $this->streamWithCache();
+		$reply = new Note();
+		$reply->setId(self::REPLY_URL);
+		$reply->setContent('a reply');
+		$this->streamRequest->method('getStreamById')
+			->willReturnCallback(fn (string $id) => $id === self::STREAM_ID ? $stream : $reply);
+		$this->curlService->expects($this->never())->method('retrieveObject');
+
+		$updatedCache = null;
+		$this->streamRequest->expects($this->once())
+			->method('updateCache')
+			->willReturnCallback(function (Note $s, Cache $cache) use (&$updatedCache) {
+				$updatedCache = $cache;
+			});
+		$noteInterface = $this->createMock(NoteInterface::class);
+		$noteInterface->expects($this->once())->method('event')->with($this->identicalTo($stream), 'updateCache');
+		$this->ap->method('getInterfaceForItem')->with($this->identicalTo($stream))->willReturn($noteInterface);
+		$this->streamQueueRequest->expects($this->once())->method('setAsSuccess')->with($this->identicalTo($queue));
+		$this->streamQueueRequest->expects($this->never())->method('setAsFailure');
+
+		$this->service->manageStreamQueue($queue);
+
+		$item = $updatedCache->getItem(self::REPLY_URL);
+		$this->assertSame(StreamQueue::STATUS_SUCCESS, $item->getStatus());
+		$this->assertSame(json_encode($reply, JSON_UNESCAPED_SLASHES), $item->getContent());
+	}
+
+	public function testUnknownReplyIsFetchedValidatedAndSaved(): void {
+		$queue = $this->queue();
+		$stream = $this->streamWithCache();
+		$fetched = new Note();
+		$fetched->setId(self::REPLY_URL);
+		$fetched->setAttributedTo(self::BOB);
+		$saved = false;
+		$this->streamRequest->method('getStreamById')
+			->willReturnCallback(function (string $id) use ($stream, $fetched, &$saved) {
+				if ($id === self::STREAM_ID) {
+					return $stream;
+				}
+				if (!$saved) {
+					throw new StreamNotFoundException();
+				}
+
+				return $fetched;
+			});
+		$this->curlService->expects($this->once())
+			->method('retrieveObject')
+			->with(self::REPLY_URL)
+			->willReturn(['id' => self::REPLY_URL, 'type' => 'Note']);
+		$this->ap->method('getItemFromData')->with(['id' => self::REPLY_URL, 'type' => 'Note'])->willReturn($fetched);
+		$this->cacheActorService->expects($this->once())->method('getFromId')->with(self::BOB)->willReturn(new Person());
+		$noteInterface = $this->createMock(NoteInterface::class);
+		$noteInterface->expects($this->once())
+			->method('save')
+			->with($this->identicalTo($fetched))
+			->willReturnCallback(function () use (&$saved) {
+				$saved = true;
+			});
+		$this->ap->method('getInterfaceForItem')->willReturn($noteInterface);
+		$this->streamQueueRequest->expects($this->once())->method('setAsSuccess');
+
+		$this->service->manageStreamQueue($queue);
+
+		$this->assertSame('remote.example', $fetched->getOrigin());
+		$this->assertSame(SignatureService::ORIGIN_REQUEST, $fetched->getOriginSource());
+	}
+
+	public function testReplyWithMismatchingIdIsRemovedFromTheCache(): void {
+		$queue = $this->queue();
+		$stream = $this->streamWithCache();
+		$fetched = new Note();
+		$fetched->setId('https://remote.example/notes/other');
+		$this->streamRequest->method('getStreamById')
+			->willReturnCallback(function (string $id) use ($stream) {
+				if ($id === self::STREAM_ID) {
+					return $stream;
+				}
+				throw new StreamNotFoundException();
+			});
+		$this->curlService->method('retrieveObject')->willReturn(['id' => 'x']);
+		$this->ap->method('getItemFromData')->willReturn($fetched);
+		$this->ap->method('getInterfaceForItem')->willReturn($this->createMock(NoteInterface::class));
+		$this->miscService->expects($this->once())
+			->method('log')
+			->with($this->stringContains('InvalidOriginException'), 1);
+		$updatedCache = null;
+		$this->streamRequest->method('updateCache')
+			->willReturnCallback(function (Note $s, Cache $cache) use (&$updatedCache) {
+				$updatedCache = $cache;
+			});
+		// nothing left to cache: the queue entry is complete
+		$this->streamQueueRequest->expects($this->once())->method('setAsSuccess');
+
+		$this->service->manageStreamQueue($queue);
+
+		$this->assertFalse($updatedCache->hasItem(self::REPLY_URL));
+	}
+
+	public function testGoneReplyIsRemovedFromTheCache(): void {
+		$queue = $this->queue();
+		$stream = $this->streamWithCache();
+		$this->streamRequest->method('getStreamById')
+			->willReturnCallback(function (string $id) use ($stream) {
+				if ($id === self::STREAM_ID) {
+					return $stream;
+				}
+				throw new StreamNotFoundException();
+			});
+		$this->curlService->method('retrieveObject')->willThrowException(new RequestContentException('gone', 410));
+		$this->ap->method('getInterfaceForItem')->willReturn($this->createMock(NoteInterface::class));
+		$this->miscService->expects($this->once())->method('log')->with($this->stringContains('RequestContentException'), 1);
+		$this->streamQueueRequest->expects($this->once())->method('setAsSuccess');
+
+		$this->service->manageStreamQueue($queue);
+
+		$this->assertFalse($stream->getCache()->hasItem(self::REPLY_URL));
+	}
+
+	public function testNetworkErrorKeepsTheItemAndMarksTheEntryFailed(): void {
+		$queue = $this->queue();
+		$stream = $this->streamWithCache();
+		$this->streamRequest->method('getStreamById')
+			->willReturnCallback(function (string $id) use ($stream) {
+				if ($id === self::STREAM_ID) {
+					return $stream;
+				}
+				throw new StreamNotFoundException();
+			});
+		$this->curlService->method('retrieveObject')->willThrowException(new RequestNetworkException('timeout'));
+		$this->ap->method('getInterfaceForItem')->willReturn($this->createMock(NoteInterface::class));
+		$this->streamRequest->expects($this->once())->method('updateCache');
+		$this->streamQueueRequest->expects($this->once())->method('setAsFailure')->with($this->identicalTo($queue));
+		$this->streamQueueRequest->expects($this->never())->method('setAsSuccess');
+
+		$this->service->manageStreamQueue($queue);
+
+		$item = $stream->getCache()->getItem(self::REPLY_URL);
+		$this->assertSame(1, $item->getError());
+		$this->assertNotSame(StreamQueue::STATUS_SUCCESS, $item->getStatus());
+	}
+
+	public function testCacheStreamByTokenProcessesEveryEntry(): void {
+		$first = $this->queue('Unknown');
+		$second = $this->queue('Unknown');
+		$this->streamQueueRequest->method('getFromToken')->with('tok')->willReturn([$first, $second]);
+		$this->streamQueueRequest->expects($this->exactly(2))->method('setAsRunning');
+		$this->streamQueueRequest->expects($this->exactly(2))
+			->method('delete')
+			->withConsecutive([$this->identicalTo($first)], [$this->identicalTo($second)]);
+
+		$this->service->cacheStreamByToken('tok');
+	}
+}

--- a/tests/Service/StreamServiceTest.php
+++ b/tests/Service/StreamServiceTest.php
@@ -1,0 +1,828 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use DateTime;
+use OCA\Social\Db\StreamRequest;
+use OCA\Social\Exceptions\CacheActorDoesNotExistException;
+use OCA\Social\Exceptions\SocialAppConfigException;
+use OCA\Social\Exceptions\StreamNotFoundException;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Announce;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Model\ActivityPub\Stream;
+use OCA\Social\Model\Client\Options\ProbeOptions;
+use OCA\Social\Model\InstancePath;
+use OCA\Social\Service\ActivityService;
+use OCA\Social\Service\CacheActorService;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\CurlService;
+use OCA\Social\Service\StreamService;
+use OCA\Social\Tools\Exceptions\RequestNetworkException;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class StreamServiceTest extends TestCase {
+	private const SOCIAL_URL = 'https://social.example/';
+	private const ACTOR_ID = 'https://social.example/@alice';
+	private const ACTOR_FOLLOWERS = 'https://social.example/@alice/followers';
+	private const GENERATED_ID = 'https://social.example/@alice/1234567890';
+
+	private StreamRequest|MockObject $streamRequest;
+	private ActivityService|MockObject $activityService;
+	private CacheActorService|MockObject $cacheActorService;
+	private ConfigService|MockObject $configService;
+	private CurlService|MockObject $curlService;
+	private StreamService $service;
+
+	protected function setUp(): void {
+		$this->streamRequest = $this->createMock(StreamRequest::class);
+		$this->activityService = $this->createMock(ActivityService::class);
+		$this->cacheActorService = $this->createMock(CacheActorService::class);
+		$this->configService = $this->createMock(ConfigService::class);
+		$this->curlService = $this->createMock(CurlService::class);
+
+		$this->configService->method('generateId')->willReturn(self::GENERATED_ID);
+		$this->configService->method('getSocialUrl')->willReturn(self::SOCIAL_URL);
+
+		$this->service = new StreamService(
+			$this->createMock(IURLGenerator::class),
+			$this->streamRequest,
+			$this->activityService,
+			$this->cacheActorService,
+			$this->configService,
+			$this->curlService,
+			new NullLogger()
+		);
+	}
+
+	private function actor(): Person {
+		$actor = new Person();
+		$actor->setId(self::ACTOR_ID);
+		$actor->setPreferredUsername('alice');
+		$actor->setFollowers(self::ACTOR_FOLLOWERS);
+		$actor->setInbox(self::ACTOR_ID . '/inbox');
+		$actor->setOutbox(self::ACTOR_ID . '/outbox');
+		$actor->setLocal(true);
+
+		return $actor;
+	}
+
+	private function remoteActor(string $id = 'https://remote.example/users/bob'): Person {
+		$actor = new Person();
+		$actor->setId($id);
+		$actor->setPreferredUsername('bob');
+		$actor->setAccount('bob@remote.example');
+		$actor->setInbox($id . '/inbox');
+		$actor->setSharedInbox('https://remote.example/inbox');
+		$actor->setFollowers($id . '/followers');
+		$actor->setOutbox($id . '/outbox');
+
+		return $actor;
+	}
+
+	private function note(string $id, string $attributedTo = self::ACTOR_ID, string $inReplyTo = ''): Note {
+		$note = new Note();
+		$note->setId($id);
+		$note->setAttributedTo($attributedTo);
+		$note->setInReplyTo($inReplyTo);
+
+		return $note;
+	}
+
+	/**
+	 * @param InstancePath[] $paths
+	 */
+	private function assertHasInstancePath(array $paths, string $uri, int $type, int $priority): void {
+		foreach ($paths as $path) {
+			if ($path->getUri() === $uri && $path->getType() === $type && $path->getPriority() === $priority) {
+				$this->addToAssertionCount(1);
+
+				return;
+			}
+		}
+
+		$this->fail('No instance path for ' . $uri . ' (type ' . $type . ', priority ' . $priority . ') in ' . json_encode($paths));
+	}
+
+
+	// assignItem() / assignStream()
+
+	public function testAssignItemGeneratesIdFromActorAndMarksItemLocal(): void {
+		$this->configService->expects($this->once())
+			->method('generateId')
+			->with('@alice');
+
+		$note = new Note();
+		$this->service->assignItem($note, $this->actor(), Stream::TYPE_PUBLIC);
+
+		$this->assertSame(self::GENERATED_ID, $note->getId());
+		$this->assertTrue($note->isLocal());
+		$this->assertNotSame('', $note->getPublished());
+		$this->assertEqualsWithDelta(time(), (new DateTime($note->getPublished()))->getTimestamp(), 5);
+		// Stream items also get their numeric publication time
+		$this->assertEqualsWithDelta(time(), $note->getPublishedTime(), 5);
+	}
+
+	public function testAssignItemOnNonStreamItemDoesNotNeedAStream(): void {
+		$announce = new Announce();
+		$this->service->assignItem($announce, $this->actor(), Stream::TYPE_ANNOUNCE);
+
+		$this->assertTrue($announce->isLocal());
+		$this->assertSame(self::GENERATED_ID, $announce->getId());
+	}
+
+	public function testAssignStreamConvertsPublishedDateToTimestamp(): void {
+		$note = new Note();
+		$note->setPublished('2026-01-02T03:04:05+00:00');
+
+		$this->service->assignStream($note);
+
+		$this->assertSame((new DateTime('2026-01-02T03:04:05+00:00'))->getTimestamp(), $note->getPublishedTime());
+	}
+
+	/**
+	 * @return array<string, array{string, string, string[], bool, bool}>
+	 */
+	public function visibilityProvider(): array {
+		return [
+			'public: as:Public in to, followers in cc' => [
+				Stream::TYPE_PUBLIC, ACore::CONTEXT_PUBLIC, [self::ACTOR_FOLLOWERS], true, true,
+			],
+			'unlisted: followers in to, as:Public in cc' => [
+				Stream::TYPE_UNLISTED, self::ACTOR_FOLLOWERS, [ACore::CONTEXT_PUBLIC], true, true,
+			],
+			'followers-only: followers in to, nobody in cc' => [
+				Stream::TYPE_FOLLOWERS, self::ACTOR_FOLLOWERS, [], false, true,
+			],
+			'direct: nobody addressed until mentions are added' => [
+				Stream::TYPE_DIRECT, '', [], false, false,
+			],
+			'announce: followers in cc only' => [
+				Stream::TYPE_ANNOUNCE, '', [self::ACTOR_FOLLOWERS], false, true,
+			],
+			'unknown type falls back to public' => [
+				'', ACore::CONTEXT_PUBLIC, [self::ACTOR_FOLLOWERS], true, true,
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider visibilityProvider
+	 */
+	public function testAssignItemAddressesRecipientsPerVisibility(
+		string $type,
+		string $expectedTo,
+		array $expectedCc,
+		bool $expectedPublic,
+		bool $expectFollowersPath,
+	): void {
+		$note = new Note();
+		$this->service->assignItem($note, $this->actor(), $type);
+
+		$this->assertSame($expectedTo, $note->getTo());
+		$this->assertSame([], $note->getToArray());
+		$this->assertSame($expectedCc, $note->getCcArray());
+		$this->assertSame($expectedPublic, $note->isPublic());
+
+		if ($expectFollowersPath) {
+			$this->assertCount(1, $note->getInstancePaths());
+			$this->assertHasInstancePath(
+				$note->getInstancePaths(), self::ACTOR_ID, InstancePath::TYPE_FOLLOWERS, InstancePath::PRIORITY_LOW
+			);
+		} else {
+			$this->assertSame([], $note->getInstancePaths());
+		}
+	}
+
+
+	// detectType()
+
+	public function testDetectTypeMarksPublicStreamsAsPublicTimeline(): void {
+		$note = new Note();
+		$note->setTo(ACore::CONTEXT_PUBLIC);
+
+		$this->cacheActorService->expects($this->never())->method('getFromId');
+
+		$this->service->detectType($note);
+
+		$this->assertSame(Stream::TYPE_PUBLIC, $note->getTimeline());
+		$this->assertSame(Note::TYPE, $note->getType());
+	}
+
+	public function testDetectTypeFindsPublicInToArrayToo(): void {
+		$note = new Note();
+		$note->setTo(self::ACTOR_FOLLOWERS);
+		$note->addToArray(ACore::CONTEXT_PUBLIC);
+
+		$this->service->detectType($note);
+
+		$this->assertSame(Stream::TYPE_PUBLIC, $note->getTimeline());
+	}
+
+
+	// addRecipient() / addRecipients()
+
+	public function testAddRecipientOnDirectMessageAddressesMentionedActorInTo(): void {
+		$bob = $this->remoteActor();
+		$this->cacheActorService->expects($this->once())
+			->method('getFromAccount')
+			->with('bob@remote.example', true)
+			->willReturn($bob);
+
+		$note = new Note();
+		$this->service->addRecipient($note, Stream::TYPE_DIRECT, 'bob@remote.example');
+
+		$this->assertSame([$bob->getId()], $note->getToArray());
+		$this->assertSame([], $note->getCcArray());
+		$this->assertTrue($note->isFilterDuplicate());
+		$this->assertSame(
+			[['type' => 'Mention', 'href' => $bob->getId(), 'name' => '@bob@remote.example']],
+			$note->getTags()
+		);
+		$this->assertCount(1, $note->getInstancePaths());
+		$this->assertHasInstancePath(
+			$note->getInstancePaths(), $bob->getInbox(), InstancePath::TYPE_INBOX, InstancePath::PRIORITY_HIGH
+		);
+	}
+
+	/**
+	 * @return array<string, array{string}>
+	 */
+	public function nonDirectTypeProvider(): array {
+		return [
+			'public' => [Stream::TYPE_PUBLIC],
+			'unlisted' => [Stream::TYPE_UNLISTED],
+			'followers' => [Stream::TYPE_FOLLOWERS],
+		];
+	}
+
+	/**
+	 * @dataProvider nonDirectTypeProvider
+	 */
+	public function testAddRecipientOnNonDirectPostAddressesMentionedActorInCc(string $type): void {
+		$bob = $this->remoteActor();
+		$this->cacheActorService->method('getFromAccount')->willReturn($bob);
+
+		$note = new Note();
+		$this->service->addRecipient($note, $type, 'bob@remote.example');
+
+		$this->assertSame([], $note->getToArray());
+		$this->assertSame([$bob->getId()], $note->getCcArray());
+		$this->assertFalse($note->isFilterDuplicate());
+		$this->assertSame('Mention', $note->getTags()[0]['type']);
+		$this->assertHasInstancePath(
+			$note->getInstancePaths(), $bob->getInbox(), InstancePath::TYPE_INBOX, InstancePath::PRIORITY_MEDIUM
+		);
+	}
+
+	public function testAddRecipientIgnoresEmptyAccount(): void {
+		$this->cacheActorService->expects($this->never())->method('getFromAccount');
+
+		$note = new Note();
+		$this->service->addRecipient($note, Stream::TYPE_PUBLIC, '');
+
+		$this->assertSame([], $note->getTags());
+		$this->assertSame([], $note->getInstancePaths());
+	}
+
+	public function testAddRecipientIgnoresUnresolvableAccount(): void {
+		$this->cacheActorService->method('getFromAccount')
+			->willThrowException(new CacheActorDoesNotExistException());
+
+		$note = new Note();
+		$this->service->addRecipient($note, Stream::TYPE_DIRECT, 'nobody@remote.example');
+
+		$this->assertSame([], $note->getToArray());
+		$this->assertSame([], $note->getCcArray());
+		$this->assertSame([], $note->getTags());
+		$this->assertSame([], $note->getInstancePaths());
+	}
+
+	public function testAddRecipientsResolvesEveryAccount(): void {
+		$bob = $this->remoteActor('https://remote.example/users/bob');
+		$carol = $this->remoteActor('https://other.example/users/carol');
+		$this->cacheActorService->expects($this->exactly(2))
+			->method('getFromAccount')
+			->willReturnMap([
+				['bob@remote.example', true, $bob],
+				['carol@other.example', true, $carol],
+			]);
+
+		$note = new Note();
+		$this->service->addRecipients($note, Stream::TYPE_PUBLIC, ['bob@remote.example', 'carol@other.example']);
+
+		$this->assertSame([$bob->getId(), $carol->getId()], $note->getCcArray());
+		$this->assertCount(2, $note->getTags('Mention'));
+		$this->assertCount(2, $note->getInstancePaths());
+	}
+
+
+	// addHashtag() / addHashtags()
+
+	public function testAddHashtagAddsLowercasedTagLink(): void {
+		$note = new Note();
+		$this->service->addHashtag($note, 'NextCloud');
+
+		$this->assertSame(
+			[['type' => 'Hashtag', 'href' => self::SOCIAL_URL . 'tag/nextcloud', 'name' => '#NextCloud']],
+			$note->getTags()
+		);
+	}
+
+	public function testAddHashtagsStoresListAndTagsEachEntry(): void {
+		$note = new Note();
+		$this->service->addHashtags($note, ['Fediverse', 'Nextcloud']);
+
+		$this->assertSame(['Fediverse', 'Nextcloud'], $note->getHashtags());
+		$this->assertCount(2, $note->getTags('Hashtag'));
+		$this->assertSame('#Fediverse', $note->getTags()[0]['name']);
+		$this->assertSame(self::SOCIAL_URL . 'tag/nextcloud', $note->getTags()[1]['href']);
+	}
+
+	public function testAddHashtagSkipsTagWhenSocialUrlIsNotConfigured(): void {
+		$configService = $this->createMock(ConfigService::class);
+		$configService->method('getSocialUrl')->willThrowException(new SocialAppConfigException());
+		$service = new StreamService(
+			$this->createMock(IURLGenerator::class),
+			$this->streamRequest,
+			$this->activityService,
+			$this->cacheActorService,
+			$configService,
+			$this->curlService,
+			new NullLogger()
+		);
+
+		$note = new Note();
+		$service->addHashtags($note, ['Nextcloud']);
+
+		$this->assertSame(['Nextcloud'], $note->getHashtags());
+		$this->assertSame([], $note->getTags());
+	}
+
+
+	// replyTo()
+
+	public function testReplyToWiresParentAndAddressesItsAuthor(): void {
+		$parentId = 'https://remote.example/notes/parent';
+		$bob = $this->remoteActor();
+		$this->streamRequest->expects($this->once())
+			->method('getStreamById')
+			->with($parentId)
+			->willReturn($this->note($parentId, $bob->getId()));
+		$this->cacheActorService->expects($this->once())
+			->method('getFromId')
+			->with($bob->getId())
+			->willReturn($bob);
+
+		$note = new Note();
+		$this->service->replyTo($note, $parentId);
+
+		$this->assertSame($parentId, $note->getInReplyTo());
+		$this->assertCount(1, $note->getInstancePaths());
+		$this->assertHasInstancePath(
+			$note->getInstancePaths(), $bob->getSharedInbox(), InstancePath::TYPE_INBOX, InstancePath::PRIORITY_HIGH
+		);
+	}
+
+	public function testReplyToWithoutParentIsANoop(): void {
+		$this->streamRequest->expects($this->never())->method('getStreamById');
+
+		$note = new Note();
+		$this->service->replyTo($note, '');
+
+		$this->assertSame('', $note->getInReplyTo());
+		$this->assertSame([], $note->getInstancePaths());
+	}
+
+	public function testReplyToUnknownParentFails(): void {
+		$this->streamRequest->method('getStreamById')->willThrowException(new StreamNotFoundException());
+		$this->cacheActorService->expects($this->never())->method('getFromId');
+
+		$note = new Note();
+		try {
+			$this->service->replyTo($note, 'https://remote.example/notes/missing');
+			$this->fail('expected StreamNotFoundException');
+		} catch (StreamNotFoundException $e) {
+			$this->assertSame('', $note->getInReplyTo());
+			$this->assertSame([], $note->getInstancePaths());
+		}
+	}
+
+
+	// deleteLocalItem()
+
+	public function testDeleteLocalItemFederatesDeleteAndRemovesRow(): void {
+		$item = $this->note('https://social.example/@alice/1');
+		$item->setLocal(true);
+
+		$this->cacheActorService->method('getFromId')->with(self::ACTOR_ID)->willReturn($this->actor());
+		$this->activityService->expects($this->once())
+			->method('deleteActivity')
+			->with($this->identicalTo($item))
+			->willReturn('token');
+		$this->streamRequest->expects($this->once())
+			->method('deleteById')
+			->with('https://social.example/@alice/1', Note::TYPE);
+
+		$this->service->deleteLocalItem($item, Note::TYPE);
+
+		$this->assertSame(self::ACTOR_ID, $item->getActorId());
+		$this->assertHasInstancePath(
+			$item->getInstancePaths(), self::ACTOR_ID, InstancePath::TYPE_FOLLOWERS, InstancePath::PRIORITY_LOW
+		);
+	}
+
+	public function testDeleteLocalItemStillDeletesWhenAuthorCannotBeResolved(): void {
+		$item = $this->note('https://social.example/@alice/1');
+		$item->setLocal(true);
+
+		$this->cacheActorService->method('getFromId')->willThrowException(new CacheActorDoesNotExistException());
+		$this->activityService->expects($this->once())->method('deleteActivity')->willReturn('token');
+		$this->streamRequest->expects($this->once())->method('deleteById')->with($item->getId(), '');
+
+		$this->service->deleteLocalItem($item);
+
+		$this->assertSame([], $item->getInstancePaths());
+	}
+
+	public function testDeleteLocalItemRefusesRemoteItems(): void {
+		$item = $this->note('https://remote.example/notes/1', 'https://remote.example/users/bob');
+		$item->setLocal(false);
+
+		$this->activityService->expects($this->never())->method('deleteActivity');
+		$this->streamRequest->expects($this->never())->method('deleteById');
+
+		$this->service->deleteLocalItem($item, Note::TYPE);
+
+		$this->assertSame('', $item->getActorId());
+	}
+
+
+	// lookups delegating to StreamRequest
+
+	public function testSetViewerIsPassedToStreamRequest(): void {
+		$viewer = $this->actor();
+		$this->streamRequest->expects($this->once())->method('setViewer')->with($this->identicalTo($viewer));
+
+		$this->service->setViewer($viewer);
+	}
+
+	public function testGetStreamByIdPassesViewerFlagAndFormat(): void {
+		$note = $this->note('https://social.example/@alice/1');
+		$this->streamRequest->expects($this->once())
+			->method('getStreamById')
+			->with('https://social.example/@alice/1', true, ACore::FORMAT_LOCAL)
+			->willReturn($note);
+
+		$this->assertSame($note, $this->service->getStreamById('https://social.example/@alice/1', true, ACore::FORMAT_LOCAL));
+	}
+
+	public function testGetStreamByIdDefaultsToActivityPubFormatWithoutViewer(): void {
+		$note = $this->note('https://social.example/@alice/1');
+		$this->streamRequest->expects($this->once())
+			->method('getStreamById')
+			->with('https://social.example/@alice/1', false, ACore::FORMAT_ACTIVITYPUB)
+			->willReturn($note);
+
+		$this->assertSame($note, $this->service->getStreamById('https://social.example/@alice/1'));
+	}
+
+	public function testGetStreamByNidDelegates(): void {
+		$note = $this->note('https://social.example/@alice/1');
+		$this->streamRequest->expects($this->once())->method('getStreamByNid')->with(42)->willReturn($note);
+
+		$this->assertSame($note, $this->service->getStreamByNid(42));
+	}
+
+	public function testGetStreamByNidPropagatesNotFound(): void {
+		$this->streamRequest->method('getStreamByNid')->willThrowException(new StreamNotFoundException());
+
+		$this->expectException(StreamNotFoundException::class);
+		$this->service->getStreamByNid(42);
+	}
+
+	public function testUpdateStreamDelegates(): void {
+		$note = $this->note('https://social.example/@alice/1');
+		$this->streamRequest->expects($this->once())->method('update')->with($this->identicalTo($note));
+
+		$this->service->updateStream($note);
+	}
+
+	public function testGetTimelinePassesProbeOptions(): void {
+		$options = new ProbeOptions();
+		$note = $this->note('https://social.example/@alice/1');
+		$this->streamRequest->expects($this->once())
+			->method('getTimeline')
+			->with($this->identicalTo($options))
+			->willReturn([$note]);
+
+		$this->assertSame([$note], $this->service->getTimeline($options));
+	}
+
+	/**
+	 * @return array<string, array{string, array, string, array}>
+	 */
+	public function timelineDelegationProvider(): array {
+		return [
+			'home' => ['getStreamHome', [10, 20, ACore::FORMAT_LOCAL], 'getTimelineHome_dep', [10, 20, ACore::FORMAT_LOCAL]],
+			'home defaults' => ['getStreamHome', [], 'getTimelineHome_dep', [0, 5, ACore::FORMAT_ACTIVITYPUB]],
+			'notifications' => ['getStreamNotifications', [10, 20], 'getTimelineNotifications_dep', [10, 20]],
+			'account' => ['getStreamAccount', ['https://remote.example/users/bob', 10, 20], 'getTimelineAccount_dep', ['https://remote.example/users/bob', 10, 20]],
+			'direct' => ['getStreamDirect', [10, 20], 'getTimelineDirect_dep', [10, 20]],
+			'local timeline restricts to local posts' => ['getStreamLocalTimeline', [10, 20], 'getTimelineGlobal_dep', [10, 20, true]],
+			'global timeline includes remote posts' => ['getStreamGlobalTimeline', [10, 20], 'getTimelineGlobal_dep', [10, 20, false]],
+			'tag' => ['getStreamLocalTag', ['nextcloud', 10, 20], 'getTimelineTag', ['nextcloud', 10, 20]],
+			'liked' => ['getStreamLiked', [10, 20], 'getTimelineLiked', [10, 20]],
+			'replies' => ['getRepliesByParentId', ['https://social.example/@alice/1', 10, 20, true], 'getRepliesByParentId', ['https://social.example/@alice/1', 10, 20, true]],
+			'replies defaults' => ['getRepliesByParentId', ['https://social.example/@alice/1'], 'getRepliesByParentId', ['https://social.example/@alice/1', 0, 5, false]],
+		];
+	}
+
+	/**
+	 * @dataProvider timelineDelegationProvider
+	 */
+	public function testTimelineGettersPassFiltersThrough(
+		string $serviceMethod,
+		array $args,
+		string $requestMethod,
+		array $expectedArgs,
+	): void {
+		$note = $this->note('https://social.example/@alice/1');
+		$this->streamRequest->expects($this->once())
+			->method($requestMethod)
+			->with(...$expectedArgs)
+			->willReturn([$note]);
+
+		$this->assertSame([$note], $this->service->$serviceMethod(...$args));
+	}
+
+	public function testInternalTimelineIsNotImplementedYet(): void {
+		$this->streamRequest->expects($this->never())->method($this->anything());
+
+		$this->assertSame([], $this->service->getStreamInternalTimeline(0, 20));
+	}
+
+
+	// getContextByNid()
+
+	public function testGetContextByNidCollectsAncestorsInThreadOrderAndDescendants(): void {
+		$post = $this->note('https://social.example/@alice/3', self::ACTOR_ID, 'https://social.example/@alice/2');
+		$parent = $this->note('https://social.example/@alice/2', self::ACTOR_ID, 'https://social.example/@alice/1');
+		$root = $this->note('https://social.example/@alice/1');
+		$reply = $this->note('https://social.example/@alice/4', self::ACTOR_ID, $post->getId());
+
+		$this->streamRequest->method('getStreamByNid')->with(3)->willReturn($post);
+		$this->streamRequest->expects($this->exactly(2))
+			->method('getStreamById')
+			->willReturnMap([
+				[$parent->getId(), true, ACore::FORMAT_ACTIVITYPUB, $parent],
+				[$root->getId(), true, ACore::FORMAT_ACTIVITYPUB, $root],
+			]);
+		$this->streamRequest->method('getDescendants')->with($post->getId())->willReturn([$reply]);
+
+		$context = $this->service->getContextByNid(3);
+
+		$this->assertSame([$root, $parent], $context['ancestors']);
+		$this->assertSame([$reply], $context['descendants']);
+		$this->assertSame(ACore::FORMAT_LOCAL, $root->getExportFormat());
+		$this->assertSame(ACore::FORMAT_LOCAL, $parent->getExportFormat());
+	}
+
+	public function testGetContextByNidStopsAtAncestorsTheViewerCannotSee(): void {
+		$post = $this->note('https://social.example/@alice/3', self::ACTOR_ID, 'https://social.example/@alice/2');
+		$this->streamRequest->method('getStreamByNid')->willReturn($post);
+		$this->streamRequest->method('getStreamById')->willThrowException(new StreamNotFoundException());
+		$this->streamRequest->method('getDescendants')->willReturn([]);
+
+		$context = $this->service->getContextByNid(3);
+
+		$this->assertSame(['ancestors' => [], 'descendants' => []], $context);
+	}
+
+	public function testGetContextByNidLimitsAncestorDepth(): void {
+		$post = $this->note('https://social.example/@alice/9', self::ACTOR_ID, 'https://social.example/@alice/8');
+		$this->streamRequest->method('getStreamByNid')->willReturn($post);
+		$this->streamRequest->method('getStreamById')->willReturnCallback(function (string $id): Note {
+			$n = (int)substr($id, -1);
+
+			return $this->note($id, self::ACTOR_ID, $n > 1 ? 'https://social.example/@alice/' . ($n - 1) : '');
+		});
+		$this->streamRequest->method('getDescendants')->willReturn([]);
+
+		$context = $this->service->getContextByNid(9);
+
+		$this->assertCount(5, $context['ancestors']);
+		$this->assertSame('https://social.example/@alice/4', $context['ancestors'][0]->getId());
+		$this->assertSame('https://social.example/@alice/8', $context['ancestors'][4]->getId());
+	}
+
+
+	// getAuthorFromPostId()
+
+	public function testGetAuthorFromPostIdResolvesAttributedActor(): void {
+		$bob = $this->remoteActor();
+		$this->streamRequest->method('getStreamById')
+			->with('https://remote.example/notes/1')
+			->willReturn($this->note('https://remote.example/notes/1', $bob->getId()));
+		$this->cacheActorService->expects($this->once())->method('getFromId')->with($bob->getId())->willReturn($bob);
+
+		$this->assertSame($bob, $this->service->getAuthorFromPostId('https://remote.example/notes/1'));
+	}
+
+	public function testGetAuthorFromPostIdFailsOnUnknownPost(): void {
+		$this->streamRequest->method('getStreamById')->willThrowException(new StreamNotFoundException());
+		$this->cacheActorService->expects($this->never())->method('getFromId');
+
+		$this->expectException(StreamNotFoundException::class);
+		$this->service->getAuthorFromPostId('https://remote.example/notes/missing');
+	}
+
+
+	// getOutboxCollection()
+
+	public function testGetOutboxCollectionDescribesActorOutbox(): void {
+		$actor = $this->actor();
+		$actor->setDetailArray('count', ['post' => 17, 'followers' => 3]);
+
+		$collection = $this->service->getOutboxCollection($actor);
+
+		$this->assertSame('OrderedCollection', $collection->getType());
+		$this->assertSame(self::ACTOR_ID . '/outbox', $collection->getId());
+		$this->assertSame(17, $collection->getTotalItems());
+		$this->assertSame(self::ACTOR_ID . '/outbox?page=1', $collection->getFirst());
+		$this->assertSame(self::ACTOR_ID . '/outbox?page=1&min_id=0', $collection->getLast());
+	}
+
+	public function testGetOutboxCollectionWithoutCountsIsEmpty(): void {
+		$collection = $this->service->getOutboxCollection($this->actor());
+
+		$this->assertSame(0, $collection->getTotalItems());
+	}
+
+
+	// syncRemoteTimeline()
+
+	public function testSyncRemoteTimelineIgnoresLocalActors(): void {
+		$this->curlService->expects($this->never())->method('retrieveObject');
+		$this->streamRequest->expects($this->never())->method('save');
+
+		$this->assertSame(0, $this->service->syncRemoteTimeline($this->actor()));
+	}
+
+	public function testSyncRemoteTimelineNeedsAnOutbox(): void {
+		$bob = $this->remoteActor();
+		$bob->setOutbox('');
+		$this->curlService->expects($this->never())->method('retrieveObject');
+
+		$this->assertSame(0, $this->service->syncRemoteTimeline($bob));
+	}
+
+	public function testSyncRemoteTimelineFollowsFirstPageAndStoresUnknownNotes(): void {
+		$bob = $this->remoteActor();
+		$noteData = [
+			'id' => 'https://remote.example/notes/new',
+			'type' => 'Note',
+			'url' => 'https://remote.example/@bob/new',
+			'attributedTo' => $bob->getId(),
+			'published' => '2026-01-02T03:04:05Z',
+			'content' => '<p>Hello #Fedi</p>',
+			'summary' => 'cw',
+			'sensitive' => true,
+			'inReplyTo' => 'https://remote.example/notes/0',
+			'conversation' => 'https://remote.example/contexts/1',
+			'to' => [ACore::CONTEXT_PUBLIC],
+			'cc' => $bob->getFollowers(),
+			'tag' => [
+				['type' => 'Hashtag', 'name' => '#Fedi', 'href' => 'https://remote.example/tags/fedi'],
+				['type' => 'Mention', 'name' => '@alice@social.example', 'href' => self::ACTOR_ID],
+			],
+			'likes' => ['totalItems' => 3],
+			'shares' => ['totalItems' => 2],
+			'replies' => ['totalItems' => 1],
+		];
+		$page = [
+			'type' => 'OrderedCollectionPage',
+			'orderedItems' => [
+				['type' => 'Create', 'object' => $noteData],
+				['type' => 'Note', 'id' => 'https://remote.example/notes/known', 'content' => 'already here'],
+				['type' => 'Announce', 'object' => 'https://other.example/notes/1'],
+				['type' => 'Note', 'content' => 'no id'],
+			],
+		];
+
+		$this->curlService->expects($this->exactly(2))
+			->method('retrieveObject')
+			->willReturnMap([
+				[$bob->getOutbox(), true, ['type' => 'OrderedCollection', 'first' => $bob->getOutbox() . '?page=true']],
+				[$bob->getOutbox() . '?page=true', true, $page],
+			]);
+		$this->streamRequest->method('getStreamById')->willReturnCallback(function (string $id): Stream {
+			if ($id === 'https://remote.example/notes/known') {
+				return $this->note($id);
+			}
+			throw new StreamNotFoundException();
+		});
+
+		$saved = null;
+		$this->streamRequest->expects($this->once())
+			->method('save')
+			->willReturnCallback(function (Stream $stream) use (&$saved): void {
+				$saved = $stream;
+			});
+
+		$this->assertSame(1, $this->service->syncRemoteTimeline($bob));
+
+		$this->assertInstanceOf(Note::class, $saved);
+		$this->assertSame('https://remote.example/notes/new', $saved->getId());
+		$this->assertSame('https://remote.example/@bob/new', $saved->getUrl());
+		$this->assertSame($bob->getId(), $saved->getAttributedTo());
+		$this->assertSame('<p>Hello #Fedi</p>', $saved->getContent());
+		$this->assertSame('cw', $saved->getSummary());
+		$this->assertTrue($saved->isSensitive());
+		$this->assertFalse($saved->isLocal());
+		$this->assertSame('https://remote.example/notes/0', $saved->getInReplyTo());
+		$this->assertSame('https://remote.example/contexts/1', $saved->getConversation());
+		$this->assertSame([ACore::CONTEXT_PUBLIC], $saved->getToArray());
+		$this->assertSame([$bob->getFollowers()], $saved->getCcArray());
+		$this->assertSame(['Fedi'], $saved->getHashtags());
+		$this->assertCount(2, $saved->getTags());
+		$this->assertSame((new DateTime('2026-01-02T03:04:05Z'))->getTimestamp(), $saved->getPublishedTime());
+		$this->assertSame(3, $saved->getDetailInt('likes'));
+		$this->assertSame(3, $saved->getDetailInt('remote_likes'));
+		$this->assertSame(2, $saved->getDetailInt('boosts'));
+		$this->assertSame(1, $saved->getDetailInt('replies'));
+		$this->assertSame($noteData, json_decode($saved->getSource(), true));
+	}
+
+	public function testSyncRemoteTimelineUsesEmbeddedFirstPage(): void {
+		$bob = $this->remoteActor();
+		$this->curlService->expects($this->once())
+			->method('retrieveObject')
+			->with($bob->getOutbox())
+			->willReturn([
+				'type' => 'OrderedCollection',
+				'first' => [
+					'items' => [
+						['type' => 'Note', 'id' => 'https://remote.example/notes/a', 'content' => 'a'],
+						['type' => 'Note', 'id' => 'https://remote.example/notes/b', 'content' => 'b'],
+					],
+				],
+			]);
+		$this->streamRequest->method('getStreamById')->willThrowException(new StreamNotFoundException());
+		$this->streamRequest->expects($this->exactly(2))->method('save');
+
+		$this->assertSame(2, $this->service->syncRemoteTimeline($bob));
+	}
+
+	public function testSyncRemoteTimelineFallsBackToActorForMissingAttribution(): void {
+		$bob = $this->remoteActor();
+		$this->curlService->method('retrieveObject')->willReturn([
+			'orderedItems' => [['type' => 'Note', 'id' => 'https://remote.example/notes/a', 'content' => 'a']],
+		]);
+		$this->streamRequest->method('getStreamById')->willThrowException(new StreamNotFoundException());
+		$this->streamRequest->expects($this->once())
+			->method('save')
+			->with($this->callback(fn (Stream $s): bool => $s->getAttributedTo() === $bob->getId()));
+
+		$this->assertSame(1, $this->service->syncRemoteTimeline($bob));
+	}
+
+	public function testSyncRemoteTimelineSwallowsNetworkFailures(): void {
+		$bob = $this->remoteActor();
+		$this->curlService->method('retrieveObject')->willThrowException(new RequestNetworkException());
+		$this->streamRequest->expects($this->never())->method('save');
+
+		$this->assertSame(0, $this->service->syncRemoteTimeline($bob));
+	}
+
+	public function testSyncRemoteTimelineKeepsGoingWhenOneItemFailsToSave(): void {
+		$bob = $this->remoteActor();
+		$this->curlService->method('retrieveObject')->willReturn([
+			'orderedItems' => [
+				['type' => 'Note', 'id' => 'https://remote.example/notes/a', 'content' => 'a'],
+				['type' => 'Note', 'id' => 'https://remote.example/notes/b', 'content' => 'b'],
+			],
+		]);
+		$this->streamRequest->method('getStreamById')->willThrowException(new StreamNotFoundException());
+		$this->streamRequest->expects($this->exactly(2))
+			->method('save')
+			->willReturnCallback(function (Stream $stream): void {
+				if ($stream->getId() === 'https://remote.example/notes/a') {
+					throw new \RuntimeException('db hiccup');
+				}
+			});
+
+		$this->assertSame(1, $this->service->syncRemoteTimeline($bob));
+	}
+}

--- a/tests/Service/TestServiceTest.php
+++ b/tests/Service/TestServiceTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use OCA\Social\AP;
+use OCA\Social\Exceptions\InvalidResourceException;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\CurlService;
+use OCA\Social\Service\MiscService;
+use OCA\Social\Service\TestService;
+use OCA\Social\Tools\Model\SimpleDataStore;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Only the input validation of TestService::testWebfinger() is covered here.
+ *
+ * The diagnostic steps themselves cannot run on PHP 8: OCA\Social\Model\Test
+ * never initialises SimpleDataStore::$data (its constructor skips
+ * parent::__construct()), so Test::aArray()/a() throw a TypeError as soon as
+ * the "actor-link" step records its result.
+ */
+class TestServiceTest extends TestCase {
+	private CurlService|MockObject $curlService;
+	private TestService $service;
+
+	protected function setUp(): void {
+		$this->curlService = $this->createMock(CurlService::class);
+		AP::$activityPub = $this->createMock(AP::class);
+		$this->service = new TestService(
+			$this->curlService,
+			$this->createMock(ConfigService::class),
+			$this->createMock(MiscService::class),
+		);
+	}
+
+	protected function tearDown(): void {
+		AP::$activityPub = null;
+	}
+
+	/** @return array<string, array{string}> */
+	public function invalidAccountProvider(): array {
+		return [
+			'no host' => ['bob'],
+			'leading at only' => ['@bob'],
+			'empty host' => ['bob@'],
+			'empty user' => ['@mastodon.example'],
+			'spaces' => ['bob smith@mastodon.example'],
+			'url instead of handle' => ['https://mastodon.example/users/bob'],
+			'empty' => [''],
+		];
+	}
+
+	/** @dataProvider invalidAccountProvider */
+	public function testRejectsAccountsThatAreNotAddressesBeforeAnyLookup(string $account): void {
+		$this->curlService->expects($this->never())->method('hostMeta');
+		$this->curlService->expects($this->never())->method('retrieveJson');
+		$store = new SimpleDataStore(['account' => $account]);
+
+		try {
+			$this->service->testWebfinger($store);
+			$this->fail('expected InvalidResourceException');
+		} catch (InvalidResourceException $e) {
+			$this->assertSame('account format is not valid', $e->getMessage());
+			$this->assertSame([], $store->gArray('tests'), 'no diagnostic step was recorded');
+		}
+	}
+
+	public function testAValidHandleReachesTheHostMetaLookupWithItsHost(): void {
+		// the leading @ is stripped and the host is what gets probed; the run
+		// itself cannot complete (see the class comment), so stop it right here
+		$this->curlService->expects($this->once())
+			->method('hostMeta')
+			->with('mastodon.example', ['https', 'http'])
+			->willThrowException(new \RuntimeException('stop here'));
+
+		$this->expectException(\RuntimeException::class);
+		$this->expectExceptionMessage('stop here');
+		$this->service->testWebfinger(new SimpleDataStore(['account' => '@bob@mastodon.example']));
+	}
+}

--- a/tests/Service/UpdateServiceTest.php
+++ b/tests/Service/UpdateServiceTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Service;
+
+use DateTime;
+use OCA\Social\Service\UpdateService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IGroupManager;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\Notification\IAction;
+use OCP\Notification\IManager as INotificationManager;
+use OCP\Notification\INotification;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class UpdateServiceTest extends TestCase {
+	private IUserManager|MockObject $userManager;
+	private IGroupManager|MockObject $groupManager;
+	private INotificationManager|MockObject $notificationManager;
+	private DateTime $now;
+	private UpdateService $service;
+
+	protected function setUp(): void {
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->notificationManager = $this->createMock(INotificationManager::class);
+		$this->now = new DateTime('2026-09-07 10:00:00');
+		$time = $this->createMock(ITimeFactory::class);
+		$time->method('getDateTime')->willReturn($this->now);
+
+		$this->service = new UpdateService($this->userManager, $this->groupManager, $time, $this->notificationManager);
+	}
+
+	private function user(string $uid): IUser|MockObject {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+
+		return $user;
+	}
+
+	/** A notification stub whose fluent setters return itself and that records what was set. */
+	private function notification(array &$calls): INotification|MockObject {
+		$notification = $this->createMock(INotification::class);
+		foreach (['setApp', 'setDateTime', 'setUser', 'setObject', 'setSubject', 'addAction'] as $method) {
+			$notification->method($method)->willReturnCallback(function (...$args) use ($notification, $method, &$calls) {
+				$calls[$method][] = $args;
+
+				return $notification;
+			});
+		}
+
+		return $notification;
+	}
+
+	public function testCreateNotificationFillsEveryField(): void {
+		$calls = [];
+		$this->notificationManager->method('createNotification')->willReturn($this->notification($calls));
+
+		$this->service->createNotification('alice', 'update_alpha3', ['k' => 'v']);
+
+		$this->assertSame([['social']], $calls['setApp']);
+		$this->assertSame([[$this->now]], $calls['setDateTime']);
+		$this->assertSame([['alice']], $calls['setUser']);
+		$this->assertSame([['update', 'update_alpha3']], $calls['setObject']);
+		$this->assertSame([['update_alpha3', ['k' => 'v']]], $calls['setSubject']);
+	}
+
+	public function testGenerateNotificationsForEveryUser(): void {
+		$this->userManager->method('search')->with('')->willReturn([$this->user('alice'), $this->user('bob')]);
+		$this->groupManager->expects($this->never())->method('isAdmin');
+		$calls = [];
+		$this->notificationManager->method('createNotification')
+			->willReturnCallback(function () use (&$calls) {
+				return $this->notification($calls);
+			});
+
+		$notifications = $this->service->generateNotifications(false, 'subject', []);
+
+		$this->assertCount(2, $notifications);
+		$this->assertSame([['alice'], ['bob']], $calls['setUser']);
+	}
+
+	public function testGenerateNotificationsForAdminsOnlyFiltersByGroupManager(): void {
+		$this->userManager->method('search')->willReturn([$this->user('alice'), $this->user('bob'), $this->user('carol')]);
+		$this->groupManager->method('isAdmin')->willReturnCallback(fn (string $uid) => $uid !== 'bob');
+		$calls = [];
+		$this->notificationManager->method('createNotification')
+			->willReturnCallback(function () use (&$calls) {
+				return $this->notification($calls);
+			});
+
+		$notifications = $this->service->generateNotifications(true, 'subject', []);
+
+		$this->assertCount(2, $notifications);
+		$this->assertSame([['alice'], ['carol']], $calls['setUser']);
+	}
+
+	public function testGenerateNotificationsWithoutUsersIsEmpty(): void {
+		$this->userManager->method('search')->willReturn([]);
+		$this->notificationManager->expects($this->never())->method('createNotification');
+
+		$this->assertSame([], $this->service->generateNotifications(true, 'subject', []));
+	}
+
+	public function testCheckUpdateStatusNotifiesAdminsWithAHelpLink(): void {
+		$this->userManager->method('search')->willReturn([$this->user('admin'), $this->user('bob')]);
+		$this->groupManager->method('isAdmin')->willReturnCallback(fn (string $uid) => $uid === 'admin');
+
+		$action = $this->createMock(IAction::class);
+		$action->expects($this->once())->method('setLabel')->with('help')->willReturnSelf();
+		$action->expects($this->once())
+			->method('setLink')
+			->with('https://help.nextcloud.com/t/social-alpha3-how-to-upgrade/85535', 'WEB')
+			->willReturnSelf();
+
+		$calls = [];
+		$notification = $this->notification($calls);
+		$notification->method('createAction')->willReturn($action);
+		$this->notificationManager->method('createNotification')->willReturn($notification);
+		$this->notificationManager->expects($this->once())
+			->method('notify')
+			->with($this->identicalTo($notification));
+
+		$this->service->checkUpdateStatus();
+
+		$this->assertSame([['admin']], $calls['setUser']);
+		$this->assertSame([['update_alpha3', []]], $calls['setSubject']);
+		$this->assertSame([[$action]], $calls['addAction']);
+	}
+}

--- a/tests/Tools/Model/CacheItemTest.php
+++ b/tests/Tools/Model/CacheItemTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Tools\Model;
+
+use OCA\Social\Tools\Model\CacheItem;
+use PHPUnit\Framework\TestCase;
+
+class CacheItemTest extends TestCase {
+	public function testConstructorStoresTheUrlWithEmptyDefaults(): void {
+		$item = new CacheItem('https://a.example/1');
+
+		$this->assertSame('https://a.example/1', $item->getUrl());
+		$this->assertSame('', $item->getContent());
+		$this->assertSame([], $item->getObject());
+		$this->assertSame(0, $item->getStatus());
+		$this->assertSame(0, $item->getError());
+		$this->assertSame(0, $item->getCreation());
+	}
+
+	public function testGetObjectDecodesJsonContentAndIgnoresGarbage(): void {
+		$item = new CacheItem('https://a.example/1');
+
+		$item->setContent('{"type":"Note","content":"hi"}');
+		$this->assertSame(['type' => 'Note', 'content' => 'hi'], $item->getObject());
+
+		$item->setContent('not json');
+		$this->assertSame([], $item->getObject());
+
+		$item->setContent('"a string"');
+		$this->assertSame([], $item->getObject());
+	}
+
+	public function testIncrementErrorCountsRetries(): void {
+		$item = new CacheItem('https://a.example/1');
+
+		$item->incrementError()->incrementError();
+		$this->assertSame(2, $item->getError());
+
+		$item->setError(0);
+		$this->assertSame(0, $item->getError());
+	}
+
+	public function testImportAndJsonSerializeRoundTrip(): void {
+		$item = new CacheItem('');
+
+		$item->import(['url' => 'https://a.example/1', 'content' => '{"a":1}', 'status' => '200', 'error' => '1', 'creation' => '1714564800']);
+
+		$this->assertSame([
+			'url' => 'https://a.example/1',
+			'content' => '{"a":1}',
+			'object' => ['a' => 1],
+			'status' => 200,
+			'error' => 1,
+			'creation' => 1714564800,
+		], $item->jsonSerialize());
+	}
+}

--- a/tests/Tools/Model/CacheTest.php
+++ b/tests/Tools/Model/CacheTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Tools\Model;
+
+use OCA\Social\Tools\Exceptions\CacheItemNotFoundException;
+use OCA\Social\Tools\Model\Cache;
+use OCA\Social\Tools\Model\CacheItem;
+use PHPUnit\Framework\TestCase;
+
+class CacheTest extends TestCase {
+	public function testANewCacheIsEmpty(): void {
+		$cache = new Cache();
+
+		$this->assertFalse($cache->hasItems());
+		$this->assertSame([], $cache->getItems());
+		$this->assertFalse($cache->hasItem('https://a.example/1'));
+	}
+
+	public function testAddItemSkipsEmptyUrlsAndDuplicates(): void {
+		$cache = new Cache();
+		$first = new CacheItem('https://a.example/1');
+
+		$cache->addItem(new CacheItem(''))
+			->addItem($first)
+			->addItem(new CacheItem('https://a.example/1'))
+			->addItem(new CacheItem('https://a.example/2'));
+
+		$this->assertTrue($cache->hasItems());
+		$this->assertCount(2, $cache->getItems());
+		$this->assertSame($first, $cache->getItem('https://a.example/1'));
+		$this->assertTrue($cache->hasItem('https://a.example/2'));
+	}
+
+	public function testGetItemThrowsForUnknownUrls(): void {
+		$this->expectException(CacheItemNotFoundException::class);
+
+		(new Cache())->getItem('https://a.example/missing');
+	}
+
+	public function testRemoveItemDropsOnlyThatUrl(): void {
+		$cache = new Cache();
+		$cache->addItem(new CacheItem('https://a.example/1'))
+			->addItem(new CacheItem('https://a.example/2'));
+
+		$cache->removeItem('https://a.example/1');
+		$cache->removeItem('https://a.example/unknown');
+
+		$this->assertFalse($cache->hasItem('https://a.example/1'));
+		$this->assertTrue($cache->hasItem('https://a.example/2'));
+		$this->assertCount(1, $cache->getItems());
+	}
+
+	public function testUpdateItemReplacesTheEntryWithTheSameUrl(): void {
+		$cache = new Cache();
+		$stale = (new CacheItem('https://a.example/1'))->setStatus(0);
+		$other = new CacheItem('https://a.example/2');
+		$cache->addItem($stale)->addItem($other);
+		$fresh = (new CacheItem('https://a.example/1'))->setStatus(200)->setContent('{"type":"Note"}');
+
+		$cache->updateItem($fresh);
+		$cache->updateItem(new CacheItem(''));
+
+		$this->assertSame($fresh, $cache->getItem('https://a.example/1'));
+		$this->assertSame([$fresh, $other], $cache->getItems(), 'order and the other entry are kept');
+	}
+
+	public function testJsonSerializeListsTheUrlsAndEmbedsEachItem(): void {
+		$cache = new Cache();
+		$item = (new CacheItem('https://a.example/1'))->setContent('{"type":"Note"}')->setStatus(200)->setCreation(1714564800);
+		$cache->addItem($item);
+
+		$json = $cache->jsonSerialize();
+
+		$this->assertSame(['https://a.example/1'], $json['_items']);
+		$this->assertSame(1, $json['_count']);
+		$this->assertSame($item, $json['https://a.example/1']);
+	}
+
+	public function testImportRebuildsTheCacheFromItsSerializedForm(): void {
+		$original = new Cache();
+		$first = (new CacheItem('https://a.example/1'))->setContent('{"type":"Note"}')->setStatus(200)->setCreation(1714564800);
+		$first->setError(1);
+		$original->addItem($first);
+		$original->addItem((new CacheItem('https://a.example/2'))->setStatus(404));
+
+		$restored = new Cache();
+		$restored->import(json_decode(json_encode($original), true));
+
+		$this->assertCount(2, $restored->getItems());
+		$first = $restored->getItem('https://a.example/1');
+		$this->assertSame('{"type":"Note"}', $first->getContent());
+		$this->assertSame(['type' => 'Note'], $first->getObject());
+		$this->assertSame(200, $first->getStatus());
+		$this->assertSame(1, $first->getError());
+		$this->assertSame(1714564800, $first->getCreation());
+		$this->assertSame(404, $restored->getItem('https://a.example/2')->getStatus());
+	}
+
+	public function testImportSkipsListedUrlsWithoutAnEntry(): void {
+		$cache = new Cache();
+
+		$cache->import(['_items' => ['https://a.example/1', 'https://a.example/2'], 'https://a.example/2' => ['url' => 'https://a.example/2']]);
+
+		$this->assertFalse($cache->hasItem('https://a.example/1'));
+		$this->assertTrue($cache->hasItem('https://a.example/2'));
+	}
+
+	public function testSetItemsReplacesEverything(): void {
+		$cache = new Cache();
+		$cache->addItem(new CacheItem('https://a.example/1'));
+		$only = new CacheItem('https://a.example/9');
+
+		$cache->setItems([$only]);
+
+		$this->assertSame([$only], $cache->getItems());
+	}
+}

--- a/tests/Tools/Model/NCRequestTest.php
+++ b/tests/Tools/Model/NCRequestTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Tools\Model;
+
+use OCA\Social\Tools\Model\NCRequest;
+use OCA\Social\Tools\Model\Request;
+use OCP\Http\Client\IClient;
+use PHPUnit\Framework\TestCase;
+
+class NCRequestTest extends TestCase {
+	public function testIsARequestCarryingTheNextcloudHttpClient(): void {
+		$client = $this->createMock(IClient::class);
+		$request = new NCRequest('/inbox', Request::TYPE_POST);
+
+		$this->assertInstanceOf(Request::class, $request);
+		$this->assertSame($request, $request->setClient($client));
+		$this->assertSame($client, $request->getClient());
+	}
+
+	public function testClientOptionsAndLocalAddressFlagDefaultToOff(): void {
+		$request = new NCRequest();
+
+		$this->assertSame([], $request->getClientOptions());
+		$this->assertFalse($request->isLocalAddressAllowed());
+
+		$request->setClientOptions(['timeout' => 5])->setLocalAddressAllowed(true);
+		$this->assertSame(['timeout' => 5], $request->getClientOptions());
+		$this->assertTrue($request->isLocalAddressAllowed());
+	}
+
+	public function testJsonSerializeExtendsTheRequestDescription(): void {
+		$request = new NCRequest('/inbox');
+		$request->setHost('mastodon.social');
+		$request->setClientOptions(['verify' => false])->setLocalAddressAllowed(true);
+
+		$json = $request->jsonSerialize();
+
+		$this->assertSame('mastodon.social', $json['host']);
+		$this->assertSame('/inbox', $json['url']);
+		$this->assertSame(['verify' => false], $json['clientOptions']);
+		$this->assertTrue($json['localAddressAllowed']);
+	}
+}

--- a/tests/Tools/Model/RequestTest.php
+++ b/tests/Tools/Model/RequestTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Tools\Model;
+
+use OCA\Social\Tools\Model\Request;
+use OCA\Social\Tools\Model\SimpleDataStore;
+use PHPUnit\Framework\TestCase;
+
+class RequestTest extends TestCase {
+	public function testDefaultsAreAnHttpsGetWithATenSecondTimeout(): void {
+		$request = new Request('/inbox');
+
+		$this->assertSame(['https'], $request->getProtocols());
+		$this->assertSame(Request::TYPE_GET, $request->getType());
+		$this->assertSame('/inbox', $request->getPath());
+		$this->assertSame(10, $request->getTimeout());
+		$this->assertTrue($request->isVerifyPeer());
+		$this->assertTrue($request->isFollowLocation());
+		$this->assertFalse($request->isBinary());
+		$this->assertFalse($request->isHttpErrorsAllowed());
+		$this->assertSame(0, $request->getPort());
+	}
+
+	public function testConstructorStoresTypeAndBinaryFlag(): void {
+		$request = new Request('/media', Request::TYPE_POST, true);
+
+		$this->assertSame(Request::TYPE_POST, $request->getType());
+		$this->assertTrue($request->isBinary());
+	}
+
+	public function testBasedOnAnAbsoluteUrlSplitsProtocolHostPortAndPath(): void {
+		$request = new Request('/inbox');
+
+		$request->basedOnUrl('http://mastodon.local:8080/users/alice');
+
+		$this->assertSame(['http'], $request->getProtocols());
+		$this->assertSame('http', $request->getUsedProtocol());
+		$this->assertSame('mastodon.local', $request->getHost());
+		$this->assertSame(8080, $request->getPort());
+		$this->assertSame('/users/alice/inbox', $request->getPath());
+		$this->assertSame('http://mastodon.local:8080/users/alice/inbox', $request->getCompleteUrl());
+		$this->assertSame('mastodon.local:8080', $request->getInstance());
+	}
+
+	public function testBasedOnAHostWithoutSchemeKeepsTheDefaultProtocol(): void {
+		$request = new Request('/inbox');
+
+		$request->basedOnUrl('mastodon.social:8443/base');
+
+		$this->assertSame(['https'], $request->getProtocols());
+		$this->assertSame('mastodon.social', $request->getHost());
+		$this->assertSame(8443, $request->getPort());
+		$this->assertSame('/base/inbox', $request->getPath());
+
+		$plain = new Request('/inbox');
+		$plain->basedOnUrl('mastodon.social');
+		$this->assertSame('mastodon.social', $plain->getHost());
+		$this->assertSame(0, $plain->getPort());
+		$this->assertSame('/inbox', $plain->getPath());
+	}
+
+	public function testSetInstanceSplitsHostAndPort(): void {
+		$request = new Request();
+
+		$request->setInstance('mastodon.social:8443');
+		$this->assertSame('mastodon.social', $request->getHost());
+		$this->assertSame(8443, $request->getPort());
+
+		$request->setInstance('other.example');
+		$this->assertSame('other.example', $request->getHost());
+		$this->assertSame('other.example:8443', $request->getInstance(), 'the port is kept');
+	}
+
+	public function testParamsAreSubstitutedIntoThePath(): void {
+		$request = new Request('/users/:name/statuses/:id');
+		$request->setHost('mastodon.social')->setUsedProtocol('https');
+
+		$request->addParam('name', 'alice')->addParamInt('id', 42);
+
+		$this->assertSame('/users/alice/statuses/:id', $request->getParametersUrl(), 'only string params are substituted');
+		$this->assertSame('https://mastodon.social/users/alice/statuses/:id', $request->getCompleteUrl());
+		$this->assertSame(['name' => 'alice', 'id' => 42], $request->getParams());
+	}
+
+	public function testDataIsSubstitutedIntoTheDeprecatedParsedUrl(): void {
+		$request = new Request('/users/:name');
+
+		$request->addData('name', 'alice')->addDataInt('page', 2);
+
+		$this->assertSame('/users/alice', $request->getParsedUrl());
+		$this->assertSame('{"name":"alice","page":2}', $request->getDataBody());
+	}
+
+	public function testDataCanBeSetFromJsonOrASerializableObject(): void {
+		$request = new Request();
+
+		$request->setDataJson('{"type":"Follow","actor":"https://a.example/users/alice"}');
+		$this->assertSame(['type' => 'Follow', 'actor' => 'https://a.example/users/alice'], $request->getData());
+
+		$request->setDataSerialize(new SimpleDataStore(['type' => 'Undo']));
+		$this->assertSame(['type' => 'Undo'], $request->getData());
+	}
+
+	public function testQueryStringDuplicatesKeysForArraysByDefault(): void {
+		$request = new Request();
+		$request->setParams(['a' => '1', 'b' => ['x', 'y']]);
+
+		$this->assertSame(Request::QS_VAR_DUPLICATE, $request->getQueryStringType());
+		$this->assertSame('?a=1&b=x&b=y', $request->getQueryString());
+
+		$request->setQueryStringType(Request::QS_VAR_ARRAY);
+		$this->assertSame('?a=1&b%5B0%5D=x&b%5B1%5D=y', $request->getQueryString());
+
+		$this->assertSame('', (new Request())->getQueryString());
+	}
+
+	public function testDeprecatedUrlParamsAndUrlDataUseEmptyBrackets(): void {
+		$request = new Request();
+		$request->setParams(['b' => ['x', 'y']]);
+		$request->setData(['c' => ['z']]);
+
+		$this->assertSame('b%5B%5D=x&b%5B%5D=y', $request->getUrlParams());
+		$this->assertSame('c%5B%5D=z', $request->getUrlData());
+		$this->assertSame('', (new Request())->getUrlParams());
+		$this->assertSame('', (new Request())->getUrlData());
+	}
+
+	public function testHeadersAreMergedAndPrefixedWithTheUserAgent(): void {
+		$request = new Request();
+		$request->setUserAgent('Nextcloud Social');
+
+		$request->addHeader('Accept', 'application/activity+json')
+			->addHeader('Accept', 'application/ld+json')
+			->addHeader('Date', 'Wed, 01 May 2024 12:00:00 GMT');
+
+		$this->assertSame([
+			'user-agent' => 'Nextcloud Social',
+			'Accept' => 'application/activity+json, application/ld+json',
+			'Date' => 'Wed, 01 May 2024 12:00:00 GMT',
+		], $request->getHeaders());
+
+		$request->setHeaders(['Signature' => 'x']);
+		$this->assertSame(['user-agent' => 'Nextcloud Social', 'Signature' => 'x'], $request->getHeaders());
+	}
+
+	public function testProtocolSettersReplaceTheList(): void {
+		$request = new Request();
+
+		$request->setProtocol('http');
+		$this->assertSame(['http'], $request->getProtocols());
+
+		$request->setProtocols(['https', 'http']);
+		$this->assertSame(['https', 'http'], $request->getProtocols());
+	}
+
+	public function testDeprecatedAddressAliasesTheHost(): void {
+		$request = new Request();
+
+		$request->setAddress('mastodon.social');
+
+		$this->assertSame('mastodon.social', $request->getHost());
+		$this->assertSame('mastodon.social', $request->getAddress());
+	}
+
+	public function typeProvider(): array {
+		return [
+			'GET' => ['get', Request::TYPE_GET, 'get'],
+			'POST' => ['POST', Request::TYPE_POST, 'post'],
+			'PUT' => ['Put', Request::TYPE_PUT, 'put'],
+			'DELETE' => ['delete', Request::TYPE_DELETE, 'delete'],
+		];
+	}
+
+	/**
+	 * @dataProvider typeProvider
+	 */
+	public function testTypeAndMethodMapBetweenNamesAndConstants(string $name, int $type, string $method): void {
+		$this->assertSame($type, Request::type($name));
+		$this->assertSame($method, Request::method($type));
+	}
+
+	public function testUnknownTypeNamesFallBackToGetAndUnknownConstantsToEmpty(): void {
+		$this->assertSame(Request::TYPE_GET, Request::type('PATCH'));
+		$this->assertSame('', Request::method(99));
+	}
+
+	public function testJsonSerializeDescribesTheRequest(): void {
+		$request = new Request('/inbox', Request::TYPE_POST);
+		$request->basedOnUrl('https://mastodon.social/users/alice');
+		$request->setUserAgent('ua')
+			->setTimeout(3)
+			->addHeader('Accept', 'application/activity+json')
+			->setCookies(['session' => 'x'])
+			->addParam('page', '1')
+			->addData('type', 'Follow')
+			->setVerifyPeer(false)
+			->setFollowLocation(false)
+			->setHttpErrorsAllowed(true)
+			->setResultCode(202)
+			->setContentType('application/json');
+
+		$this->assertSame([
+			'protocols' => ['https'],
+			'used_protocol' => 'https',
+			'port' => 0,
+			'host' => 'mastodon.social',
+			'url' => '/users/alice/inbox',
+			'timeout' => 3,
+			'type' => Request::TYPE_POST,
+			'cookies' => ['session' => 'x'],
+			'headers' => ['user-agent' => 'ua', 'Accept' => 'application/activity+json'],
+			'params' => ['page' => '1'],
+			'data' => ['type' => 'Follow'],
+			'userAgent' => 'ua',
+			'followLocation' => false,
+			'verifyPeer' => false,
+			'binary' => false,
+		], $request->jsonSerialize());
+		$this->assertTrue($request->isHttpErrorsAllowed());
+		$this->assertSame(202, $request->getResultCode());
+		$this->assertSame('application/json', $request->getContentType());
+	}
+}

--- a/tests/Tools/Model/SimpleDataStoreTest.php
+++ b/tests/Tools/Model/SimpleDataStoreTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Tools\Model;
+
+use OCA\Social\Model\InstancePath;
+use OCA\Social\Tools\Exceptions\ItemNotFoundException;
+use OCA\Social\Tools\Exceptions\MalformedArrayException;
+use OCA\Social\Tools\Model\SimpleDataStore;
+use PHPUnit\Framework\TestCase;
+
+class SimpleDataStoreTest extends TestCase {
+	public function testConstructorAcceptsInitialDataOrNothing(): void {
+		$this->assertSame(['a' => 1], (new SimpleDataStore(['a' => 1]))->gAll());
+		$this->assertSame([], (new SimpleDataStore())->gAll());
+		$this->assertSame([], (new SimpleDataStore(null))->gAll());
+	}
+
+	public function testStringValues(): void {
+		$store = new SimpleDataStore();
+
+		$store->s('host', 'cloud.example.org')->a('tags', 'a')->a('tags', 'b');
+
+		$this->assertSame('cloud.example.org', $store->g('host'));
+		$this->assertSame('', $store->g('missing'));
+		$this->assertSame(['a', 'b'], $store->gArray('tags'));
+	}
+
+	public function testIntValues(): void {
+		$store = new SimpleDataStore();
+
+		$store->sInt('count', 3)->aInt('ids', 1)->aInt('ids', 2);
+
+		$this->assertSame(3, $store->gInt('count'));
+		$this->assertSame(0, $store->gInt('missing'));
+		$this->assertSame([1, 2], $store->gArray('ids'));
+	}
+
+	public function testBoolValues(): void {
+		$store = new SimpleDataStore();
+
+		$store->sBool('ok', true)->aBool('flags', true)->aBool('flags', false);
+
+		$this->assertTrue($store->gBool('ok'));
+		$this->assertFalse($store->gBool('missing'));
+		$this->assertSame([true, false], $store->gArray('flags'));
+	}
+
+	public function testArrayValues(): void {
+		$store = new SimpleDataStore();
+
+		$store->sArray('list', ['a'])->aArray('list', ['b', 'c']);
+		$store->aArray('fresh', ['x']);
+
+		$this->assertSame(['a', 'b', 'c'], $store->gArray('list'));
+		$this->assertSame(['x'], $store->gArray('fresh'));
+		$this->assertSame([], $store->gArray('missing'));
+	}
+
+	public function testObjectValues(): void {
+		$store = new SimpleDataStore();
+		$first = new InstancePath('https://a.example/inbox');
+		$second = new InstancePath('https://b.example/inbox');
+
+		$store->sObj('main', $first)->aObj('all', $first)->aObj('all', $second);
+
+		$this->assertSame($first, $store->gItem('main'));
+		$this->assertSame([$first, $second], $store->gItem('all'));
+	}
+
+	public function testNestedStores(): void {
+		$store = new SimpleDataStore();
+		$inner = new SimpleDataStore(['k' => 'v']);
+
+		$store->sData('one', $inner)->aData('many', $inner)->aData('many', new SimpleDataStore(['k' => 'w']));
+
+		$this->assertSame(['k' => 'v'], $store->gArray('one'));
+		$this->assertSame('v', $store->gData('one')->g('k'));
+		$this->assertSame('v', $store->g('one.k'), 'dotted paths reach into nested data');
+		$this->assertSame([['k' => 'v'], ['k' => 'w']], $store->gArray('many'));
+		$this->assertSame([], $store->gData('missing')->gAll());
+	}
+
+	public function testGItemReturnsTheRawValueOrThrows(): void {
+		$store = new SimpleDataStore(['raw' => 1.5]);
+
+		$this->assertSame(1.5, $store->gItem('raw'));
+
+		$this->expectException(ItemNotFoundException::class);
+		$store->gItem('missing');
+	}
+
+	public function testKeysAndHasKey(): void {
+		$store = new SimpleDataStore(['a' => 1, 'b' => null]);
+
+		$this->assertSame(['a', 'b'], $store->keys());
+		$this->assertTrue($store->hasKey('a'));
+		$this->assertTrue($store->hasKey('b'), 'a null value still counts as a key');
+		$this->assertFalse($store->hasKey('c'));
+		$this->assertTrue($store->haveKey('a'));
+	}
+
+	public function testHasKeysChecksAllAndCanInsist(): void {
+		$store = new SimpleDataStore(['a' => 1, 'b' => 2]);
+
+		$this->assertTrue($store->hasKeys(['a', 'b']));
+		$this->assertFalse($store->hasKeys(['a', 'c']));
+		$this->assertTrue($store->haveKeys(['a']));
+
+		$this->expectException(MalformedArrayException::class);
+		$this->expectExceptionMessage('c missing in ["a","b"]');
+		$store->hasKeys(['a', 'c'], true);
+	}
+
+	public function testDefaultFillsOnlyMissingKeys(): void {
+		$store = new SimpleDataStore(['a' => 1]);
+
+		$store->default(['a' => 9, 'b' => 2]);
+
+		$this->assertSame(['a' => 1, 'b' => 2], $store->gAll());
+	}
+
+	public function testSAllReplacesEverythingAndJsonSerializeExposesIt(): void {
+		$store = new SimpleDataStore(['old' => 1]);
+
+		$store->sAll(['new' => true]);
+
+		$this->assertSame(['new' => true], $store->gAll());
+		$this->assertSame(['new' => true], $store->jsonSerialize());
+		$this->assertSame('{"new":true}', json_encode($store));
+	}
+}

--- a/tests/Tools/Traits/TArrayToolsTest.php
+++ b/tests/Tools/Traits/TArrayToolsTest.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Tools\Traits;
+
+use OCA\Social\Model\InstancePath;
+use OCA\Social\Tools\Exceptions\ArrayNotFoundException;
+use OCA\Social\Tools\Exceptions\ItemNotFoundException;
+use OCA\Social\Tools\Exceptions\MalformedArrayException;
+use OCA\Social\Tools\Exceptions\UnknownTypeException;
+use OCA\Social\Tools\Model\SimpleDataStore;
+use OCA\Social\Tools\Traits\TArrayTools;
+use PHPUnit\Framework\TestCase;
+
+class TArrayToolsTest extends TestCase {
+	/** Exposes the protected trait methods. */
+	private object $tools;
+
+	protected function setUp(): void {
+		$this->tools = new class {
+			use TArrayTools;
+
+			public function __call(string $name, array $args) {
+				return $this->$name(...$args);
+			}
+
+			public function clean(array $arr): array {
+				$this->cleanArray($arr);
+
+				return $arr;
+			}
+		};
+	}
+
+	private function sample(): array {
+		return [
+			'str' => 'value',
+			'int' => 42,
+			'zero' => 0,
+			'float' => 1.5,
+			'true' => true,
+			'null' => null,
+			'list' => ['a', 'b'],
+			'json' => '{"k":"v"}',
+			'nested' => ['deep' => ['key' => 'found', 'count' => '7', 'flag' => 'true', 'arr' => [1]]],
+		];
+	}
+
+	public function testGetReturnsStringsAndIntsAsStrings(): void {
+		$this->assertSame('value', $this->tools->get('str', $this->sample()));
+		$this->assertSame('42', $this->tools->get('int', $this->sample()));
+		$this->assertSame('0', $this->tools->get('zero', $this->sample()));
+	}
+
+	public function nonStringProvider(): array {
+		return [
+			'missing' => ['missing'],
+			'null' => ['null'],
+			'float' => ['float'],
+			'bool' => ['true'],
+			'array' => ['list'],
+			'nested through a scalar' => ['str.sub'],
+			'nested missing leaf' => ['nested.deep.none'],
+			'nested missing root' => ['none.deep'],
+		];
+	}
+
+	/**
+	 * @dataProvider nonStringProvider
+	 */
+	public function testGetFallsBackToTheDefaultForAnythingElse(string $key): void {
+		$this->assertSame('dflt', $this->tools->get($key, $this->sample(), 'dflt'));
+		$this->assertSame('', $this->tools->get($key, $this->sample()));
+	}
+
+	public function testGetWalksDottedPaths(): void {
+		$this->assertSame('found', $this->tools->get('nested.deep.key', $this->sample()));
+		$this->assertSame('7', $this->tools->get('nested.deep.count', $this->sample()));
+	}
+
+	public function testGetPrefersALiteralDottedKey(): void {
+		$this->assertSame('literal', $this->tools->get('a.b', ['a.b' => 'literal', 'a' => ['b' => 'nested']]));
+	}
+
+	public function testGetIntCastsNumericStringsAndUsesTheDefaultForNullOrMissing(): void {
+		$this->assertSame(42, $this->tools->getInt('int', $this->sample()));
+		$this->assertSame(7, $this->tools->getInt('nested.deep.count', $this->sample()));
+		$this->assertSame(0, $this->tools->getInt('zero', $this->sample(), 9));
+		$this->assertSame(1, $this->tools->getInt('true', $this->sample()));
+		$this->assertSame(0, $this->tools->getInt('str', $this->sample(), 9), 'non-numeric strings become 0, not the default');
+		$this->assertSame(9, $this->tools->getInt('null', $this->sample(), 9));
+		$this->assertSame(9, $this->tools->getInt('missing', $this->sample(), 9));
+		$this->assertSame(9, $this->tools->getInt('str.sub', $this->sample(), 9));
+	}
+
+	public function testGetFloatReadsWholeNumbersAndFallsBack(): void {
+		$this->assertSame(42.0, $this->tools->getFloat('int', $this->sample()));
+		$this->assertSame(7.0, $this->tools->getFloat('nested.deep.count', $this->sample()));
+		$this->assertSame(2.5, $this->tools->getFloat('null', $this->sample(), 2.5));
+		$this->assertSame(2.5, $this->tools->getFloat('missing', $this->sample(), 2.5));
+		$this->assertSame(2.5, $this->tools->getFloat('str.sub', $this->sample(), 2.5));
+	}
+
+	public function boolProvider(): array {
+		return [
+			'bool true' => [true, true],
+			'bool false' => [false, false],
+			'"1"' => ['1', true],
+			'"0"' => ['0', false],
+			'int 1' => [1, true],
+			'int 0' => [0, false],
+			'"true"' => ['true', true],
+			'"FALSE"' => ['FALSE', false],
+			'"yes" is not understood' => ['yes', 'default'],
+			'null' => [null, 'default'],
+		];
+	}
+
+	/**
+	 * @dataProvider boolProvider
+	 */
+	public function testGetBoolUnderstandsBooleansAndTheirStringForms($value, $expected): void {
+		$expectDefault = ($expected === 'default');
+
+		$this->assertSame($expectDefault ? true : $expected, $this->tools->getBool('k', ['k' => $value], true));
+		$this->assertSame($expectDefault ? false : $expected, $this->tools->getBool('k', ['k' => $value], false));
+	}
+
+	public function testGetBoolWalksDottedPathsAndFallsBackWhenMissing(): void {
+		$this->assertTrue($this->tools->getBool('nested.deep.flag', $this->sample()));
+		$this->assertTrue($this->tools->getBool('missing', $this->sample(), true));
+		$this->assertFalse($this->tools->getBool('none.deep', $this->sample()));
+	}
+
+	public function testGetArrayReturnsArraysAndDecodesJsonStrings(): void {
+		$this->assertSame(['a', 'b'], $this->tools->getArray('list', $this->sample()));
+		$this->assertSame(['k' => 'v'], $this->tools->getArray('json', $this->sample()));
+		$this->assertSame([1], $this->tools->getArray('nested.deep.arr', $this->sample()));
+	}
+
+	public function notAnArrayProvider(): array {
+		return [
+			'missing' => ['missing'],
+			'null' => ['null'],
+			'int' => ['int'],
+			'bool' => ['true'],
+			'plain string' => ['str'],
+			'nested through scalar' => ['int.sub'],
+		];
+	}
+
+	/**
+	 * @dataProvider notAnArrayProvider
+	 */
+	public function testGetArrayFallsBackToTheDefault(string $key): void {
+		$this->assertSame(['d'], $this->tools->getArray($key, $this->sample(), ['d']));
+	}
+
+	public function testGetArrayFallsBackForAJsonScalar(): void {
+		$this->assertSame(['d'], $this->tools->getArray('k', ['k' => '"just a string"'], ['d']));
+	}
+
+	public function testValidKeyChecksLiteralAndDottedKeys(): void {
+		$this->assertTrue($this->tools->validKey('null', $this->sample()), 'a null value still is a key');
+		$this->assertTrue($this->tools->validKey('nested.deep.key', $this->sample()));
+		$this->assertFalse($this->tools->validKey('nested.deep.none', $this->sample()));
+		$this->assertFalse($this->tools->validKey('str.sub', $this->sample()));
+		$this->assertFalse($this->tools->validKey('missing', $this->sample()));
+	}
+
+	public function testGetListBuildsObjectsThroughTheirImportMethod(): void {
+		$list = $this->tools->getList('paths', [
+			'paths' => [
+				['uri' => 'https://a.example/inbox', 'type' => 1],
+				['uri' => 'https://b.example/inbox', 'type' => 2],
+			],
+		], [InstancePath::class, 'import']);
+
+		$this->assertCount(2, $list);
+		$this->assertContainsOnlyInstancesOf(InstancePath::class, $list);
+		$this->assertSame('https://b.example/inbox', $list[1]->getUri());
+		$this->assertSame(2, $list[1]->getType());
+	}
+
+	public function testExtractArrayFindsTheEntryWithAMatchingValue(): void {
+		$list = [['rel' => 'self', 'href' => 'https://a.example/users/alice'], ['rel' => 'http://webfinger.net/rel/profile-page', 'href' => 'https://a.example/@alice']];
+
+		$this->assertSame($list[1], $this->tools->extractArray('rel', 'http://webfinger.net/rel/profile-page', $list));
+	}
+
+	public function testExtractArrayThrowsWhenNothingMatches(): void {
+		$this->expectException(ArrayNotFoundException::class);
+
+		$this->tools->extractArray('rel', 'other', [['rel' => 'self'], ['href' => 'x']]);
+	}
+
+	public function typeProvider(): array {
+		return [
+			'null' => ['null', 'Null'],
+			'string' => ['str', 'String'],
+			'array' => ['list', 'Array'],
+			'boolean' => ['true', 'Boolean'],
+			'integer' => ['int', 'Integer'],
+			'nested' => ['nested.deep.key', 'String'],
+		];
+	}
+
+	/**
+	 * @dataProvider typeProvider
+	 */
+	public function testTypeOfNamesTheType(string $key, string $expected): void {
+		$this->assertSame($expected, $this->tools->typeOf($key, $this->sample()));
+	}
+
+	public function testTypeOfRecognisesSerializableObjects(): void {
+		$this->assertSame('Serializable', $this->tools->typeOf('obj', ['obj' => new SimpleDataStore()]));
+	}
+
+	public function testTypeOfRejectsUnknownTypes(): void {
+		$this->expectException(UnknownTypeException::class);
+
+		$this->tools->typeOf('float', $this->sample());
+	}
+
+	public function missingKeyProvider(): array {
+		return [
+			'missing' => ['missing'],
+			'nested missing root' => ['none.key'],
+			'nested missing leaf' => ['nested.none'],
+			'nested through scalar' => ['str.key'],
+		];
+	}
+
+	/**
+	 * @dataProvider missingKeyProvider
+	 */
+	public function testTypeOfThrowsForMissingKeys(string $key): void {
+		$this->expectException(ItemNotFoundException::class);
+
+		$this->tools->typeOf($key, $this->sample());
+	}
+
+	public function testMustContainsAcceptsWhenAllKeysArePresent(): void {
+		$this->tools->mustContains(['str', 'null'], $this->sample());
+
+		$this->addToAssertionCount(1);
+	}
+
+	public function testMustContainsNamesTheMissingKey(): void {
+		$this->expectException(MalformedArrayException::class);
+		$this->expectExceptionMessage('missing key: nope');
+
+		$this->tools->mustContains(['str', 'nope'], $this->sample());
+	}
+
+	public function testCleanArrayDropsEmptyStringsAndArraysOnly(): void {
+		$cleaned = $this->tools->clean([
+			'empty' => '',
+			'none' => [],
+			'zero' => 0,
+			'false' => false,
+			'null' => null,
+			'str' => 'a',
+			'list' => [1],
+		]);
+
+		$this->assertSame(['zero' => 0, 'false' => false, 'null' => null, 'str' => 'a', 'list' => [1]], $cleaned);
+	}
+}

--- a/tests/Tools/Traits/TFileToolsTest.php
+++ b/tests/Tools/Traits/TFileToolsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Tools\Traits;
+
+use OCA\Social\Tools\Traits\TFileTools;
+use PHPUnit\Framework\TestCase;
+
+class TFileToolsTest extends TestCase {
+	public function testChecksumOfAStreamIsItsMd5(): void {
+		$tools = new class {
+			use TFileTools;
+
+			public function checksum($stream): string {
+				return $this->getChecksumFromStream($stream);
+			}
+		};
+		$stream = fopen('php://memory', 'r+');
+		fwrite($stream, 'hello fediverse');
+		rewind($stream);
+
+		$this->assertSame(md5('hello fediverse'), $tools->checksum($stream));
+
+		rewind($stream);
+		$this->assertSame(md5('hello fediverse'), $tools->checksum($stream), 'reading again from the start gives the same checksum');
+		fclose($stream);
+	}
+}

--- a/tests/Tools/Traits/TNCDataResponseTest.php
+++ b/tests/Tools/Traits/TNCDataResponseTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Tools\Traits;
+
+use OCA\Social\Tools\Model\SimpleDataStore;
+use OCA\Social\Tools\Traits\TNCDataResponse;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\IRequest;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class TNCDataResponseTest extends TestCase {
+	/** Exposes the protected trait methods. */
+	private object $controller;
+
+	protected function setUp(): void {
+		$this->controller = new class {
+			use TNCDataResponse;
+
+			public function __call(string $name, array $args) {
+				return $this->$name(...$args);
+			}
+		};
+	}
+
+	protected function tearDown(): void {
+		\OC::$server->reset();
+	}
+
+	public function testFailReportsTheExceptionAndLogsAWarning(): void {
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->once())->method('warning')
+			->with($this->callback(fn (string $message): bool => str_starts_with($message, '500 - ')
+				&& str_contains($message, '"exception":"RuntimeException"')
+				&& str_contains($message, '"message":"boom"')));
+		\OC::$server->register(LoggerInterface::class, $logger);
+
+		$response = $this->controller->fail(new \RuntimeException('boom'), ['context' => 'x']);
+
+		$this->assertInstanceOf(DataResponse::class, $response);
+		$this->assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		$this->assertSame(
+			['context' => 'x', 'status' => -1, 'exception' => \RuntimeException::class, 'message' => 'boom'],
+			$response->getData()
+		);
+	}
+
+	public function testFailCanUseAnotherStatusAndStaySilent(): void {
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->never())->method('warning');
+		\OC::$server->register(LoggerInterface::class, $logger);
+
+		$response = $this->controller->fail(new \InvalidArgumentException('bad'), [], Http::STATUS_BAD_REQUEST, false);
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame(\InvalidArgumentException::class, $response->getData()['exception']);
+	}
+
+	public function testSuccessWrapsTheResult(): void {
+		$response = $this->controller->success(['id' => 1], ['extra' => true]);
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['extra' => true, 'result' => ['id' => 1], 'status' => 1], $response->getData());
+		$this->assertSame(['result' => [], 'status' => 1], $this->controller->success()->getData());
+	}
+
+	public function testDirectSuccessReturnsTheObjectItself(): void {
+		$store = new SimpleDataStore(['a' => 1]);
+
+		$response = $this->controller->directSuccess($store);
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($store, $response->getData());
+	}
+
+	public function testActivityPubSuccessSetsTheJsonLdContentType(): void {
+		$request = $this->createMock(IRequest::class);
+		$request->method('getId')->willReturn('req-1');
+		\OC::$server->register(IRequest::class, $request);
+		$store = new SimpleDataStore(['type' => 'Note']);
+
+		$response = $this->controller->activityPubSuccess($store);
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame($store, $response->getData());
+		$this->assertSame(
+			'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+			$response->getHeaders()['Content-Type']
+		);
+	}
+}

--- a/tests/Tools/Traits/TNCSetupTest.php
+++ b/tests/Tools/Traits/TNCSetupTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Tools\Traits;
+
+use OCA\Social\Tools\Traits\TNCSetup;
+use OCP\IConfig;
+use PHPUnit\Framework\TestCase;
+
+class TNCSetupTest extends TestCase {
+	private object $setup;
+
+	protected function setUp(): void {
+		$this->setup = new class {
+			use TNCSetup;
+		};
+	}
+
+	protected function tearDown(): void {
+		\OC::$server->reset();
+	}
+
+	public function testSetupStoresAValueAndReadsItBack(): void {
+		$this->assertSame('social', $this->setup->setup('app', 'social'));
+		$this->assertSame('social', $this->setup->setup('app'));
+		$this->assertSame('social', $this->setup->setup('app', '', 'other'), 'an empty value does not overwrite');
+		$this->assertSame('dflt', $this->setup->setup('missing', '', 'dflt'));
+		$this->assertSame('', $this->setup->setup('missing'));
+	}
+
+	public function testSetupArrayStoresNonEmptyArrays(): void {
+		$this->assertSame(['a', 'b'], $this->setup->setupArray('list', ['a', 'b']));
+		$this->assertSame(['a', 'b'], $this->setup->setupArray('list'));
+		$this->assertSame(['a', 'b'], $this->setup->setupArray('list', [], ['d']), 'an empty array does not overwrite');
+		$this->assertSame(['d'], $this->setup->setupArray('missing', [], ['d']));
+	}
+
+	public function testSetupIntUsesMinus999AsTheNoValueMarker(): void {
+		$this->assertSame(0, $this->setup->setupInt('count', 0));
+		$this->assertSame(0, $this->setup->setupInt('count'));
+		$this->assertSame(0, $this->setup->setupInt('count', -999, 7), 'the marker does not overwrite');
+		$this->assertSame(7, $this->setup->setupInt('missing', -999, 7));
+	}
+
+	public function testAppConfigIsEmptyWithoutAnAppName(): void {
+		$this->assertSame('', $this->setup->appConfig('key'));
+	}
+
+	public function testAppConfigReadsTheValueOfTheConfiguredApp(): void {
+		$config = $this->createMock(IConfig::class);
+		$config->expects($this->once())->method('getAppValue')
+			->with('social', 'address', '')
+			->willReturn('https://cloud.example.org');
+		\OC::$server->register(IConfig::class, $config);
+		$this->setup->setup('app', 'social');
+
+		$this->assertSame('https://cloud.example.org', $this->setup->appConfig('address'));
+	}
+}

--- a/tests/Tools/Traits/TPathToolsTest.php
+++ b/tests/Tools/Traits/TPathToolsTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Tools\Traits;
+
+use OCA\Social\Tools\Traits\TPathTools;
+use PHPUnit\Framework\TestCase;
+
+class TPathToolsTest extends TestCase {
+	/** Exposes the protected trait methods. */
+	private object $tools;
+
+	protected function setUp(): void {
+		$this->tools = new class {
+			use TPathTools;
+
+			public function __call(string $name, array $args) {
+				return $this->$name(...$args);
+			}
+		};
+	}
+
+	public function endSlashProvider(): array {
+		return [
+			'adds a slash' => ['apps/social', 'apps/social/'],
+			'keeps a single slash' => ['apps/social/', 'apps/social/'],
+			'collapses double slashes' => ['apps//social', 'apps/social/'],
+			'trims whitespace' => [' apps/social', 'apps/social/'],
+			'empty becomes root' => ['', '/'],
+		];
+	}
+
+	/**
+	 * @dataProvider endSlashProvider
+	 */
+	public function testWithEndSlash(string $path, string $expected): void {
+		$this->assertSame($expected, $this->tools->withEndSlash($path));
+	}
+
+	public function withoutEndSlashProvider(): array {
+		return [
+			'removes the slash' => ['apps/social/', false, 'apps/social'],
+			'removes several' => ['apps/social///', false, 'apps/social'],
+			'root is kept' => ['/', false, '/'],
+			'root is removed when forced' => ['/', true, ''],
+			'no slash to remove' => ['apps/social', false, 'apps/social'],
+		];
+	}
+
+	/**
+	 * @dataProvider withoutEndSlashProvider
+	 */
+	public function testWithoutEndSlash(string $path, bool $force, string $expected): void {
+		$this->assertSame($expected, $this->tools->withoutEndSlash($path, $force));
+	}
+
+	public function testWithoutEndSlashCanSkipTheDoubleSlashCleanup(): void {
+		$this->assertSame('a//b', $this->tools->withoutEndSlash('a//b/', false, false));
+		$this->assertSame('a/b', $this->tools->withoutEndSlash('a//b/'));
+	}
+
+	public function beginSlashProvider(): array {
+		return [
+			'adds a slash' => ['apps/social', '/apps/social'],
+			'keeps a single slash' => ['/apps/social', '/apps/social'],
+			'collapses double slashes' => ['/apps//social', '/apps/social'],
+			'empty becomes root' => ['', '/'],
+		];
+	}
+
+	/**
+	 * @dataProvider beginSlashProvider
+	 */
+	public function testWithBeginSlash(string $path, string $expected): void {
+		$this->assertSame($expected, $this->tools->withBeginSlash($path));
+	}
+
+	public function withoutBeginSlashProvider(): array {
+		return [
+			'removes the slash' => ['/apps/social', false, 'apps/social'],
+			'removes several' => ['///apps/social', false, 'apps/social'],
+			'root is kept' => ['/', false, '/'],
+			'root is removed when forced' => ['/', true, ''],
+			'no slash to remove' => ['apps/social', false, 'apps/social'],
+		];
+	}
+
+	/**
+	 * @dataProvider withoutBeginSlashProvider
+	 */
+	public function testWithoutBeginSlash(string $path, bool $force, string $expected): void {
+		$this->assertSame($expected, $this->tools->withoutBeginSlash($path, $force));
+	}
+
+	public function testWithoutBeginAtStripsTheMentionPrefix(): void {
+		$this->assertSame('alice@mastodon.social', $this->tools->withoutBeginAt('@alice@mastodon.social'));
+		$this->assertSame('alice@mastodon.social', $this->tools->withoutBeginAt('@@alice@mastodon.social '));
+		$this->assertSame('alice', $this->tools->withoutBeginAt('alice'));
+	}
+}

--- a/tests/Tools/Traits/TStringToolsTest.php
+++ b/tests/Tools/Traits/TStringToolsTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Tools\Traits;
+
+use OCA\Social\Tools\Traits\TStringTools;
+use PHPUnit\Framework\TestCase;
+
+class TStringToolsTest extends TestCase {
+	private const UUID_PATTERN = '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/';
+
+	/** Exposes the protected trait methods. */
+	private object $tools;
+
+	protected function setUp(): void {
+		$this->tools = new class {
+			use TStringTools;
+
+			public function __call(string $name, array $args) {
+				return $this->$name(...$args);
+			}
+		};
+	}
+
+	public function testTokenDefaultsToFifteenAlphanumericCharacters(): void {
+		$token = $this->tools->token();
+
+		$this->assertSame(15, strlen($token));
+		$this->assertMatchesRegularExpression('/^[A-Za-z0-9]{15}$/', $token);
+	}
+
+	public function testTokenHonoursTheLengthAndIsRandom(): void {
+		$first = $this->tools->token(40);
+
+		$this->assertMatchesRegularExpression('/^[A-Za-z0-9]{40}$/', $first);
+		$this->assertNotSame($first, $this->tools->token(40));
+		$this->assertSame('', $this->tools->token(0));
+	}
+
+	public function testUuidIsAVersionFourUuid(): void {
+		$uuid = $this->tools->uuid();
+
+		$this->assertMatchesRegularExpression(self::UUID_PATTERN, $uuid);
+		$this->assertNotSame($uuid, $this->tools->uuid());
+	}
+
+	public function testShortUuidsDropTheDashesLongerOnesKeepThem(): void {
+		$this->assertMatchesRegularExpression('/^[0-9a-f]{8}$/', $this->tools->uuid(8));
+		$this->assertMatchesRegularExpression('/^[0-9a-f]{16}$/', $this->tools->uuid(16));
+		$this->assertMatchesRegularExpression('/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab]$/', $this->tools->uuid(20));
+	}
+
+	public function commonPartProvider(): array {
+		return [
+			'shared prefix' => ['nextcloud', 'nextdoor', true, 'next'],
+			'identical' => ['same', 'same', true, 'same'],
+			'nothing in common' => ['abc', 'xyz', true, ''],
+			'case matters by default' => ['NextCloud', 'nextcloud', true, ''],
+			'case insensitive keeps the first spelling' => ['NextCloud', 'nextdoor', false, 'Next'],
+			'shorter string bounds the result' => ['ab', 'abc', true, 'ab'],
+		];
+	}
+
+	/**
+	 * @dataProvider commonPartProvider
+	 */
+	public function testCommonPartReturnsTheSharedPrefix(string $a, string $b, bool $caseSensitive, string $expected): void {
+		$this->assertSame($expected, $this->tools->commonPart($a, $b, $caseSensitive));
+	}
+
+	public function testFeedStringWithParamsReplacesBracedPlaceholders(): void {
+		$result = $this->tools->feedStringWithParams(
+			'{user} followed {target} ({user})',
+			['user' => 'alice', 'target' => 'bob', 'unused' => 'x']
+		);
+
+		$this->assertSame('alice followed bob (alice)', $result);
+		$this->assertSame('{missing}', $this->tools->feedStringWithParams('{missing}', []));
+	}
+
+	public function testGenerateRandomWordAlternatesConsonantsAndVowels(): void {
+		$word = $this->tools->generateRandomWord(8);
+
+		$this->assertSame(10, strlen($word));
+		$this->assertMatchesRegularExpression('/^([bcdfghjklmnprstv][aeiouy])+$/', $word);
+	}
+
+	public function testGenerateRandomSentenceHasTheRequestedNumberOfWords(): void {
+		$sentence = $this->tools->generateRandomSentence(4);
+
+		$words = explode(' ', $sentence);
+		$this->assertCount(4, $words);
+		foreach ($words as $word) {
+			$this->assertMatchesRegularExpression('/^[a-z]+$/', $word);
+		}
+	}
+}

--- a/tests/WellKnown/JrdResponseTest.php
+++ b/tests/WellKnown/JrdResponseTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\WellKnown;
+
+use OCA\Social\WellKnown\JrdResponse;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use PHPUnit\Framework\TestCase;
+
+class JrdResponseTest extends TestCase {
+	protected function setUp(): void {
+		\OC::$server->register(IRequest::class, $this->createMock(IRequest::class));
+	}
+
+	protected function tearDown(): void {
+		\OC::$server->reset();
+	}
+
+	public function testANewResponseIsEmpty(): void {
+		$this->assertTrue((new JrdResponse('acct:alice@cloud.example'))->isEmpty());
+	}
+
+	/** @return iterable<string, array{callable(JrdResponse): void}> */
+	public function fillers(): iterable {
+		yield 'alias' => [fn (JrdResponse $r) => $r->addAlias('https://cloud.example/@alice')];
+		yield 'property' => [fn (JrdResponse $r) => $r->addProperty('http://schema/name', 'Alice')];
+		yield 'link' => [fn (JrdResponse $r) => $r->addLink('self', null, null)];
+		yield 'expires' => [fn (JrdResponse $r) => $r->setExpires('2030-01-01T00:00:00Z')];
+	}
+
+	/** @dataProvider fillers */
+	public function testAnyContentMakesTheResponseNonEmpty(callable $fill): void {
+		$response = new JrdResponse();
+		$fill($response);
+
+		$this->assertFalse($response->isEmpty());
+	}
+
+	public function testEmptyResponseRendersAsBodylessDataResponseWithItsStatus(): void {
+		$http = (new JrdResponse('', Http::STATUS_NOT_FOUND))->toHttpResponse();
+
+		$this->assertInstanceOf(DataResponse::class, $http);
+		$this->assertNotInstanceOf(JSONResponse::class, $http);
+		$this->assertSame(Http::STATUS_NOT_FOUND, $http->getStatus());
+		$this->assertSame('', $http->getData());
+	}
+
+	public function testSubjectAloneIsEnoughForAJsonDocument(): void {
+		$http = (new JrdResponse('acct:alice@cloud.example'))->toHttpResponse();
+
+		$this->assertInstanceOf(JSONResponse::class, $http);
+		$this->assertSame(['subject' => 'acct:alice@cloud.example'], $http->getData());
+		$this->assertSame('application/json; charset=utf-8', $http->getHeaders()['Content-Type']);
+	}
+
+	public function testFullDocumentSerialisation(): void {
+		$response = (new JrdResponse('acct:alice@cloud.example'))
+			->setExpires('2030-01-01T00:00:00Z')
+			->addAlias('https://cloud.example/@alice')
+			->addAlias('https://cloud.example/u/alice')
+			->addProperty('http://schema/name', 'Alice')
+			->addProperty('http://schema/empty', null)
+			->addLink('self', 'application/activity+json', 'https://cloud.example/@alice')
+			->addLink('http://ostatus.org/schema/1.0/subscribe', '', '', null, null, ['template' => 'https://cloud.example/follow?uri={uri}'])
+			->addLink('http://webfinger.net/rel/avatar', 'image/png', 'https://cloud.example/avatar.png', ['en' => 'Avatar'], ['size' => '64']);
+
+		$this->assertSame([
+			'subject' => 'acct:alice@cloud.example',
+			'expires' => '2030-01-01T00:00:00Z',
+			'aliases' => ['https://cloud.example/@alice', 'https://cloud.example/u/alice'],
+			'properties' => ['http://schema/name' => 'Alice', 'http://schema/empty' => null],
+			'links' => [
+				['rel' => 'self', 'type' => 'application/activity+json', 'href' => 'https://cloud.example/@alice'],
+				['rel' => 'http://ostatus.org/schema/1.0/subscribe', 'template' => 'https://cloud.example/follow?uri={uri}'],
+				[
+					'rel' => 'http://webfinger.net/rel/avatar',
+					'type' => 'image/png',
+					'href' => 'https://cloud.example/avatar.png',
+					'titles' => ['en' => 'Avatar'],
+					'properties' => ['size' => '64'],
+				],
+			],
+		], $response->toHttpResponse()->getData());
+	}
+
+	public function testEmptyLinkAttributesAreDropped(): void {
+		$response = (new JrdResponse('s'))->addLink('rel-only', null, null, [], []);
+
+		$this->assertSame([['rel' => 'rel-only']], $response->toHttpResponse()->getData()['links']);
+	}
+
+	public function testHttpCodeCanBeChangedAfterConstruction(): void {
+		$response = (new JrdResponse('s'))->setHttpCode(Http::STATUS_GONE);
+
+		$this->assertSame(Http::STATUS_GONE, $response->toHttpResponse()->getStatus());
+	}
+}

--- a/tests/WellKnown/WebfingerHandlerTest.php
+++ b/tests/WellKnown/WebfingerHandlerTest.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\WellKnown;
+
+use OCA\Social\AppInfo\Application;
+use OCA\Social\Db\CacheActorsRequest;
+use OCA\Social\Exceptions\ActorDoesNotExistException;
+use OCA\Social\Exceptions\CacheActorDoesNotExistException;
+use OCA\Social\Exceptions\SocialAppConfigException;
+use OCA\Social\Exceptions\UnauthorizedFediverseException;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Service\CacheActorService;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\FediverseService;
+use OCA\Social\WellKnown\JrdResponse;
+use OCA\Social\WellKnown\WebfingerHandler;
+use OCA\Social\WellKnown\XrdResponse;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\Http\WellKnown\IRequestContext;
+use OCP\Http\WellKnown\IResponse;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class WebfingerHandlerTest extends TestCase {
+	private const ACTOR_URL = 'https://cloud.example/index.php/apps/social/@alice';
+
+	/** @var IURLGenerator&MockObject */
+	private $urlGenerator;
+	/** @var CacheActorsRequest&MockObject */
+	private $cacheActorsRequest;
+	/** @var CacheActorService&MockObject */
+	private $cacheActorService;
+	/** @var FediverseService&MockObject */
+	private $fediverseService;
+	/** @var ConfigService&MockObject */
+	private $configService;
+	/** @var IRequest&MockObject */
+	private $request;
+	/** @var IRequestContext&MockObject */
+	private $context;
+	private WebfingerHandler $handler;
+
+	protected function setUp(): void {
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->cacheActorsRequest = $this->createMock(CacheActorsRequest::class);
+		$this->cacheActorService = $this->createMock(CacheActorService::class);
+		$this->fediverseService = $this->createMock(FediverseService::class);
+		$this->configService = $this->createMock(ConfigService::class);
+		$this->request = $this->createMock(IRequest::class);
+		$this->context = $this->createMock(IRequestContext::class);
+		$this->context->method('getHttpRequest')->willReturn($this->request);
+
+		$this->configService->method('getCloudUrl')->willReturnCallback(
+			fn (bool $noPhp = false): string => $noPhp ? 'https://cloud.example' : 'https://cloud.example/index.php'
+		);
+		$this->configService->method('getSocialUrl')->willReturn('https://cloud.example/index.php/apps/social/');
+		$this->urlGenerator->method('linkToRoute')
+			->with('social.ActivityPub.actorAlias', ['username' => 'alice'])
+			->willReturn('/index.php/apps/social/@alice');
+		$this->urlGenerator->method('getAbsoluteURL')
+			->willReturnCallback(fn (string $url): string => 'https://cloud.example' . $url);
+
+		\OC::$server->register(IRequest::class, $this->request);
+
+		$this->handler = new WebfingerHandler(
+			$this->urlGenerator,
+			$this->cacheActorsRequest,
+			$this->cacheActorService,
+			$this->fediverseService,
+			$this->configService
+		);
+	}
+
+	protected function tearDown(): void {
+		\OC::$server->reset();
+	}
+
+	private function resource(string $resource): void {
+		$this->request->method('getParam')->with('resource')->willReturn($resource);
+	}
+
+	/** @return Person&MockObject */
+	private function localActor(string $username, bool $local = true): Person {
+		$actor = $this->createMock(Person::class);
+		$actor->method('getPreferredUsername')->willReturn($username);
+		$actor->method('isLocal')->willReturn($local);
+
+		return $actor;
+	}
+
+	private function jsonOf(IResponse $response): array {
+		$http = $response->toHttpResponse();
+		$this->assertInstanceOf(JSONResponse::class, $http);
+
+		return $http->getData();
+	}
+
+
+	// handle() dispatch
+
+	public function testJailedInstanceLeavesThePreviousResponseUntouched(): void {
+		$this->fediverseService->method('jailed')->willThrowException(new UnauthorizedFediverseException());
+		$previous = $this->createMock(IResponse::class);
+		$this->cacheActorService->expects($this->never())->method('getFromLocalAccount');
+
+		$this->assertSame($previous, $this->handler->handle('webfinger', $this->context, $previous));
+	}
+
+	public function testUnknownServicesLeaveThePreviousResponseUntouched(): void {
+		$previous = $this->createMock(IResponse::class);
+
+		$this->assertSame($previous, $this->handler->handle('openid-configuration', $this->context, $previous));
+		$this->assertNull($this->handler->handle('openid-configuration', $this->context, null));
+	}
+
+	public function testNodeinfoAdvertisesTheSchemaEndpoint(): void {
+		$response = $this->handler->handle('NodeInfo', $this->context, null);
+
+		$this->assertInstanceOf(JrdResponse::class, $response);
+		$this->assertSame([
+			'links' => [[
+				'rel' => 'http://nodeinfo.diaspora.software/ns/schema/2.0',
+				'href' => 'https://cloud.example/index.php/apps/social/.well-known/nodeinfo/2.0',
+			]],
+		], $this->jsonOf($response));
+	}
+
+	public function testHostMetaAdvertisesTheWebfingerTemplateWithoutIndexPhp(): void {
+		$response = $this->handler->handle('host-meta', $this->context, null);
+
+		$this->assertInstanceOf(XrdResponse::class, $response);
+		$this->assertStringContainsString(
+			'<Link rel="lrdd"  template="https://cloud.example/.well-known/webfinger?resource={uri}"/>',
+			$response->toHttpResponse()->render()
+		);
+	}
+
+	public function testHostMetaIsSkippedWhenTheCloudUrlIsNotConfigured(): void {
+		$configService = $this->createMock(ConfigService::class);
+		$configService->method('getCloudUrl')->willThrowException(new SocialAppConfigException());
+		$handler = new WebfingerHandler($this->urlGenerator, $this->cacheActorsRequest, $this->cacheActorService, $this->fediverseService, $configService);
+		$previous = $this->createMock(IResponse::class);
+
+		$this->assertSame($previous, $handler->handle('host-meta', $this->context, $previous));
+	}
+
+
+	// handleWebfinger()
+
+	public function testLocalAccountIsDescribedWithSelfAndProfileLinks(): void {
+		$this->resource('acct:alice@cloud.example');
+		$this->cacheActorService->method('getFromLocalAccount')->with('alice@cloud.example')->willReturn($this->localActor('alice'));
+
+		$response = $this->handler->handle('webfinger', $this->context, null);
+
+		$this->assertInstanceOf(JrdResponse::class, $response);
+		$http = $response->toHttpResponse();
+		$this->assertSame(Http::STATUS_OK, $http->getStatus());
+		$this->assertSame([
+			'subject' => 'acct:alice@cloud.example',
+			'aliases' => [self::ACTOR_URL, 'https://cloud.example/index.php/u/alice'],
+			'links' => [
+				['rel' => 'self', 'type' => 'application/activity+json', 'href' => self::ACTOR_URL],
+				['rel' => 'http://webfinger.net/rel/profile-page', 'type' => 'text/html', 'href' => 'https://cloud.example/index.php/u/alice'],
+				['rel' => 'http://ostatus.org/schema/1.0/subscribe', 'template' => 'https://cloud.example/index.php/apps/social/ostatus/follow/?uri={uri}'],
+			],
+		], $this->jsonOf($response));
+	}
+
+	public function testSubjectWithoutAcctPrefixIsLookedUpVerbatim(): void {
+		$this->resource('alice@cloud.example');
+		$this->cacheActorService->expects($this->once())->method('getFromLocalAccount')->with('alice@cloud.example')
+			->willReturn($this->localActor('alice'));
+
+		$json = $this->jsonOf($this->handler->handleWebfinger($this->context, null));
+
+		$this->assertSame('alice@cloud.example', $json['subject']);
+	}
+
+	public function testResourceIsReadFromTheRequestUriWhenParamsAreMissing(): void {
+		$this->resource('');
+		$this->request->method('getRequestUri')->willReturn('/.well-known/webfinger?resource=acct%3Aalice%40cloud.example&rel=self');
+		$this->cacheActorService->expects($this->once())->method('getFromLocalAccount')->with('alice@cloud.example')
+			->willReturn($this->localActor('alice'));
+
+		$json = $this->jsonOf($this->handler->handleWebfinger($this->context, null));
+
+		$this->assertSame('acct:alice@cloud.example', $json['subject']);
+	}
+
+	public function testUnknownLocalUserLeavesThePreviousResponseUntouched(): void {
+		$this->resource('acct:ghost@cloud.example');
+		$this->cacheActorService->method('getFromLocalAccount')->willThrowException(new ActorDoesNotExistException());
+		$this->cacheActorsRequest->expects($this->never())->method('getFromId');
+		$previous = $this->createMock(IResponse::class);
+
+		$this->assertNull($this->handler->handleWebfinger($this->context, $previous));
+		$this->assertSame($previous, $this->handler->handle('webfinger', $this->context, $previous));
+	}
+
+	public function testUnconfiguredAppLeavesThePreviousResponseUntouched(): void {
+		$this->resource('acct:alice@cloud.example');
+		$this->cacheActorService->method('getFromLocalAccount')->willThrowException(new SocialAppConfigException());
+		$previous = $this->createMock(IResponse::class);
+
+		$this->assertSame($previous, $this->handler->handle('webfinger', $this->context, $previous));
+	}
+
+	public function testActorIdFallsBackToTheActorCache(): void {
+		$this->resource(self::ACTOR_URL);
+		$this->cacheActorService->method('getFromLocalAccount')->willThrowException(new CacheActorDoesNotExistException());
+		$this->cacheActorsRequest->expects($this->once())->method('getFromId')->with(self::ACTOR_URL)
+			->willReturn($this->localActor('alice'));
+
+		$json = $this->jsonOf($this->handler->handleWebfinger($this->context, null));
+
+		$this->assertSame(self::ACTOR_URL, $json['subject']);
+		$this->assertSame(self::ACTOR_URL, $json['links'][0]['href']);
+	}
+
+	public function testUncachedUnknownActorIsAnEmpty404(): void {
+		$this->resource('acct:nobody@cloud.example');
+		$this->cacheActorService->method('getFromLocalAccount')->willThrowException(new CacheActorDoesNotExistException());
+		$this->cacheActorsRequest->method('getFromId')->willThrowException(new CacheActorDoesNotExistException());
+
+		$response = $this->handler->handleWebfinger($this->context, $this->createMock(IResponse::class));
+
+		$this->assertInstanceOf(JrdResponse::class, $response);
+		$this->assertTrue($response->isEmpty());
+		$http = $response->toHttpResponse();
+		$this->assertInstanceOf(DataResponse::class, $http);
+		$this->assertSame(Http::STATUS_NOT_FOUND, $http->getStatus());
+	}
+
+	public function testRemoteActorsAreNotServed(): void {
+		$this->resource('acct:bob@remote.example');
+		$this->cacheActorService->method('getFromLocalAccount')->willReturn($this->localActor('bob', false));
+
+		$response = $this->handler->handleWebfinger($this->context, null);
+
+		$this->assertInstanceOf(JrdResponse::class, $response);
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->toHttpResponse()->getStatus());
+	}
+
+	public function testAppSubjectAnnotatesThePreviousJrdWithTheAppLink(): void {
+		$this->resource(Application::APP_SUBJECT);
+		$this->configService->method('getAppValue')->with('installed_version')->willReturn('0.10.1');
+		$this->cacheActorService->expects($this->never())->method('getFromLocalAccount');
+		$previous = new JrdResponse(Application::APP_SUBJECT);
+
+		$response = $this->handler->handleWebfinger($this->context, $previous);
+
+		$this->assertSame($previous, $response);
+		$this->assertSame([[
+			'rel' => Application::APP_REL,
+			'type' => 'application/json',
+			'href' => 'https://cloud.example/index.php/apps/social/',
+			'properties' => ['app' => 'social', 'name' => 'Social', 'version' => '0.10.1'],
+		]], $this->jsonOf($response)['links']);
+	}
+
+	public function testAppSubjectWithoutPreviousResponseYieldsNothing(): void {
+		$this->resource(Application::APP_SUBJECT);
+
+		$this->assertNull($this->handler->handleWebfinger($this->context, null));
+	}
+}

--- a/tests/WellKnown/XrdResponseTest.php
+++ b/tests/WellKnown/XrdResponseTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\WellKnown;
+
+use OCA\Social\WellKnown\XrdResponse;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\TextPlainResponse;
+use OCP\IRequest;
+use PHPUnit\Framework\TestCase;
+
+class XrdResponseTest extends TestCase {
+	protected function setUp(): void {
+		\OC::$server->register(IRequest::class, $this->createMock(IRequest::class));
+	}
+
+	protected function tearDown(): void {
+		\OC::$server->reset();
+	}
+
+	public function testEmptyDocumentIsAValidXrdEnvelope(): void {
+		$http = (new XrdResponse())->toHttpResponse();
+
+		$this->assertInstanceOf(TextPlainResponse::class, $http);
+		$this->assertSame(Http::STATUS_OK, $http->getStatus());
+		$this->assertSame(
+			"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<XRD xmlns=\"http://docs.oasis-open.org/ns/xri/xrd-1.0\">\n</XRD>\n",
+			$http->render()
+		);
+	}
+
+	public function testContentTypeIsXrdXmlInsteadOfTextPlain(): void {
+		$http = (new XrdResponse())->toHttpResponse();
+
+		$this->assertSame('application/xrd+xml', $http->getHeaders()['Content-Type']);
+	}
+
+	public function testLinksAreRenderedAsLinkElementsInOrder(): void {
+		$response = (new XrdResponse())
+			->addLink('lrdd', 'https://cloud.example/.well-known/webfinger?resource={uri}')
+			->addLink('http://ostatus.org/schema/1.0/subscribe', 'https://cloud.example/follow?uri={uri}');
+
+		$xml = $response->toHttpResponse()->render();
+
+		$this->assertStringContainsString('  <Link rel="lrdd"  template="https://cloud.example/.well-known/webfinger?resource={uri}"/>' . "\n", $xml);
+		$this->assertStringContainsString('  <Link rel="http://ostatus.org/schema/1.0/subscribe"  template="https://cloud.example/follow?uri={uri}"/>' . "\n", $xml);
+		$this->assertLessThan(strpos($xml, 'ostatus.org'), strpos($xml, 'lrdd'));
+		$this->assertSame(2, substr_count($xml, '<Link '));
+	}
+
+	public function testHttpCodeIsForwarded(): void {
+		$this->assertSame(Http::STATUS_NOT_FOUND, (new XrdResponse(Http::STATUS_NOT_FOUND))->toHttpResponse()->getStatus());
+		$this->assertSame(Http::STATUS_GONE, (new XrdResponse())->setHttpCode(Http::STATUS_GONE)->toHttpResponse()->getStatus());
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,11 +1,64 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-require_once __DIR__ . '/../../../tests/bootstrap.php';
-require_once __DIR__ . '/../vendor/autoload.php';
+/**
+ * Standalone unit-test bootstrap.
+ *
+ * The suite runs without a Nextcloud server: OCP interfaces come from the
+ * `nextcloud/ocp` dev dependency, the app's own classes from the composer
+ * autoloader. Anything that would need a booted server (database, config,
+ * the `OC` container) is mocked in the tests themselves.
+ */
 
-OC_App::loadApp('social');
-OC_Hook::clear();
+// friendica/json-ld trips a compile-time deprecation on PHP 8.5; it is a
+// dependency, not our code, so keep it out of the test output.
+$previous = error_reporting(E_ALL & ~E_DEPRECATED);
+require_once __DIR__ . '/../vendor/autoload.php';
+error_reporting($previous);
+
+/**
+ * OCP interfaces, from the `nextcloud/ocp` dev dependency.
+ *
+ * Registered here rather than through composer's `autoload-dev`, deliberately:
+ * the app's autoloader is loaded by the server at runtime, so a psr-4 entry for
+ * `OCP\` there would shadow the server's real interfaces with these stubs on
+ * any installation that has dev dependencies present, and a server class
+ * carrying `#[\Override]` against a method the stub lacks then fails to load.
+ */
+spl_autoload_register(static function (string $class): void {
+	if (!str_starts_with($class, 'OCP\\')) {
+		return;
+	}
+
+	$file = __DIR__ . '/../vendor/nextcloud/ocp/' . str_replace('\\', '/', $class) . '.php';
+	if (is_file($file)) {
+		require_once $file;
+	}
+});
+
+if (!defined('PHPUNIT_RUN')) {
+	define('PHPUNIT_RUN', 1);
+}
+
+// `\OC` is the server's static root and is not part of the OCP stubs. A few code
+// paths reach it for the container, so provide one that hands out registered test
+// doubles (see TestContainer).
+if (!class_exists('OC', false)) {
+	class OC {
+		public static ?\OCA\Social\Tests\Helper\TestContainer $server = null;
+	}
+}
+OC::$server = new \OCA\Social\Tests\Helper\TestContainer();
+
+// Exceptions the app throws that live in the server's private namespace and are
+// therefore absent from the OCP stubs. Declared so the paths that raise them
+// stay reachable in tests.
+if (!class_exists('OC\\User\\NoUserException', false)) {
+	class_alias(\OCA\Social\Tests\Helper\NoUserException::class, 'OC\\User\\NoUserException');
+}

--- a/tests/js/App.test.js
+++ b/tests/js/App.test.js
@@ -1,0 +1,238 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/* global setInitialState */
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, shallowRef } from 'vue'
+import { createStore } from 'vuex'
+import axios from '@nextcloud/axios'
+import App from '../../src/App.vue'
+import account from '../../src/store/account.js'
+import errors from '../../src/store/errors.js'
+import settings from '../../src/store/settings.js'
+import timeline from '../../src/store/timeline.js'
+
+vi.hoisted(() => {
+	document.head.dataset.user = 'alice'
+	document.head.dataset.userDisplayname = 'Alice'
+})
+
+const pristine = {
+	account: structuredClone(account.state),
+	timeline: structuredClone(timeline.state),
+}
+
+const stubs = {
+	NcContent: { props: ['appName'], template: '<div class="content-stub" :data-app-name="appName"><slot /></div>' },
+	NcAppContent: { template: '<main class="app-content-stub"><slot /></main>' },
+	Navigation: { emits: ['search', 'reset-cache', 'open-composer'], template: '<nav class="navigation-stub" />' },
+	RouterView: { template: '<div class="router-view-stub" />' },
+}
+
+const baseServerData = {
+	public: false,
+	setup: false,
+	isAdmin: false,
+	firstrun: false,
+	cloudAddress: 'https://cloud.example.org',
+	cliUrl: 'https://cloud.example.org',
+	checks: { success: true, checks: { wellknown: true } },
+}
+
+let store
+let dispatch
+let route
+let router
+const fetchAccountInfo = vi.fn(async () => undefined)
+
+const setServerData = (overrides = {}) => {
+	setInitialState('social', 'serverData', { ...baseServerData, ...overrides })
+	window._nc_initial_state?.clear()
+}
+
+const makeStore = () => {
+	Object.assign(account.state, structuredClone(pristine.account))
+	Object.assign(timeline.state, structuredClone(pristine.timeline))
+	store = createStore({
+		modules: {
+			settings,
+			errors,
+			account: { ...account, actions: { ...account.actions, fetchAccountInfo } },
+			timeline: { ...timeline, actions: { ...timeline.actions, refreshTimeline: vi.fn(), fetchTimeline: vi.fn() } },
+		},
+	})
+	dispatch = vi.spyOn(store, 'dispatch')
+	return store
+}
+
+// $route is exposed through a getter so swapping the ref triggers the
+// component's $route watcher like vue-router would.
+const routePlugin = {
+	install(app) {
+		Object.defineProperty(app.config.globalProperties, '$route', { get: () => route.value, configurable: true })
+	},
+}
+
+const mountApp = () => mount(App, {
+	global: { plugins: [store, routePlugin], mocks: { $router: router }, stubs },
+})
+
+describe('App', () => {
+	beforeEach(() => {
+		makeStore()
+		fetchAccountInfo.mockClear()
+		route = shallowRef({ name: 'timeline', params: {}, fullPath: '/timeline' })
+		router = { push: vi.fn() }
+		setServerData()
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+		delete globalThis.OCA.Push
+	})
+
+	it('imports the server data and loads the current account', () => {
+		mountApp()
+		expect(store.state.settings.serverData).toEqual(baseServerData)
+		expect(dispatch).toHaveBeenCalledWith('fetchCurrentAccountInfo', 'alice@cloud.example.org')
+		expect(store.state.account.currentAccount).toBe('alice@cloud.example.org')
+		// the action dispatches the lookup through its module context
+		expect(fetchAccountInfo).toHaveBeenCalledTimes(1)
+		expect(fetchAccountInfo.mock.calls[0][1]).toBe('alice@cloud.example.org')
+	})
+
+	it('renders the navigation and the routed view inside the app content', () => {
+		const wrapper = mountApp()
+		expect(wrapper.find('.content-stub').attributes('data-app-name')).toBe('social')
+		expect(wrapper.find('.content-stub').classes()).not.toContain('public')
+		expect(wrapper.find('.navigation-stub').exists()).toBe(true)
+		expect(wrapper.find('.app-content-stub .router-view-stub').exists()).toBe(true)
+		expect(wrapper.find('.setup').exists()).toBe(false)
+	})
+
+	it('drops the navigation and skips the account lookup on the public page', () => {
+		setServerData({ public: true })
+		const wrapper = mountApp()
+		expect(wrapper.find('.content-stub').classes()).toContain('public')
+		expect(wrapper.find('.navigation-stub').exists()).toBe(false)
+		expect(wrapper.find('.router-view-stub').exists()).toBe(true)
+		expect(dispatch).not.toHaveBeenCalledWith('fetchCurrentAccountInfo', expect.anything())
+	})
+
+	it('warns administrators about a broken .well-known setup', () => {
+		setServerData({ isAdmin: true, checks: { success: false, checks: { wellknown: false } } })
+		const wrapper = mountApp()
+		expect(wrapper.find('.setup h3').text()).toBe('.well-known/webfinger isn\'t properly set up!')
+		expect(wrapper.find('.setup a.external_link').attributes('href')).toContain('admin-setup-well-known-URL')
+		expect(wrapper.find('.router-view-stub').exists()).toBe(true)
+	})
+
+	it('does not show the .well-known warning to regular users', () => {
+		setServerData({ isAdmin: false, checks: { success: false, checks: { wellknown: false } } })
+		expect(mountApp().find('.setup').exists()).toBe(false)
+	})
+
+	it('stores the search term coming from the navigation and clears it on navigation', async () => {
+		const wrapper = mountApp()
+		wrapper.findComponent(stubs.Navigation).vm.$emit('search', 'fediverse')
+		expect(store.state.timeline.searchQuery).toBe('fediverse')
+
+		route.value = { name: 'timeline', params: { type: 'federated' }, fullPath: '/timeline/federated' }
+		await nextTick()
+		expect(store.state.timeline.searchQuery).toBe('')
+	})
+
+	it('refreshes the server cache and then the timeline', async () => {
+		const post = vi.spyOn(axios, 'post').mockResolvedValue({ data: {} })
+		const wrapper = mountApp()
+		wrapper.findComponent(stubs.Navigation).vm.$emit('reset-cache')
+		expect(post).toHaveBeenCalledWith('/index.php/apps/social/api/v1/cache/refresh')
+		expect(dispatch).not.toHaveBeenCalledWith('refreshTimeline')
+		await flushPromises()
+		expect(dispatch).toHaveBeenCalledWith('refreshTimeline')
+	})
+
+	describe('push notifications', () => {
+		const status = { id: 's1', content: '<p>live</p>', created_at: '2026-03-01T10:00:00Z' }
+		let addCallback
+
+		beforeEach(() => {
+			addCallback = vi.fn()
+			globalThis.OCA.Push = { isEnabled: () => true, addCallback }
+		})
+
+		it('registers for the social push channel when the push app is enabled', () => {
+			mountApp()
+			expect(addCallback).toHaveBeenCalledTimes(1)
+			expect(addCallback.mock.calls[0][1]).toBe('social')
+		})
+
+		it('adds pushed home posts only while the home timeline is shown', () => {
+			mountApp()
+			const [callback] = addCallback.mock.calls[0]
+			callback({ source: 'timeline.home', payload: status })
+			expect(dispatch).toHaveBeenCalledWith('addToTimeline', [status])
+			expect(store.state.timeline.timeline).toEqual(['s1'])
+
+			dispatch.mockClear()
+			callback({ source: 'timeline.direct', payload: { ...status, id: 's2' } })
+			expect(dispatch).not.toHaveBeenCalledWith('addToTimeline', expect.anything())
+		})
+
+		it('adds pushed direct messages on the direct timeline', () => {
+			route.value = { name: 'timeline', params: { type: 'direct' }, fullPath: '/timeline/direct' }
+			mountApp()
+			const [callback] = addCallback.mock.calls[0]
+			callback({ source: 'timeline.direct', payload: status })
+			expect(dispatch).toHaveBeenCalledWith('addToTimeline', [status])
+			dispatch.mockClear()
+			callback({ source: 'timeline.home', payload: status })
+			expect(dispatch).not.toHaveBeenCalledWith('addToTimeline', expect.anything())
+		})
+
+		it('does not register when the push app is disabled', () => {
+			globalThis.OCA.Push = { isEnabled: () => false, addCallback }
+			mountApp()
+			expect(addCallback).not.toHaveBeenCalled()
+		})
+	})
+
+	describe('before the setup is finished', () => {
+		it('lets administrators enter the ActivityPub base URL and finish the setup', async () => {
+			setServerData({ setup: true, isAdmin: true })
+			const post = vi.spyOn(axios, 'post').mockResolvedValue({ data: {} })
+			const wrapper = mountApp()
+
+			expect(wrapper.find('.navigation-stub').exists()).toBe(false)
+			expect(wrapper.find('.router-view-stub').exists()).toBe(false)
+			expect(wrapper.find('.setup h2').text()).toBe('Social app setup')
+			const input = wrapper.find('input.setup-input')
+			expect(input.attributes('placeholder')).toBe('https://cloud.example.org')
+			expect(input.attributes('required')).toBeDefined()
+			expect(wrapper.find('.setup h3').exists()).toBe(false)
+
+			await input.setValue('https://social.example.org')
+			await wrapper.find('form').trigger('submit')
+			expect(post).toHaveBeenCalledWith('/index.php/apps/social/api/v1/config/cloudAddress', { cloudAddress: 'https://social.example.org' })
+
+			await flushPromises()
+			expect(wrapper.find('.setup h2').exists()).toBe(false)
+			expect(wrapper.find('.router-view-stub').exists()).toBe(true)
+		})
+
+		it('also shows the .well-known warning on the setup form', () => {
+			setServerData({ setup: true, isAdmin: true, checks: { success: false, checks: { wellknown: false } } })
+			expect(mountApp().find('form h3').text()).toBe('.well-known/webfinger isn\'t properly set up!')
+		})
+
+		it('tells regular users to wait for the administrator', () => {
+			setServerData({ setup: true, isAdmin: false })
+			const wrapper = mountApp()
+			expect(wrapper.find('.setup').text()).toBe('The Social app needs to be set up by the server administrator.')
+			expect(wrapper.find('form').exists()).toBe(false)
+			expect(wrapper.find('.router-view-stub').exists()).toBe(false)
+		})
+	})
+})

--- a/tests/js/components/ActorAvatar.test.js
+++ b/tests/js/components/ActorAvatar.test.js
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import ActorAvatar from '../../../src/components/ActorAvatar.vue'
+
+// NcAvatar loads images asynchronously and never renders an <img> in jsdom,
+// so assert on what the component hands to it instead.
+const NcAvatarStub = {
+	name: 'NcAvatar',
+	props: ['url', 'user', 'displayName', 'size', 'disableTooltip', 'showUserStatus'],
+	template: '<span class="nc-avatar-stub" />',
+}
+
+const mountAvatar = (props) => mount(ActorAvatar, {
+	props,
+	global: { stubs: { NcAvatar: NcAvatarStub } },
+})
+
+const local = { username: 'bob', acct: 'bob', avatar: 'https://cloud.example.org/avatar/bob/128' }
+
+describe('ActorAvatar', () => {
+	it('resolves a local actor through the server avatar endpoint by username', () => {
+		const avatar = mountAvatar({ actor: local }).findComponent(NcAvatarStub)
+		expect(avatar.props('user')).toBe('bob')
+		expect(avatar.props('displayName')).toBe('bob')
+		// the actor's own avatar URL is ignored for local users, the server one wins
+		expect(avatar.props('url')).toBeUndefined()
+	})
+
+	it('never shows a tooltip or user status', () => {
+		const avatar = mountAvatar({ actor: local }).findComponent(NcAvatarStub)
+		expect(avatar.props('disableTooltip')).toBe(true)
+		expect(avatar.props('showUserStatus')).toBe(false)
+	})
+
+	it('defaults to 32px and forwards a custom size', () => {
+		expect(mountAvatar({ actor: local }).findComponent(NcAvatarStub).props('size')).toBe(32)
+		expect(mountAvatar({ actor: local, size: 64 }).findComponent(NcAvatarStub).props('size')).toBe(64)
+	})
+
+	it('works for a local actor without any avatar field', () => {
+		const avatar = mountAvatar({ actor: { username: 'bob', acct: 'bob' } }).findComponent(NcAvatarStub)
+		expect(avatar.props('user')).toBe('bob')
+		expect(avatar.props('url')).toBeUndefined()
+	})
+})

--- a/tests/js/components/Composer.test.js
+++ b/tests/js/components/Composer.test.js
@@ -1,0 +1,485 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { flushPromises, mount, RouterLinkStub } from '@vue/test-utils'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import Composer from '../../../src/components/Composer/Composer.vue'
+import PreviewGridItem from '../../../src/components/Composer/PreviewGridItem.vue'
+import SubmitStatusButton from '../../../src/components/Composer/SubmitStatusButton.vue'
+import VisibilitySelect from '../../../src/components/Visibility/VisibilitySelect.vue'
+import eventBus from '../../../src/services/eventBus.js'
+
+// @nextcloud/auth reads the user from <head>, which the harness does not set
+vi.mock('@nextcloud/auth', async (importOriginal) => ({
+	...(await importOriginal()),
+	getCurrentUser: () => ({ uid: 'alice', displayName: 'Alice', isAdmin: false }),
+}))
+
+const media = {
+	id: 'media-1',
+	type: 'image',
+	url: 'https://cloud.example.org/media/original.png',
+	preview_url: 'https://cloud.example.org/media/small.png',
+	description: '',
+	blurhash: 'LEHV6nWB2yk8pyo0adR*.7kCMdnj',
+	meta: { small: { width: 4, height: 3 } },
+}
+
+const bob = {
+	id: '2',
+	acct: 'bob@remote.example',
+	username: 'bob',
+	display_name: 'Bob',
+	url: 'https://remote.example/@bob',
+	avatar: 'https://remote.example/avatar.png',
+}
+
+const carol = {
+	id: '3',
+	acct: 'carol',
+	username: 'carol',
+	display_name: 'Carol',
+	url: 'https://cloud.example.org/@carol',
+	avatar: 'https://cloud.example.org/avatar/carol/64',
+}
+
+const replyTo = (account = bob, overrides = {}) => ({
+	id: '42',
+	visibility: 'unlisted',
+	content: '<p>Original post</p>',
+	mentions: [],
+	tags: [],
+	account,
+	...overrides,
+})
+
+// What the mention autocomplete inserts into the contenteditable
+const MENTION_BOB = '<span class="mention" contenteditable="false">'
+	+ '<a href="https://remote.example/@bob" target="_blank"><img src="https://remote.example/avatar.png">@bob@remote.example</a>'
+	+ '</span>&nbsp;'
+
+const wrappers = []
+
+const mountComposer = (props = {}) => {
+	const $store = {
+		dispatch: vi.fn((action) => Promise.resolve(action === 'createMedia' ? media : undefined)),
+		commit: vi.fn(),
+		getters: { getServerData: { public: false, cloudAddress: 'https://cloud.example.org' } },
+	}
+	const wrapper = mount(Composer, {
+		props,
+		global: {
+			mocks: { $store },
+			stubs: {
+				// the template uses <Tribute> without registering a component for it
+				Tribute: { template: '<div class="tribute-stub"><slot /></div>' },
+				NcEmojiPicker: { name: 'NcEmojiPicker', emits: ['select'], template: '<div class="emoji-picker-stub"><slot /></div>' },
+				NcAvatar: true,
+				ActorAvatar: true,
+				RouterLink: RouterLinkStub,
+			},
+		},
+	})
+	wrappers.push(wrapper)
+	return { wrapper, $store }
+}
+
+const input = (wrapper) => wrapper.find('.message')
+// untrimmed, unlike DOMWrapper.text(), because inserted emoji end with a space
+const typed = (wrapper) => input(wrapper).element.textContent
+
+const setContent = async (wrapper, html) => {
+	input(wrapper).element.innerHTML = html
+	await input(wrapper).trigger('input')
+}
+
+const submitButton = (wrapper) => wrapper.findComponent(SubmitStatusButton).find('button')
+const canPost = (wrapper) => submitButton(wrapper).attributes('disabled') === undefined
+const currentVisibility = (wrapper) => wrapper.findComponent(VisibilitySelect).props('visibility')
+const selectVisibility = (wrapper, visibility) => wrapper.findComponent(VisibilitySelect).vm.$emit('update:visibility', visibility)
+const pickEmoji = (wrapper, emoji) => wrapper.findComponent({ name: 'NcEmojiPicker' }).vm.$emit('select', emoji)
+
+const attachFile = async (wrapper, file) => {
+	const fileInput = wrapper.find('input[type="file"]')
+	Object.defineProperty(fileInput.element, 'files', { value: [file], configurable: true })
+	await fileInput.trigger('change')
+}
+
+const postedStatus = ($store) => $store.dispatch.mock.calls.find(([action]) => action === 'post')?.[1]
+
+describe('Composer', () => {
+	let getContext
+	let createObjectURL
+
+	// jsdom has no innerText; the composer empties its input through it after posting
+	beforeAll(() => {
+		Object.defineProperty(HTMLElement.prototype, 'innerText', {
+			configurable: true,
+			get() {
+				return this.textContent
+			},
+			set(value) {
+				this.textContent = value
+			},
+		})
+	})
+
+	afterAll(() => {
+		delete HTMLElement.prototype.innerText
+	})
+
+	beforeEach(() => {
+		localStorage.clear()
+		vi.spyOn(console, 'debug').mockImplementation(() => {})
+		getContext = vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+			createImageData: (width, height) => ({ data: new Uint8ClampedArray(width * height * 4) }),
+			putImageData: () => {},
+		})
+		createObjectURL = URL.createObjectURL
+		URL.createObjectURL = vi.fn(() => 'blob:preview-1')
+	})
+
+	afterEach(() => {
+		while (wrappers.length > 0) {
+			wrappers.pop().unmount()
+		}
+		eventBus.all.clear()
+		getContext.mockRestore()
+		URL.createObjectURL = createObjectURL
+		vi.restoreAllMocks()
+	})
+
+	describe('author', () => {
+		it('shows the current user with their federated handle', () => {
+			const { wrapper } = mountComposer()
+			expect(wrapper.find('.post-author-name').text()).toBe('Alice')
+			expect(wrapper.find('.post-author-id').text()).toBe('@alice@cloud.example.org')
+		})
+	})
+
+	describe('default visibility', () => {
+		it('uses the visibility passed by the parent first', () => {
+			localStorage.setItem('social.lastPostType', 'direct')
+			const { wrapper } = mountComposer({ defaultVisibility: 'unlisted' })
+			expect(currentVisibility(wrapper)).toBe('unlisted')
+		})
+
+		it('falls back to the visibility of the last post', () => {
+			localStorage.setItem('social.lastPostType', 'direct')
+			const { wrapper } = mountComposer()
+			expect(currentVisibility(wrapper)).toBe('direct')
+		})
+
+		it('defaults to followers only', () => {
+			const { wrapper } = mountComposer()
+			expect(currentVisibility(wrapper)).toBe('followers')
+			expect(submitButton(wrapper).text()).toBe('Post to followers')
+		})
+
+		it('follows the visibility selector', async () => {
+			const { wrapper } = mountComposer()
+			await selectVisibility(wrapper, 'public')
+			expect(currentVisibility(wrapper)).toBe('public')
+			expect(submitButton(wrapper).text()).toBe('Post')
+		})
+	})
+
+	describe('whether a post can be sent', () => {
+		it('not while the message is empty', async () => {
+			const { wrapper } = mountComposer()
+			expect(canPost(wrapper)).toBe(false)
+			await setContent(wrapper, '<br>')
+			expect(canPost(wrapper)).toBe(false)
+		})
+
+		it('once there is some text', async () => {
+			const { wrapper } = mountComposer()
+			await setContent(wrapper, 'Hello fediverse')
+			expect(canPost(wrapper)).toBe(true)
+		})
+
+		it('not beyond 500 characters, which is flagged on the input', async () => {
+			const { wrapper } = mountComposer()
+			await setContent(wrapper, 'a'.repeat(500))
+			expect(canPost(wrapper)).toBe(true)
+			expect(input(wrapper).classes()).not.toContain('too-long')
+
+			await setContent(wrapper, 'a'.repeat(501))
+			expect(canPost(wrapper)).toBe(false)
+			expect(input(wrapper).classes()).toContain('too-long')
+		})
+
+		it('not as a direct message without anyone mentioned', async () => {
+			const { wrapper } = mountComposer({ defaultVisibility: 'direct' })
+			await setContent(wrapper, 'psst, secret')
+			expect(canPost(wrapper)).toBe(false)
+		})
+
+		it('as a direct message once a handle is typed', async () => {
+			const { wrapper } = mountComposer({ defaultVisibility: 'direct' })
+			await setContent(wrapper, 'psst @bob@remote.example secret')
+			expect(canPost(wrapper)).toBe(true)
+		})
+
+		it('as a direct message once the autocomplete inserted a mention', async () => {
+			const { wrapper } = mountComposer({ defaultVisibility: 'direct' })
+			await setContent(wrapper, `${MENTION_BOB}secret`)
+			expect(canPost(wrapper)).toBe(true)
+		})
+
+		it('not while an attachment is still uploading', async () => {
+			const { wrapper, $store } = mountComposer()
+			await setContent(wrapper, 'Look at this')
+			let finishUpload
+			$store.dispatch.mockImplementation((action) => (action === 'createMedia'
+				? new Promise((resolve) => { finishUpload = resolve })
+				: Promise.resolve()))
+
+			await attachFile(wrapper, new File(['x'], 'cat.png', { type: 'image/png' }))
+			expect(canPost(wrapper)).toBe(false)
+
+			finishUpload(media)
+			await flushPromises()
+			expect(canPost(wrapper)).toBe(true)
+		})
+	})
+
+	describe('attachments', () => {
+		it('uploads a selected file and previews it', async () => {
+			const { wrapper, $store } = mountComposer()
+			const file = new File(['x'], 'cat.png', { type: 'image/png' })
+
+			await attachFile(wrapper, file)
+
+			expect(URL.createObjectURL).toHaveBeenCalledWith(file)
+			expect($store.dispatch).toHaveBeenCalledWith('createMedia', file)
+			const preview = wrapper.findComponent(PreviewGridItem)
+			expect(preview.props('randomKey')).toBe('blob:preview-1')
+			expect(preview.find('.loading-icon').exists()).toBe(true)
+
+			await flushPromises()
+			expect(preview.props('preview')).toEqual({ file, data: media })
+			expect(preview.find('img').attributes('src')).toBe(media.preview_url)
+		})
+
+		it('drops a preview again when it is deleted', async () => {
+			const { wrapper } = mountComposer()
+			await attachFile(wrapper, new File(['x'], 'cat.png', { type: 'image/png' }))
+			await flushPromises()
+
+			await wrapper.findComponent(PreviewGridItem).find('button').trigger('click')
+
+			expect(wrapper.findComponent(PreviewGridItem).exists()).toBe(false)
+		})
+
+		it('opens the file picker from the attachment button', async () => {
+			const { wrapper } = mountComposer()
+			const click = vi.spyOn(wrapper.find('input[type="file"]').element, 'click')
+			await wrapper.find('button[aria-label="Add attachment"]').trigger('click')
+			expect(click).toHaveBeenCalledTimes(1)
+		})
+	})
+
+	describe('emoji', () => {
+		it('inserts a picked emoji into an empty message', async () => {
+			const { wrapper } = mountComposer()
+			await pickEmoji(wrapper, '😀')
+			expect(typed(wrapper)).toBe('😀 ')
+			expect(canPost(wrapper)).toBe(true)
+		})
+
+		it('appends a picked emoji to the text', async () => {
+			const { wrapper } = mountComposer()
+			await setContent(wrapper, 'hi')
+			await pickEmoji(wrapper, '😀')
+			expect(typed(wrapper)).toBe('hi😀 ')
+		})
+
+		it('keeps a picked emoji before a trailing line break', async () => {
+			const { wrapper } = mountComposer()
+			await setContent(wrapper, 'hi<br>')
+			await pickEmoji(wrapper, '🎉')
+			expect(input(wrapper).element.innerHTML).toBe('hi🎉 <br>')
+		})
+
+		it('unwraps the picker\'s category object to its first emoji', async () => {
+			const { wrapper } = mountComposer()
+			await pickEmoji(wrapper, { people: { grinning: '😀', wink: '😉' } })
+			expect(typed(wrapper)).toBe('😀 ')
+		})
+	})
+
+	describe('posting', () => {
+		it('sends the plain text of the message with the attachments and visibility', async () => {
+			const { wrapper, $store } = mountComposer({ defaultVisibility: 'public' })
+			await attachFile(wrapper, new File(['x'], 'cat.png', { type: 'image/png' }))
+			await flushPromises()
+			await setContent(wrapper,
+				`<div>${MENTION_BOB}hello <img class="emoji" alt="😀" src="/apps/social/img/twemoji/1f600.svg"> Tom &amp; Jerry</div>`
+				+ '<div>second line</div>')
+
+			await submitButton(wrapper).trigger('click')
+			await flushPromises()
+
+			expect(postedStatus($store)).toEqual({
+				content_type: '',
+				status: '@bob@remote.example hello 😀 Tom & Jerry\nsecond line',
+				visibility: 'public',
+				media_ids: ['media-1'],
+				in_reply_to_id: undefined,
+				sensitive: false,
+				spoiler_text: '',
+			})
+		})
+
+		it('locks the input while sending and clears everything afterwards', async () => {
+			const { wrapper, $store } = mountComposer()
+			await attachFile(wrapper, new File(['x'], 'cat.png', { type: 'image/png' }))
+			await flushPromises()
+			await setContent(wrapper, 'Hello')
+			let finishPost
+			$store.dispatch.mockImplementation((action) => (action === 'post'
+				? new Promise((resolve) => { finishPost = resolve })
+				: Promise.resolve()))
+
+			await submitButton(wrapper).trigger('click')
+			expect(input(wrapper).attributes('contenteditable')).toBe('false')
+			expect(input(wrapper).classes()).toContain('icon-loading')
+			expect(canPost(wrapper)).toBe(false)
+
+			finishPost()
+			await flushPromises()
+
+			expect(input(wrapper).attributes('contenteditable')).toBe('true')
+			expect(typed(wrapper)).toBe('')
+			expect(wrapper.findComponent(PreviewGridItem).exists()).toBe(false)
+			expect(canPost(wrapper)).toBe(false)
+			expect($store.dispatch).toHaveBeenLastCalledWith('refreshTimeline')
+		})
+
+		it('posts on Ctrl+Enter but not on Enter alone', async () => {
+			const { wrapper, $store } = mountComposer()
+			await setContent(wrapper, 'Hello')
+
+			await input(wrapper).trigger('keyup', { key: 'Enter' })
+			expect(postedStatus($store)).toBeUndefined()
+
+			await input(wrapper).trigger('keyup', { key: 'Enter', ctrlKey: true })
+			await flushPromises()
+			expect(postedStatus($store)).toMatchObject({ status: 'Hello' })
+		})
+
+		it('sends no media ids after the only attachment was removed', async () => {
+			const { wrapper, $store } = mountComposer()
+			await attachFile(wrapper, new File(['x'], 'cat.png', { type: 'image/png' }))
+			await flushPromises()
+			await wrapper.findComponent(PreviewGridItem).find('button').trigger('click')
+			await setContent(wrapper, 'No picture after all')
+
+			await submitButton(wrapper).trigger('click')
+			await flushPromises()
+
+			expect(postedStatus($store)).toMatchObject({ media_ids: [] })
+		})
+	})
+
+	describe('replying', () => {
+		it('shows who is being answered and adopts the visibility of their post', async () => {
+			const { wrapper } = mountComposer({ defaultVisibility: 'public' })
+
+			eventBus.emit('composer-reply', replyTo(bob))
+			await flushPromises()
+
+			const banner = wrapper.find('.reply-to')
+			expect(banner.find('.reply-info').text()).toContain('In reply to')
+			expect(banner.find('strong').text()).toBe('bob@remote.example')
+			expect(banner.text()).toContain('Original post')
+			expect(currentVisibility(wrapper)).toBe('unlisted')
+		})
+
+		it('prefills a mention of the remote author', async () => {
+			const { wrapper } = mountComposer()
+
+			eventBus.emit('composer-reply', replyTo(bob))
+			await flushPromises()
+
+			const mention = input(wrapper).find('.mention a')
+			expect(mention.attributes('href')).toBe('https://remote.example/@bob')
+			expect(mention.find('img').attributes('src')).toBe(bob.avatar)
+			expect(mention.text()).toBe('@bob@remote.example')
+			expect(canPost(wrapper)).toBe(true)
+		})
+
+		it('completes the handle of a local author with the instance host', async () => {
+			const { wrapper } = mountComposer()
+
+			eventBus.emit('composer-reply', replyTo(carol))
+			await flushPromises()
+
+			expect(input(wrapper).find('.mention a').text()).toBe('@carol@cloud.example.org')
+		})
+
+		it('does not overwrite a message that is already being written', async () => {
+			const { wrapper } = mountComposer()
+			await setContent(wrapper, 'my draft')
+
+			eventBus.emit('composer-reply', replyTo(bob))
+			await flushPromises()
+
+			expect(wrapper.find('.reply-to').exists()).toBe(true)
+			expect(input(wrapper).find('.mention').exists()).toBe(false)
+			expect(input(wrapper).text()).toBe('my draft')
+		})
+
+		it('sends the reply as an answer to the original post', async () => {
+			const { wrapper, $store } = mountComposer()
+			eventBus.emit('composer-reply', replyTo(bob))
+			await flushPromises()
+
+			await submitButton(wrapper).trigger('click')
+			await flushPromises()
+
+			expect(postedStatus($store)).toMatchObject({
+				in_reply_to_id: '42',
+				visibility: 'unlisted',
+				status: '@bob@remote.example',
+			})
+			expect(wrapper.find('.reply-to').exists()).toBe(false)
+		})
+
+		it('can be dismissed, which also hides the composer', async () => {
+			const { wrapper, $store } = mountComposer()
+			eventBus.emit('composer-reply', replyTo(bob))
+			await flushPromises()
+
+			await wrapper.find('.reply-to button[aria-label="Close reply"]').trigger('click')
+
+			expect(wrapper.find('.reply-to').exists()).toBe(false)
+			expect($store.commit).toHaveBeenCalledWith('setComposerDisplayStatus', false)
+		})
+	})
+
+	describe('initial mention', () => {
+		it('starts the message with a mention of the given account', async () => {
+			const { wrapper } = mountComposer({ initialMention: bob })
+			await flushPromises()
+			expect(input(wrapper).find('.mention a').text()).toBe('@bob@remote.example')
+			expect(canPost(wrapper)).toBe(true)
+		})
+	})
+
+	describe('lifecycle', () => {
+		it('listens for replies only while mounted', () => {
+			const { wrapper } = mountComposer()
+			expect(eventBus.all.get('composer-reply')).toHaveLength(1)
+
+			wrapper.unmount()
+			wrappers.pop()
+
+			expect(eventBus.all.get('composer-reply') ?? []).toHaveLength(0)
+			expect(() => eventBus.emit('composer-reply', replyTo(bob))).not.toThrow()
+		})
+	})
+})

--- a/tests/js/components/Emoji.test.js
+++ b/tests/js/components/Emoji.test.js
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import Emoji from '../../../src/components/Emoji.vue'
+
+const mountEmoji = (emoji) => mount(Emoji, { props: { emoji } })
+
+describe('Emoji', () => {
+	it('renders a twemoji image from the app bundle for a simple emoji', () => {
+		const img = mountEmoji('😀').find('img.emoji')
+		expect(img.attributes('src')).toBe('/apps/social/img/twemoji/1f600.svg')
+		expect(img.attributes('alt')).toBe('😀')
+		expect(img.attributes('draggable')).toBe('false')
+	})
+
+	it('drops the variation selector from a plain emoji', () => {
+		// red heart is U+2764 U+FE0F; twemoji ships it as 2764.svg
+		expect(mountEmoji('❤️').find('img').attributes('src')).toBe('/apps/social/img/twemoji/2764.svg')
+	})
+
+	it('keeps the full code point sequence for a ZWJ sequence', () => {
+		expect(mountEmoji('👨‍👩‍👧').find('img').attributes('src'))
+			.toBe('/apps/social/img/twemoji/1f468-200d-1f469-200d-1f467.svg')
+	})
+
+	it('keeps the variation selector inside a ZWJ sequence', () => {
+		// rainbow flag: U+1F3F3 U+FE0F U+200D U+1F308
+		expect(mountEmoji('🏳️‍🌈').find('img').attributes('src'))
+			.toBe('/apps/social/img/twemoji/1f3f3-fe0f-200d-1f308.svg')
+	})
+})

--- a/tests/js/components/EmptyContent.test.js
+++ b/tests/js/components/EmptyContent.test.js
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import EmptyContent from '../../../src/components/EmptyContent.vue'
+
+const mountEmpty = (item) => mount(EmptyContent, { props: { item } })
+
+describe('EmptyContent', () => {
+	it('renders the description', () => {
+		const wrapper = mountEmpty({ title: 'No posts', description: 'Follow somebody to fill your timeline', image: 'img/undraw/posts.svg' })
+		expect(wrapper.find('.empty-content__description').text()).toBe('Follow somebody to fill your timeline')
+	})
+
+	it('resolves the illustration relative to the app root', () => {
+		const img = mountEmpty({ description: 'x', image: 'img/undraw/posts.svg' }).find('img.empty-content__image')
+		expect(img.attributes('src')).toBe('/apps/social/img/undraw/posts.svg')
+		expect(img.attributes('alt')).toBe('')
+		expect(img.element.closest('.empty-content__icon')).not.toBeNull()
+	})
+
+	it('omits the icon area when the item has no image', () => {
+		const wrapper = mountEmpty({ description: 'Nothing here' })
+		expect(wrapper.find('img').exists()).toBe(false)
+		expect(wrapper.find('.empty-content__icon').exists()).toBe(false)
+		expect(wrapper.find('.empty-content__description').text()).toBe('Nothing here')
+	})
+
+	it('omits the description paragraph when there is none', () => {
+		const wrapper = mountEmpty({ image: 'img/x.svg' })
+		expect(wrapper.find('.empty-content__description').exists()).toBe(false)
+	})
+})

--- a/tests/js/components/FollowButton.test.js
+++ b/tests/js/components/FollowButton.test.js
@@ -1,0 +1,157 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { createStore } from 'vuex'
+import FollowButton from '../../../src/components/FollowButton.vue'
+import account from '../../../src/store/account.js'
+import settings from '../../../src/store/settings.js'
+
+// @nextcloud/auth reads the current user from <head> once and caches it.
+vi.hoisted(() => {
+	document.head.dataset.user = 'alice'
+	document.head.dataset.userDisplayname = 'Alice'
+})
+
+// The store modules keep their state in a shared module-level object.
+const pristine = structuredClone(account.state)
+
+const bob = { id: 'https://remote.example/users/bob', url: 'https://remote.example/users/bob', acct: 'bob@remote.example', username: 'bob', display_name: 'Bob' }
+const carol = { id: 'https://cloud.example.org/users/carol', url: 'https://cloud.example.org/users/carol', acct: 'carol', username: 'carol', display_name: 'Carol' }
+
+let store
+
+const makeStore = (serverData = {}) => {
+	Object.assign(account.state, structuredClone(pristine))
+	store = createStore({ modules: { account, settings } })
+	store.commit('setServerData', { public: false, cloudAddress: 'https://cloud.example.org', ...serverData })
+	store.commit('addAccount', { actorId: bob.url, data: bob })
+	store.commit('addAccount', { actorId: carol.url, data: carol })
+	return store
+}
+
+const setRelationship = (target, data = {}) => store.commit('addRelationship', {
+	actorId: target.id,
+	data: { id: target.id, following: false, requested: false, ...data },
+})
+
+const mountButton = (uid = bob.acct, errorHandler) => mount(FollowButton, {
+	props: { uid },
+	global: { plugins: [store], config: { errorHandler } },
+})
+
+const buttonTexts = (wrapper) => wrapper.findAll('button').map((button) => button.text())
+
+describe('FollowButton', () => {
+	beforeEach(() => {
+		makeStore()
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('renders nothing until the relationship with the account is known', () => {
+		expect(mountButton().find('button').exists()).toBe(false)
+	})
+
+	it('renders nothing for unauthenticated visitors of the public page', () => {
+		makeStore({ public: true })
+		setRelationship(bob)
+		expect(mountButton().find('button').exists()).toBe(false)
+	})
+
+	it('offers to follow an account the user does not follow yet', () => {
+		setRelationship(bob)
+		const wrapper = mountButton()
+		expect(buttonTexts(wrapper)).toEqual(['Follow'])
+		expect(wrapper.find('button').attributes('disabled')).toBeUndefined()
+	})
+
+	it('shows the following state together with the hover unfollow action', () => {
+		setRelationship(bob, { following: true })
+		const wrapper = mountButton()
+		expect(wrapper.find('.follow-button-container .follow-button--following').text()).toBe('Following')
+		expect(wrapper.find('.follow-button-container .follow-button--unfollow').text()).toBe('Unfollow')
+		expect(buttonTexts(wrapper)).toEqual(['Following', 'Unfollow'])
+	})
+
+	it('shows a disabled "Requested" state while a follow request is pending', () => {
+		setRelationship(bob, { requested: true })
+		const button = mountButton().find('button')
+		expect(button.text()).toBe('Requested')
+		expect(button.attributes('disabled')).toBeDefined()
+	})
+
+	it('dispatches followAccount with both handles and blocks the button until it settles', async () => {
+		setRelationship(bob)
+		let settle
+		const dispatch = vi.spyOn(store, 'dispatch').mockImplementation(() => new Promise((resolve) => {
+			settle = resolve
+		}))
+		const wrapper = mountButton()
+
+		await wrapper.find('button').trigger('click')
+		expect(dispatch).toHaveBeenCalledWith('followAccount', {
+			currentAccount: 'alice@cloud.example.org',
+			accountToFollow: 'bob@remote.example',
+		})
+		expect(wrapper.find('button').attributes('disabled')).toBeDefined()
+
+		settle()
+		await flushPromises()
+		expect(wrapper.find('button').attributes('disabled')).toBeUndefined()
+	})
+
+	it('dispatches unfollowAccount from the unfollow button', async () => {
+		setRelationship(bob, { following: true })
+		const dispatch = vi.spyOn(store, 'dispatch').mockResolvedValue(undefined)
+		const wrapper = mountButton()
+
+		await wrapper.find('.follow-button--unfollow').trigger('click')
+		expect(dispatch).toHaveBeenCalledWith('unfollowAccount', {
+			currentAccount: 'alice@cloud.example.org',
+			accountToUnfollow: 'bob@remote.example',
+		})
+		expect(dispatch).toHaveBeenCalledTimes(1)
+	})
+
+	it('re-enables the button when the follow request is rejected', async () => {
+		setRelationship(bob)
+		vi.spyOn(store, 'dispatch').mockRejectedValue(new Error('status -1'))
+		const errorHandler = vi.fn()
+		const wrapper = mountButton(bob.acct, errorHandler)
+
+		await wrapper.find('button').trigger('click')
+		await flushPromises()
+		expect(errorHandler).toHaveBeenCalledTimes(1)
+		expect(wrapper.find('button').attributes('disabled')).toBeUndefined()
+	})
+
+	it('completes a bare local uid with the instance hostname', async () => {
+		setRelationship(carol)
+		const dispatch = vi.spyOn(store, 'dispatch').mockResolvedValue(undefined)
+		await mountButton('carol').find('button').trigger('click')
+		expect(dispatch).toHaveBeenCalledWith('followAccount', {
+			currentAccount: 'alice@cloud.example.org',
+			accountToFollow: 'carol@cloud.example.org',
+		})
+	})
+
+	it('flips to the following state once the store records the follow', async () => {
+		setRelationship(bob)
+		const wrapper = mountButton()
+		expect(buttonTexts(wrapper)).toEqual(['Follow'])
+
+		store.commit('followAccount', bob.acct)
+		await nextTick()
+		expect(buttonTexts(wrapper)).toEqual(['Following', 'Unfollow'])
+
+		store.commit('unfollowAccount', bob.acct)
+		await nextTick()
+		expect(buttonTexts(wrapper)).toEqual(['Follow'])
+	})
+})

--- a/tests/js/components/MediaAttachment.test.js
+++ b/tests/js/components/MediaAttachment.test.js
@@ -1,0 +1,94 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import MediaAttachment from '../../../src/components/MediaAttachment.vue'
+
+const attachment = {
+	id: '7',
+	type: 'image',
+	url: 'https://cloud.example.org/media/original.jpg',
+	preview_url: 'https://cloud.example.org/media/small.jpg',
+	description: 'A cat on a sofa',
+	blurhash: 'LEHV6nWB2yk8pyo0adR*.7kCMdnj',
+	meta: { small: { width: 4, height: 3 } },
+}
+
+describe('MediaAttachment', () => {
+	let context
+	let getContext
+
+	beforeEach(() => {
+		// jsdom has no 2D canvas: hand out a stub context and record what is drawn
+		context = {
+			createImageData: vi.fn((width, height) => ({ data: new Uint8ClampedArray(width * height * 4) })),
+			putImageData: vi.fn(),
+		}
+		getContext = vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(context)
+	})
+
+	afterEach(() => {
+		getContext.mockRestore()
+	})
+
+	it('renders the small preview image', () => {
+		const wrapper = mount(MediaAttachment, { props: { attachment } })
+		expect(wrapper.find('img.attachment__preview').attributes('src')).toBe(attachment.preview_url)
+	})
+
+	it('paints the blurhash placeholder at the small preview dimensions', () => {
+		mount(MediaAttachment, { props: { attachment } })
+
+		expect(getContext).toHaveBeenCalledWith('2d')
+		expect(context.createImageData).toHaveBeenCalledWith(4, 3)
+		const imageData = context.createImageData.mock.results[0].value
+		expect(imageData.data).toHaveLength(4 * 3 * 4)
+		expect(imageData.data.some((channel) => channel !== 0)).toBe(true)
+		expect(context.putImageData).toHaveBeenCalledWith(imageData, 0, 0)
+	})
+
+	it('shows the placeholder and a spinner until the preview has loaded', async () => {
+		const wrapper = mount(MediaAttachment, { props: { attachment } })
+		expect(wrapper.find('canvas.attachment__blurhash').exists()).toBe(true)
+		expect(wrapper.find('.loading-icon').exists()).toBe(true)
+
+		await wrapper.find('img').trigger('load')
+
+		expect(wrapper.find('canvas').exists()).toBe(false)
+		expect(wrapper.find('.loading-icon').exists()).toBe(false)
+		expect(wrapper.find('img.attachment__preview').exists()).toBe(true)
+	})
+
+	it('shows only a spinner while the attachment is still uploading', () => {
+		const wrapper = mount(MediaAttachment, { props: { attachment: null } })
+		expect(wrapper.find('img').exists()).toBe(false)
+		expect(wrapper.find('.loading-icon').exists()).toBe(true)
+		expect(getContext).not.toHaveBeenCalled()
+	})
+
+	it('skips the blurhash when the preview size is unknown', () => {
+		mount(MediaAttachment, { props: { attachment: { ...attachment, meta: { small: {} } } } })
+		expect(getContext).not.toHaveBeenCalled()
+		expect(context.putImageData).not.toHaveBeenCalled()
+	})
+
+	it('repaints when the attachment arrives after an upload', async () => {
+		const wrapper = mount(MediaAttachment, { props: { attachment: null } })
+		expect(context.createImageData).not.toHaveBeenCalled()
+
+		await wrapper.setProps({ attachment: { ...attachment, meta: { small: { width: 2, height: 5 } } } })
+
+		expect(context.createImageData).toHaveBeenCalledWith(2, 5)
+		expect(wrapper.find('img').attributes('src')).toBe(attachment.preview_url)
+	})
+
+	it('emits click so a parent can open the viewer', async () => {
+		const wrapper = mount(MediaAttachment, { props: { attachment } })
+		await wrapper.find('.attachment').trigger('click')
+		// the component's own emit carries no payload (the native event is recorded separately)
+		expect(wrapper.emitted('click')).toContainEqual([])
+	})
+})

--- a/tests/js/components/MessageContent.test.js
+++ b/tests/js/components/MessageContent.test.js
@@ -1,0 +1,182 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import MessageContent from '../../../src/components/MessageContent.js'
+
+const Empty = { template: '<div />' }
+
+/**
+ * The named routes MessageContent links to, with the paths of src/router.js,
+ * so the rendered <a href> is what the app would navigate to.
+ */
+const makeRouter = () => createRouter({
+	history: createMemoryHistory('/apps/social/'),
+	routes: [
+		{ path: '/', component: Empty },
+		{
+			path: '/timeline/:type?',
+			name: 'timeline',
+			component: Empty,
+			children: [{ path: 'tags/:tag', name: 'tags', component: Empty }],
+		},
+		{ path: '/@:account', name: 'profile', component: Empty },
+	],
+})
+
+const mountContent = (content, extra = {}) => mount(MessageContent, {
+	props: { item: { content, mentions: [], ...extra } },
+	global: { plugins: [makeRouter()] },
+})
+
+describe('MessageContent', () => {
+	describe('formatting', () => {
+		it('keeps the structural markup Mastodon sends', () => {
+			const wrapper = mountContent('<p>Hello <strong>world</strong><br>and <em>more</em></p>'
+				+ '<blockquote><p>quoted</p></blockquote><ul><li>one</li></ul><pre><code>run()</code></pre>')
+
+			expect(wrapper.find('p strong').text()).toBe('world')
+			expect(wrapper.find('p br').exists()).toBe(true)
+			expect(wrapper.find('p em').text()).toBe('more')
+			expect(wrapper.find('blockquote p').text()).toBe('quoted')
+			expect(wrapper.find('ul li').text()).toBe('one')
+			expect(wrapper.find('pre code').text()).toBe('run()')
+		})
+
+		it('drops every attribute from structural elements', () => {
+			const wrapper = mountContent('<p class="x" style="position:fixed" onclick="alert(1)">text</p>')
+			expect(wrapper.find('p').attributes()).toEqual({})
+			expect(wrapper.find('p').text()).toBe('text')
+		})
+
+		it('reduces unknown elements to their text', () => {
+			const wrapper = mountContent('<p><font color="red">red</font> <mark data-x="1">marked</mark></p>')
+			expect(wrapper.find('font').exists()).toBe(false)
+			expect(wrapper.find('mark').exists()).toBe(false)
+			expect(wrapper.html()).not.toContain('data-x')
+			expect(wrapper.find('p').text()).toBe('red marked')
+		})
+	})
+
+	describe('links', () => {
+		it('opens ordinary links in a new tab without referrer or opener', () => {
+			const wrapper = mountContent('<p>see <a href="https://example.org/x" onclick="alert(1)">https://example.org/x</a></p>')
+
+			const link = wrapper.find('a')
+			expect(link.attributes()).toEqual({
+				href: 'https://example.org/x',
+				rel: 'nofollow noopener noreferrer',
+				target: '_blank',
+			})
+			expect(link.text()).toBe('https://example.org/x')
+		})
+
+		it('renders a dead link for script-capable URL schemes', () => {
+			const wrapper = mountContent('<p><a href="javascript:alert(1)">click</a> <a href="data:text/html,x">data</a></p>')
+
+			const links = wrapper.findAll('a')
+			expect(links).toHaveLength(2)
+			for (const link of links) {
+				expect(link.attributes('href')).toBeUndefined()
+				expect(link.attributes('target')).toBe('_blank')
+			}
+			expect(wrapper.html()).not.toContain('javascript:')
+		})
+
+		it('does not leave plain URLs in text clickable', () => {
+			const wrapper = mountContent('<p>go to https://example.org now</p>')
+			expect(wrapper.find('a').exists()).toBe(false)
+			expect(wrapper.text()).toBe('go to https://example.org now')
+		})
+	})
+
+	describe('hashtags', () => {
+		it('turns a Mastodon hashtag anchor into a link to the tag timeline', () => {
+			const wrapper = mountContent('<p>about <a href="https://mastodon.example/tags/nextcloud" class="mention hashtag" rel="tag">#<span>nextcloud</span></a></p>')
+
+			const link = wrapper.find('a')
+			expect(link.attributes('href')).toBe('/apps/social/timeline/tags/nextcloud')
+			expect(link.attributes('rel')).toBeUndefined()
+			expect(link.text()).toBe('#nextcloud')
+		})
+
+		it('links a hashtag written in plain text', () => {
+			const wrapper = mountContent('<p>Loving the #Fediverse today</p>')
+
+			const link = wrapper.find('a')
+			expect(link.attributes('href')).toBe('/apps/social/timeline/tags/Fediverse')
+			expect(link.text()).toBe('#Fediverse')
+			expect(wrapper.text()).toBe('Loving the #Fediverse today')
+		})
+	})
+
+	describe('mentions', () => {
+		it('links a plain-text handle to the profile, showing only the short name', () => {
+			const wrapper = mountContent('<p>cc @carol@other.example thanks</p>')
+
+			const link = wrapper.find('a')
+			expect(link.attributes('href')).toBe('/apps/social/@carol@other.example')
+			expect(link.text()).toBe('@carol')
+			expect(wrapper.text()).toBe('cc @carol thanks')
+		})
+
+		it('keeps the remote profile link of a mention listed in the status mentions', () => {
+			const wrapper = mountContent(
+				'<p><a href="https://remote.example/@bob" class="u-url mention">bob@remote.example</a> hi</p>',
+				{ mentions: [{ id: '9', username: 'bob', acct: 'bob@remote.example', url: 'https://remote.example/@bob' }] },
+			)
+
+			const link = wrapper.find('a')
+			expect(link.attributes('href')).toBe('https://remote.example/@bob')
+			expect(link.attributes('rel')).toBe('nofollow noopener noreferrer')
+			expect(link.attributes('target')).toBe('_blank')
+			expect(link.text()).toBe('bob@remote.example')
+		})
+
+		it('refuses an unsafe URL on a listed mention', () => {
+			const wrapper = mountContent(
+				'<p><a href="javascript:alert(1)" class="mention">bob@remote.example</a> hi</p>',
+				{ mentions: [{ id: '9', username: 'bob', acct: 'bob@remote.example', url: 'https://remote.example/@bob' }] },
+			)
+			expect(wrapper.find('a').attributes('href')).toBeUndefined()
+		})
+
+		it('reduces a mention anchor that is not among the status mentions to text', () => {
+			const wrapper = mountContent('<p><a href="https://evil.example/@bob" class="mention">@bob</a> hi</p>')
+			expect(wrapper.find('a').exists()).toBe(false)
+			expect(wrapper.text()).toBe('@bob hi')
+		})
+	})
+
+	describe('emoji', () => {
+		it('replaces an emoji sequence by its twemoji image', () => {
+			const wrapper = mountContent('<p>Hi 🧑‍🤝‍🧑 there</p>')
+
+			const emoji = wrapper.find('img.emoji')
+			expect(emoji.attributes('alt')).toBe('🧑‍🤝‍🧑')
+			expect(emoji.attributes('src')).toBe('/apps/social/img/twemoji/1f9d1-200d-1f91d-200d-1f9d1.svg')
+			expect(emoji.attributes('draggable')).toBe('false')
+			expect(wrapper.text()).toBe('Hi  there')
+		})
+	})
+
+	describe('hostile markup', () => {
+		it('never renders script or image elements from the content', () => {
+			const wrapper = mountContent('<p>a<script>alert(1)</script><img src="x" onerror="alert(1)">b</p>')
+
+			expect(wrapper.find('script').exists()).toBe(false)
+			expect(wrapper.find('img').exists()).toBe(false)
+			expect(wrapper.html()).not.toContain('onerror')
+		})
+
+		it('renders an empty wrapper for an empty status', () => {
+			const wrapper = mountContent('')
+			expect(wrapper.element.tagName).toBe('DIV')
+			expect(wrapper.text()).toBe('')
+		})
+	})
+})

--- a/tests/js/components/Navigation.test.js
+++ b/tests/js/components/Navigation.test.js
@@ -1,0 +1,193 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { createStore } from 'vuex'
+import Navigation from '../../../src/components/Navigation.vue'
+import errors from '../../../src/store/errors.js'
+import settings from '../../../src/store/settings.js'
+
+vi.hoisted(() => {
+	document.head.dataset.user = 'alice'
+	document.head.dataset.userDisplayname = 'Alice'
+})
+
+// Simple stand-ins for the @nextcloud/vue navigation shell that render their
+// slots and expose the props the component drives them with.
+const stubs = {
+	NcAppNavigation: { template: '<nav><slot name="search" /><slot name="list" /><slot name="footer" /></nav>' },
+	NcAppNavigationSearch: {
+		props: ['modelValue', 'label'],
+		emits: ['update:modelValue'],
+		template: '<input class="nav-search" :value="modelValue" :aria-label="label" @input="$emit(\'update:modelValue\', $event.target.value)">',
+	},
+	NcAppNavigationItem: {
+		props: ['name', 'active', 'counter', 'href', 'target'],
+		emits: ['click'],
+		template: '<li class="nav-item" :class="{ active }" :data-name="name" :data-counter="counter" :data-href="href" @click="$emit(\'click\')">'
+			+ '<slot name="icon" /><span class="nav-item__name">{{ name }}</span><slot name="subname" /><slot /></li>',
+	},
+	NcAppNavigationSpacer: { template: '<hr>' },
+	NcAppNavigationSettings: { props: ['name'], template: '<div class="nav-settings" :data-name="name"><slot /></div>' },
+	NcAvatar: { props: ['user', 'displayName', 'size'], template: '<span class="nc-avatar-stub" :data-user="user" />' },
+	NcModal: { props: ['name'], emits: ['close'], template: '<div class="modal-stub" :data-name="name"><slot /></div>' },
+	Composer: { template: '<div class="composer-stub" />' },
+}
+
+let store
+let router
+
+const mountNavigation = (route = { name: 'timeline', params: {} }) => mount(Navigation, {
+	global: { plugins: [store], mocks: { $route: route, $router: router }, stubs },
+})
+
+const items = (wrapper) => wrapper.findAll('.nav-item')
+const itemNames = (wrapper) => items(wrapper).map((item) => item.attributes('data-name'))
+const item = (wrapper, name) => items(wrapper).find((candidate) => candidate.attributes('data-name') === name)
+
+describe('Navigation', () => {
+	beforeEach(() => {
+		store = createStore({ modules: { errors, settings } })
+		store.commit('clearErrors')
+		store.commit('setServerData', { public: false, cloudAddress: 'https://cloud.example.org' })
+		router = { push: vi.fn() }
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('lists the fixed entries in order, without an errors entry when there are none', () => {
+		expect(itemNames(mountNavigation())).toEqual([
+			'New post',
+			'Home',
+			'Notifications',
+			'Direct messages',
+			'Local',
+			'Global',
+			'Liked posts',
+			'Profile',
+			'Reset local cache',
+			'Help & documentation',
+		])
+	})
+
+	it.each([
+		['Home', { name: 'timeline' }],
+		['Notifications', { name: 'timeline', params: { type: 'notifications' } }],
+		['Direct messages', { name: 'timeline', params: { type: 'direct' } }],
+		['Local', { name: 'timeline', params: { type: 'timeline' } }],
+		['Global', { name: 'timeline', params: { type: 'federated' } }],
+		['Liked posts', { name: 'timeline', params: { type: 'favourites' } }],
+		['Profile', { name: 'profile', params: { account: 'alice' } }],
+	])('navigates to the %s timeline on click', async (name, to) => {
+		const wrapper = mountNavigation()
+		await item(wrapper, name).trigger('click')
+		expect(router.push).toHaveBeenCalledWith(to)
+	})
+
+	it('shows the notifications counter placeholder', () => {
+		expect(item(mountNavigation(), 'Notifications').attributes('data-counter')).toBe('0')
+	})
+
+	it.each([
+		[{ name: 'timeline', params: {} }, 'Home'],
+		[{ name: 'timeline', params: { type: 'federated' } }, 'Global'],
+		[{ name: 'timeline', params: { type: 'direct' } }, 'Direct messages'],
+		[{ name: 'profile', params: { account: 'alice' } }, 'Profile'],
+		[{ name: 'profile.followers', params: { account: 'alice' } }, 'Profile'],
+	])('marks only the entry matching route %o as active', (route, active) => {
+		const wrapper = mountNavigation(route)
+		expect(items(wrapper).filter((candidate) => candidate.classes('active')).map((candidate) => candidate.attributes('data-name'))).toEqual([active])
+	})
+
+	it('does not mark the own profile entry active for somebody else\'s profile', () => {
+		const wrapper = mountNavigation({ name: 'profile', params: { account: 'bob@remote.example' } })
+		expect(items(wrapper).filter((candidate) => candidate.classes('active'))).toHaveLength(0)
+	})
+
+	it('shows the current user on the profile entry', () => {
+		const profile = item(mountNavigation(), 'Profile')
+		expect(profile.find('.nc-avatar-stub').attributes('data-user')).toBe('alice')
+		expect(profile.find('.navigation__subname').text()).toBe('@alice')
+	})
+
+	it('emits the search term as the user types', async () => {
+		const wrapper = mountNavigation()
+		await wrapper.find('.nav-search').setValue('nextcloud')
+		expect(wrapper.emitted('search')).toEqual([['nextcloud']])
+	})
+
+	it('opens the composer modal from "New post"', async () => {
+		const wrapper = mountNavigation()
+		expect(wrapper.find('.modal-stub').exists()).toBe(false)
+		await item(wrapper, 'New post').trigger('click')
+		const modal = wrapper.find('.modal-stub')
+		expect(modal.attributes('data-name')).toBe('New post')
+		expect(modal.find('.composer-stub').exists()).toBe(true)
+	})
+
+	it('emits reset-cache from the settings entry and links to the documentation', async () => {
+		const wrapper = mountNavigation()
+		expect(wrapper.find('.nav-settings').attributes('data-name')).toBe('Settings')
+		await item(wrapper, 'Reset local cache').trigger('click')
+		expect(wrapper.emitted('reset-cache')).toHaveLength(1)
+		expect(item(wrapper, 'Help & documentation').attributes('data-href')).toBe('https://github.com/SchBenedikt/social/')
+	})
+
+	describe('errors', () => {
+		beforeEach(() => {
+			vi.spyOn(Date, 'now').mockReturnValueOnce(1).mockReturnValueOnce(2)
+			store.commit('addError', { title: 'Account lookup failed', message: 'Could not load bob' })
+			store.commit('addError', { title: 'Post failed', message: 'Server unreachable' })
+		})
+
+		it('adds an errors entry with the error count', () => {
+			const wrapper = mountNavigation()
+			expect(itemNames(wrapper).slice(0, 3)).toEqual(['New post', 'Errors', 'Home'])
+			expect(item(wrapper, 'Errors').attributes('data-counter')).toBe('2')
+		})
+
+		it('opens a modal listing the errors and dismisses a single one through the store', async () => {
+			const dispatch = vi.spyOn(store, 'dispatch')
+			const wrapper = mountNavigation()
+			await item(wrapper, 'Errors').trigger('click')
+
+			const modal = wrapper.find('.modal-stub[data-name="Errors"]')
+			expect(modal.findAll('.modal-errors__title').map((title) => title.text())).toEqual(['Account lookup failed', 'Post failed'])
+			expect(modal.findAll('.modal-errors__message').map((message) => message.text())).toEqual(['Could not load bob', 'Server unreachable'])
+
+			await modal.find('.modal-errors__item button').trigger('click')
+			expect(dispatch).toHaveBeenCalledWith('dismissAppError', 1)
+			await nextTick()
+			expect(modal.findAll('.modal-errors__title').map((title) => title.text())).toEqual(['Post failed'])
+			expect(item(wrapper, 'Errors').attributes('data-counter')).toBe('1')
+		})
+
+		it('offers "Dismiss all" only for several errors and clears them all', async () => {
+			const commit = vi.spyOn(store, 'commit')
+			const wrapper = mountNavigation()
+			await item(wrapper, 'Errors').trigger('click')
+
+			const dismissAll = () => wrapper.findAll('.modal-stub button').filter((button) => button.text() === 'Dismiss all')
+			expect(dismissAll()).toHaveLength(1)
+
+			await dismissAll()[0].trigger('click')
+			expect(commit).toHaveBeenCalledWith('clearErrors')
+			await nextTick()
+			expect(wrapper.find('.modal-errors__item').exists()).toBe(false)
+			expect(dismissAll()).toHaveLength(0)
+			expect(item(wrapper, 'Errors')).toBeUndefined()
+		})
+
+		it('hides "Dismiss all" when only one error is left', async () => {
+			store.commit('dismissError', 2)
+			const wrapper = mountNavigation()
+			await item(wrapper, 'Errors').trigger('click')
+			expect(wrapper.findAll('.modal-stub button').map((button) => button.text())).toEqual(['Dismiss'])
+		})
+	})
+})

--- a/tests/js/components/PostAttachment.test.js
+++ b/tests/js/components/PostAttachment.test.js
@@ -1,0 +1,150 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import PostAttachment from '../../../src/components/PostAttachment.vue'
+import MediaAttachment from '../../../src/components/MediaAttachment.vue'
+
+const attachment = (index) => ({
+	id: `a${index}`,
+	type: 'image',
+	url: `https://cloud.example.org/media/${index}.jpg`,
+	preview_url: `https://cloud.example.org/media/${index}-small.jpg`,
+	description: `Picture ${index}`,
+	blurhash: 'LEHV6nWB2yk8pyo0adR*.7kCMdnj',
+	meta: { small: { width: 4, height: 3 } },
+})
+
+const attachments = (count) => Array.from({ length: count }, (_, index) => attachment(index + 1))
+
+// The real NcModal teleports and traps focus; this stand-in exposes the
+// navigation contract PostAttachment relies on.
+const NcModalStub = {
+	name: 'NcModal',
+	props: {
+		hasPrevious: { type: Boolean, default: false },
+		hasNext: { type: Boolean, default: false },
+		size: { type: String, default: '' },
+	},
+	emits: ['close', 'previous', 'next'],
+	template: `<div class="modal-stub" :data-size="size">
+		<button class="modal-stub__previous" :disabled="!hasPrevious" @click="$emit('previous')">previous</button>
+		<button class="modal-stub__next" :disabled="!hasNext" @click="$emit('next')">next</button>
+		<button class="modal-stub__close" @click="$emit('close')">close</button>
+		<slot />
+	</div>`,
+}
+
+const mountAttachments = (items) => mount(PostAttachment, {
+	props: { attachments: items },
+	global: {
+		mocks: { $store: { getters: { getServerData: { public: false } } } },
+		stubs: { NcModal: NcModalStub },
+	},
+})
+
+const viewerImage = (wrapper) => wrapper.find('.attachment__viewer img')
+
+// MediaAttachment's own root is also class "attachment", so select the tiles only
+const tiles = (wrapper) => wrapper.findAll('.attachments-container > .attachment')
+
+describe('PostAttachment', () => {
+	let getContext
+
+	beforeEach(() => {
+		getContext = vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+			createImageData: (width, height) => ({ data: new Uint8ClampedArray(width * height * 4) }),
+			putImageData: () => {},
+		})
+	})
+
+	afterEach(() => {
+		getContext.mockRestore()
+	})
+
+	it('renders a tile per attachment for up to four attachments', () => {
+		const items = attachments(4)
+		const wrapper = mountAttachments(items)
+
+		const tiles = wrapper.findAllComponents(MediaAttachment)
+		expect(tiles).toHaveLength(4)
+		expect(tiles.map((tile) => tile.props('attachment'))).toEqual(items)
+		expect(wrapper.find('.more-attachments').exists()).toBe(false)
+	})
+
+	it('collapses five or more attachments into three tiles and a "+" tile', () => {
+		const items = attachments(5)
+		const wrapper = mountAttachments(items)
+
+		const tiles = wrapper.findAllComponents(MediaAttachment)
+		expect(tiles.map((tile) => tile.props('attachment'))).toEqual(items.slice(0, 3))
+		expect(wrapper.find('.more-attachments').text()).toBe('+')
+	})
+
+	it('keeps the viewer closed until a tile is clicked', () => {
+		const wrapper = mountAttachments(attachments(2))
+		expect(wrapper.find('.modal-stub').exists()).toBe(false)
+	})
+
+	it('opens the full-size viewer on the clicked attachment with its description as alt text', async () => {
+		const items = attachments(3)
+		const wrapper = mountAttachments(items)
+
+		await tiles(wrapper)[1].trigger('click')
+
+		expect(wrapper.find('.modal-stub').attributes('data-size')).toBe('full')
+		expect(viewerImage(wrapper).attributes('src')).toBe(items[1].url)
+		expect(viewerImage(wrapper).attributes('alt')).toBe('Picture 2')
+	})
+
+	it('opens the fourth attachment from the "+" tile', async () => {
+		const items = attachments(6)
+		const wrapper = mountAttachments(items)
+
+		await wrapper.find('.more-attachments').trigger('click')
+
+		expect(viewerImage(wrapper).attributes('src')).toBe(items[3].url)
+	})
+
+	it('steps through the attachments with next and previous', async () => {
+		const items = attachments(3)
+		const wrapper = mountAttachments(items)
+		await tiles(wrapper)[0].trigger('click')
+
+		expect(wrapper.find('.modal-stub__previous').attributes('disabled')).toBeDefined()
+		expect(wrapper.find('.modal-stub__next').attributes('disabled')).toBeUndefined()
+
+		await wrapper.find('.modal-stub__next').trigger('click')
+		expect(viewerImage(wrapper).attributes('src')).toBe(items[1].url)
+		expect(wrapper.find('.modal-stub__previous').attributes('disabled')).toBeUndefined()
+
+		await wrapper.find('.modal-stub__next').trigger('click')
+		expect(viewerImage(wrapper).attributes('src')).toBe(items[2].url)
+		expect(wrapper.find('.modal-stub__next').attributes('disabled')).toBeDefined()
+
+		await wrapper.find('.modal-stub__previous').trigger('click')
+		expect(viewerImage(wrapper).attributes('src')).toBe(items[1].url)
+	})
+
+	it('disables both directions for a single attachment', async () => {
+		const wrapper = mountAttachments(attachments(1))
+		await tiles(wrapper)[0].trigger('click')
+		expect(wrapper.find('.modal-stub__previous').attributes('disabled')).toBeDefined()
+		expect(wrapper.find('.modal-stub__next').attributes('disabled')).toBeDefined()
+	})
+
+	it('closes the viewer and reopens on the newly clicked attachment', async () => {
+		const items = attachments(2)
+		const wrapper = mountAttachments(items)
+		await tiles(wrapper)[0].trigger('click')
+
+		await wrapper.find('.modal-stub__close').trigger('click')
+		expect(wrapper.find('.modal-stub').exists()).toBe(false)
+
+		await tiles(wrapper)[1].trigger('click')
+		expect(viewerImage(wrapper).attributes('src')).toBe(items[1].url)
+	})
+})

--- a/tests/js/components/PreviewGrid.test.js
+++ b/tests/js/components/PreviewGrid.test.js
@@ -1,0 +1,94 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import PreviewGrid from '../../../src/components/Composer/PreviewGrid.vue'
+import PreviewGridItem from '../../../src/components/Composer/PreviewGridItem.vue'
+
+const media = (id) => ({
+	id,
+	type: 'image',
+	url: `https://cloud.example.org/media/${id}.png`,
+	preview_url: `https://cloud.example.org/media/${id}-small.png`,
+	description: '',
+	blurhash: 'LEHV6nWB2yk8pyo0adR*.7kCMdnj',
+	meta: { small: { width: 4, height: 3 } },
+})
+
+const file = (name) => new File(['x'], name, { type: 'image/png' })
+
+const mountGrid = (miniatures) => mount(PreviewGrid, {
+	props: { uploading: false, uploadProgress: 0, miniatures },
+})
+
+describe('PreviewGrid', () => {
+	let getContext
+
+	beforeEach(() => {
+		getContext = vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+			createImageData: (width, height) => ({ data: new Uint8ClampedArray(width * height * 4) }),
+			putImageData: () => {},
+		})
+	})
+
+	afterEach(() => {
+		getContext.mockRestore()
+	})
+
+	it('renders nothing without attachments', () => {
+		const wrapper = mountGrid({})
+		expect(wrapper.findAllComponents(PreviewGridItem)).toHaveLength(0)
+		expect(wrapper.find('.preview-grid').exists()).toBe(true)
+	})
+
+	it('renders one item per attachment, keyed by the local preview URL', () => {
+		const miniatures = {
+			'blob:one': { file: file('one.png'), data: media('m1') },
+			'blob:two': { file: file('two.png'), data: media('m2') },
+		}
+		const wrapper = mountGrid(miniatures)
+
+		const items = wrapper.findAllComponents(PreviewGridItem)
+		expect(items).toHaveLength(2)
+		expect(items[0].props()).toEqual({ preview: miniatures['blob:one'], randomKey: 'blob:one' })
+		expect(items[1].props()).toEqual({ preview: miniatures['blob:two'], randomKey: 'blob:two' })
+	})
+
+	it('shows finished uploads as images and pending ones as a spinner', () => {
+		const wrapper = mountGrid({
+			'blob:done': { file: file('done.png'), data: media('m1') },
+			'blob:pending': { file: file('pending.png'), data: null },
+		})
+
+		const [done, pending] = wrapper.findAllComponents(PreviewGridItem)
+		expect(done.find('img').attributes('src')).toBe('https://cloud.example.org/media/m1-small.png')
+		expect(pending.find('img').exists()).toBe(false)
+		expect(pending.find('.loading-icon').exists()).toBe(true)
+	})
+
+	it('re-emits an item removal as "deleted" with the attachment key', async () => {
+		const wrapper = mountGrid({
+			'blob:one': { file: file('one.png'), data: media('m1') },
+			'blob:two': { file: file('two.png'), data: media('m2') },
+		})
+
+		await wrapper.findAllComponents(PreviewGridItem)[1].find('button').trigger('click')
+
+		expect(wrapper.emitted('deleted')).toEqual([['blob:two']])
+	})
+
+	it('drops the item once the parent removed the attachment', async () => {
+		const wrapper = mountGrid({
+			'blob:one': { file: file('one.png'), data: media('m1') },
+			'blob:two': { file: file('two.png'), data: media('m2') },
+		})
+		await wrapper.setProps({ miniatures: { 'blob:two': { file: file('two.png'), data: media('m2') } } })
+
+		const items = wrapper.findAllComponents(PreviewGridItem)
+		expect(items).toHaveLength(1)
+		expect(items[0].props('randomKey')).toBe('blob:two')
+	})
+})

--- a/tests/js/components/PreviewGridItem.test.js
+++ b/tests/js/components/PreviewGridItem.test.js
@@ -1,0 +1,69 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import PreviewGridItem from '../../../src/components/Composer/PreviewGridItem.vue'
+import MediaAttachment from '../../../src/components/MediaAttachment.vue'
+
+const media = {
+	id: 'media-1',
+	type: 'image',
+	url: 'https://cloud.example.org/media/original.png',
+	preview_url: 'https://cloud.example.org/media/small.png',
+	description: 'Screenshot',
+	blurhash: 'LEHV6nWB2yk8pyo0adR*.7kCMdnj',
+	meta: { small: { width: 4, height: 3 } },
+}
+
+const file = new File(['x'], 'screenshot.png', { type: 'image/png' })
+
+const mountItem = (preview) => mount(PreviewGridItem, {
+	props: { preview, randomKey: 'blob:preview-1' },
+})
+
+describe('PreviewGridItem', () => {
+	let getContext
+
+	beforeEach(() => {
+		getContext = vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+			createImageData: (width, height) => ({ data: new Uint8ClampedArray(width * height * 4) }),
+			putImageData: () => {},
+		})
+	})
+
+	afterEach(() => {
+		getContext.mockRestore()
+	})
+
+	it('shows the uploaded media through MediaAttachment', () => {
+		const wrapper = mountItem({ file, data: media })
+		expect(wrapper.findComponent(MediaAttachment).props('attachment')).toEqual(media)
+		expect(wrapper.find('img.attachment__preview').attributes('src')).toBe(media.preview_url)
+	})
+
+	it('shows a pending state while the upload has not finished', () => {
+		const wrapper = mountItem({ file, data: null })
+		expect(wrapper.find('img').exists()).toBe(false)
+		expect(wrapper.find('.loading-icon').exists()).toBe(true)
+	})
+
+	it('offers a delete action', () => {
+		const wrapper = mountItem({ file, data: media })
+		expect(wrapper.find('.preview-item__actions button').text()).toBe('Delete')
+	})
+
+	it('emits delete with its key when the delete action is used', async () => {
+		const wrapper = mountItem({ file, data: media })
+		await wrapper.find('.preview-item__actions button').trigger('click')
+		expect(wrapper.emitted('delete')).toEqual([['blob:preview-1']])
+	})
+
+	it('can be removed while the upload is still pending', async () => {
+		const wrapper = mountItem({ file, data: null })
+		await wrapper.find('.preview-item__actions button').trigger('click')
+		expect(wrapper.emitted('delete')).toEqual([['blob:preview-1']])
+	})
+})

--- a/tests/js/components/ProfileInfo.test.js
+++ b/tests/js/components/ProfileInfo.test.js
@@ -1,0 +1,299 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { createStore } from 'vuex'
+import axios from '@nextcloud/axios'
+import { showError, showSuccess } from '@nextcloud/dialogs'
+import ProfileInfo from '../../../src/components/ProfileInfo.vue'
+import account from '../../../src/store/account.js'
+import settings from '../../../src/store/settings.js'
+
+vi.hoisted(() => {
+	document.head.dataset.user = 'alice'
+	document.head.dataset.userDisplayname = 'Alice'
+})
+
+vi.mock('@nextcloud/dialogs', async (importOriginal) => ({
+	...await importOriginal(),
+	showError: vi.fn(),
+	showSuccess: vi.fn(),
+}))
+
+const pristine = structuredClone(account.state)
+
+const NcAvatarStub = {
+	name: 'NcAvatar',
+	props: ['url', 'user', 'size', 'disableTooltip'],
+	template: '<span class="nc-avatar-stub" />',
+}
+const FollowButtonStub = {
+	name: 'FollowButton',
+	props: ['uid'],
+	template: '<button class="follow-button-stub" />',
+}
+const RouterLinkStub = {
+	name: 'RouterLink',
+	props: ['to'],
+	template: '<a class="router-link-stub"><slot /></a>',
+}
+const NcModalStub = {
+	name: 'NcModal',
+	emits: ['close'],
+	template: '<div class="modal-stub"><slot /></div>',
+}
+
+const bob = {
+	id: 'https://remote.example/users/bob',
+	url: 'https://remote.example/users/bob',
+	acct: 'bob@remote.example',
+	username: 'bob',
+	display_name: 'Bob',
+	avatar: 'https://remote.example/media/bob.png',
+	header: 'https://remote.example/media/bob-header.png',
+	statuses_count: 12,
+	following_count: 3,
+	followers_count: 5,
+	fields: [],
+}
+const carol = {
+	id: 'https://cloud.example.org/users/carol',
+	url: 'https://cloud.example.org/users/carol',
+	acct: 'carol',
+	username: 'carol',
+	display_name: null,
+	avatar: 'https://cloud.example.org/avatar/carol/128',
+	header: '',
+	statuses_count: 0,
+	following_count: 0,
+	followers_count: 1,
+	fields: [],
+}
+const alice = {
+	id: 'https://cloud.example.org/users/alice',
+	url: 'https://cloud.example.org/users/alice',
+	acct: 'alice',
+	username: 'alice',
+	display_name: 'Alice',
+	avatar: 'https://cloud.example.org/avatar/alice/128',
+	header: '',
+	statuses_count: 7,
+	following_count: 2,
+	followers_count: 2,
+	fields: [],
+}
+
+let store
+
+const makeStore = (serverData = {}) => {
+	Object.assign(account.state, structuredClone(pristine))
+	store = createStore({ modules: { account, settings } })
+	store.commit('setServerData', { public: false, cloudAddress: 'https://cloud.example.org', ...serverData })
+	for (const data of [bob, carol, alice]) {
+		store.commit('addAccount', { actorId: data.url, data })
+	}
+	return store
+}
+
+const mountProfile = (uid) => mount(ProfileInfo, {
+	props: { uid },
+	global: {
+		plugins: [store],
+		stubs: { NcAvatar: NcAvatarStub, FollowButton: FollowButtonStub, RouterLink: RouterLinkStub, NcModal: NcModalStub },
+	},
+})
+
+const linkTexts = (wrapper) => wrapper.findAll('.user-profile__info li').map((li) => li.text().replace(/\s+/g, ' '))
+const buttonByText = (wrapper, text) => wrapper.findAll('button').find((button) => button.text() === text)
+const bannerOf = (wrapper) => wrapper.find('.user-profile__banner')
+
+describe('ProfileInfo', () => {
+	beforeEach(() => {
+		makeStore()
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+		vi.mocked(showError).mockClear()
+		vi.mocked(showSuccess).mockClear()
+	})
+
+	it('renders nothing for an account that is not in the store', () => {
+		expect(mountProfile('nobody@remote.example').find('.user-profile').exists()).toBe(false)
+	})
+
+	it('shows the name, the delivered avatar and the counters of a remote account', () => {
+		const wrapper = mountProfile('bob@remote.example')
+		expect(wrapper.find('h2').text()).toBe('Bob')
+		const avatar = wrapper.findComponent(NcAvatarStub)
+		expect(avatar.props('url')).toBe('https://remote.example/media/bob.png')
+		expect(avatar.props('user')).toBeUndefined()
+		expect(avatar.props('size')).toBe(128)
+		expect(linkTexts(wrapper)).toEqual(['12 posts', '3 following', '5 followers'])
+	})
+
+	it('links the counters to the profile sub pages of the shown account', () => {
+		const links = mountProfile('bob@remote.example').findAllComponents(RouterLinkStub).map((link) => link.props('to'))
+		expect(links).toEqual([
+			{ name: 'profile', params: { account: 'bob@remote.example' } },
+			{ name: 'profile.following', params: { account: 'bob@remote.example' } },
+			{ name: 'profile.followers', params: { account: 'bob@remote.example' } },
+		])
+	})
+
+	it('uses the server avatar of the uid for a local account and falls back to the username', () => {
+		const wrapper = mountProfile('carol')
+		const avatar = wrapper.findComponent(NcAvatarStub)
+		expect(avatar.props('user')).toBe('carol')
+		expect(avatar.props('url')).toBeUndefined()
+		expect(wrapper.find('h2').text()).toBe('carol')
+	})
+
+	it('hands the uid to the follow button and does not offer the public follow flow', () => {
+		const wrapper = mountProfile('bob@remote.example')
+		expect(wrapper.findComponent(FollowButtonStub).props('uid')).toBe('bob@remote.example')
+		expect(buttonByText(wrapper, 'Follow')).toBeUndefined()
+	})
+
+	it('only lets the viewer edit the banner of their own profile', () => {
+		const own = mountProfile('alice')
+		expect(buttonByText(own, 'Change banner')).toBeDefined()
+		expect(buttonByText(own, 'Set from URL')).toBeDefined()
+		expect(bannerOf(own).classes()).toContain('user-profile__banner--editable')
+
+		const other = mountProfile('bob@remote.example')
+		expect(buttonByText(other, 'Change banner')).toBeUndefined()
+		expect(buttonByText(other, 'Set from URL')).toBeUndefined()
+		expect(bannerOf(other).classes()).not.toContain('user-profile__banner--editable')
+	})
+
+	it('marks the banner as visible only when the account has a header image', () => {
+		expect(bannerOf(mountProfile('bob@remote.example')).classes()).toContain('user-profile__banner--visible')
+		expect(bannerOf(mountProfile('carol')).classes()).not.toContain('user-profile__banner--visible')
+	})
+
+	it('paints the header image onto the banner when it changes and clears it when removed', async () => {
+		const wrapper = mountProfile('carol')
+		store.commit('addAccount', { actorId: carol.url, data: { header: 'https://cloud.example.org/carol-header.png' } })
+		await nextTick()
+		expect(bannerOf(wrapper).element.style.backgroundImage).toContain('https://cloud.example.org/carol-header.png')
+		expect(bannerOf(wrapper).element.style.backgroundSize).toBe('cover')
+		expect(bannerOf(wrapper).classes()).toContain('user-profile__banner--visible')
+
+		store.commit('addAccount', { actorId: carol.url, data: { header: '' } })
+		await nextTick()
+		expect(bannerOf(wrapper).element.style.backgroundImage).toBe('')
+		expect(bannerOf(wrapper).element.style.backgroundColor).toBe('var(--color-background-dark)')
+		expect(bannerOf(wrapper).classes()).not.toContain('user-profile__banner--visible')
+	})
+
+	describe('on the public page', () => {
+		beforeEach(() => {
+			makeStore({ public: true })
+		})
+
+		it('offers a follow button that opens the remote follow dialog for the local part of the uid', async () => {
+			const open = vi.spyOn(window, 'open').mockImplementation(() => null)
+			const wrapper = mountProfile('bob@remote.example')
+			await buttonByText(wrapper, 'Follow').trigger('click')
+			expect(open).toHaveBeenCalledTimes(1)
+			expect(open.mock.calls[0][0]).toBe('/index.php/apps/social/api/v1/ostatus/followRemote/bob')
+			expect(open.mock.calls[0][1]).toBe('followRemote')
+		})
+	})
+
+	describe('banner upload on the own profile', () => {
+		let post
+		let dispatch
+
+		beforeEach(() => {
+			post = vi.spyOn(axios, 'post')
+			dispatch = vi.spyOn(store, 'dispatch').mockResolvedValue(alice)
+		})
+
+		it('uploads the chosen file, applies the returned banner and refreshes the account', async () => {
+			post.mockResolvedValue({ data: { result: { url: 'https://cloud.example.org/banners/alice.png' } } })
+			const wrapper = mountProfile('alice')
+			const file = new File(['png'], 'banner.png', { type: 'image/png' })
+			const input = wrapper.find('input[type="file"]')
+			Object.defineProperty(input.element, 'files', { value: [file], configurable: true })
+
+			await input.trigger('change')
+			await flushPromises()
+
+			expect(post).toHaveBeenCalledTimes(1)
+			const [url, body] = post.mock.calls[0]
+			expect(url).toBe('/index.php/apps/social/api/v1/banner')
+			expect(body).toBeInstanceOf(FormData)
+			expect(body.get('file')).toBe(file)
+			expect(bannerOf(wrapper).element.style.backgroundImage).toContain('https://cloud.example.org/banners/alice.png')
+			expect(showSuccess).toHaveBeenCalledWith('Banner uploaded successfully')
+			expect(dispatch).toHaveBeenCalledWith('fetchAccountInfo', 'alice@cloud.example.org')
+			expect(buttonByText(wrapper, 'Change banner').attributes('disabled')).toBeUndefined()
+		})
+
+		it('ignores a change event without a file', async () => {
+			const wrapper = mountProfile('alice')
+			await wrapper.find('input[type="file"]').trigger('change')
+			await flushPromises()
+			expect(post).not.toHaveBeenCalled()
+		})
+
+		it('reports a failed upload and unlocks the buttons again', async () => {
+			post.mockRejectedValue(new Error('500'))
+			const wrapper = mountProfile('alice')
+			const input = wrapper.find('input[type="file"]')
+			Object.defineProperty(input.element, 'files', { value: [new File(['x'], 'b.png', { type: 'image/png' })], configurable: true })
+
+			await input.trigger('change')
+			await flushPromises()
+
+			expect(showError).toHaveBeenCalledWith('Failed to upload banner')
+			expect(dispatch).not.toHaveBeenCalled()
+			expect(buttonByText(wrapper, 'Change banner').attributes('disabled')).toBeUndefined()
+		})
+
+		it('sets the banner from a URL through the modal', async () => {
+			post.mockResolvedValue({ data: { result: { url: 'https://cloud.example.org/banners/from-url.png' } } })
+			const wrapper = mountProfile('alice')
+			expect(wrapper.find('.modal-stub').exists()).toBe(false)
+
+			await buttonByText(wrapper, 'Set from URL').trigger('click')
+			const modal = wrapper.find('.modal-stub')
+			expect(modal.find('h3').text()).toBe('Set banner from URL')
+			const apply = buttonByText(modal, 'Apply')
+			expect(apply.attributes('disabled')).toBeDefined()
+
+			await modal.find('input[type="url"]').setValue(' https://example.com/image.jpg ')
+			expect(apply.attributes('disabled')).toBeUndefined()
+			await apply.trigger('click')
+			await flushPromises()
+
+			const [url, body, config] = post.mock.calls[0]
+			expect(url).toBe('/index.php/apps/social/api/v1/banner/url')
+			expect(body).toBeInstanceOf(URLSearchParams)
+			expect(body.get('url')).toBe('https://example.com/image.jpg')
+			expect(config.headers['Content-Type']).toBe('application/x-www-form-urlencoded')
+			expect(wrapper.find('.modal-stub').exists()).toBe(false)
+			expect(bannerOf(wrapper).element.style.backgroundImage).toContain('https://cloud.example.org/banners/from-url.png')
+			expect(showSuccess).toHaveBeenCalledWith('Banner set successfully')
+			expect(dispatch).toHaveBeenCalledWith('fetchAccountInfo', 'alice@cloud.example.org')
+		})
+
+		it('keeps the modal open and reports when the URL cannot be fetched', async () => {
+			post.mockRejectedValue(new Error('400'))
+			const wrapper = mountProfile('alice')
+			await buttonByText(wrapper, 'Set from URL').trigger('click')
+			await wrapper.find('.modal-stub input[type="url"]').setValue('https://example.com/broken.jpg')
+			await buttonByText(wrapper.find('.modal-stub'), 'Apply').trigger('click')
+			await flushPromises()
+
+			expect(showError).toHaveBeenCalledWith('Failed to set banner from URL')
+			expect(wrapper.find('.modal-stub').exists()).toBe(true)
+			expect(buttonByText(wrapper.find('.modal-stub'), 'Apply').attributes('disabled')).toBeUndefined()
+		})
+	})
+})

--- a/tests/js/components/Search.test.js
+++ b/tests/js/components/Search.test.js
@@ -1,0 +1,125 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createStore } from 'vuex'
+import axios from '@nextcloud/axios'
+import Search from '../../../src/components/Search.vue'
+import account from '../../../src/store/account.js'
+import settings from '../../../src/store/settings.js'
+
+vi.hoisted(() => {
+	document.head.dataset.user = 'alice'
+	document.head.dataset.userDisplayname = 'Alice'
+})
+
+const pristine = structuredClone(account.state)
+
+const UserEntryStub = {
+	name: 'UserEntry',
+	props: ['item'],
+	template: '<div class="user-entry-stub" />',
+}
+const RouterLinkStub = {
+	name: 'RouterLink',
+	props: ['to'],
+	template: '<a class="router-link-stub"><slot /></a>',
+}
+
+const bob = { id: 'https://remote.example/users/bob', url: 'https://remote.example/users/bob', acct: 'bob@remote.example', username: 'bob', display_name: 'Bob' }
+const carol = { id: 'https://cloud.example.org/users/carol', url: 'https://cloud.example.org/users/carol', acct: 'carol', username: 'carol', display_name: 'Carol' }
+
+const response = ({ exact = null, accounts = [], hashtags = [] } = {}) => ({
+	data: {
+		result: {
+			accounts: { exact, result: accounts },
+			hashtags: { result: hashtags.map((hashtag) => ({ hashtag })) },
+		},
+	},
+})
+
+let store
+let get
+
+const mountSearch = (term) => mount(Search, {
+	props: { term },
+	global: { plugins: [store], stubs: { UserEntry: UserEntryStub, RouterLink: RouterLinkStub } },
+})
+
+describe('Search', () => {
+	beforeEach(() => {
+		Object.assign(account.state, structuredClone(pristine))
+		store = createStore({ modules: { account, settings } })
+		store.commit('setServerData', { public: false, cloudAddress: 'https://cloud.example.org' })
+		get = vi.spyOn(axios, 'get')
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('queries the search endpoint for the initial term and shows a spinner meanwhile', () => {
+		get.mockReturnValue(new Promise(() => {}))
+		const wrapper = mountSearch('nextcloud')
+		expect(get).toHaveBeenCalledTimes(1)
+		expect(get).toHaveBeenCalledWith('/index.php/apps/social/api/v1/search?search=nextcloud')
+		expect(wrapper.find('#emptycontent').classes()).toContain('icon-loading')
+		expect(wrapper.find('h2').exists()).toBe(false)
+	})
+
+	it('lists matching accounts and hashtags and caches the accounts in the store', async () => {
+		get.mockResolvedValue(response({ accounts: [bob, carol], hashtags: ['nextcloud', 'fediverse'] }))
+		const wrapper = mountSearch('nextcloud')
+		await flushPromises()
+
+		expect(wrapper.find('h3').text()).toBe('Searching for nextcloud')
+		expect(wrapper.findAllComponents(UserEntryStub).map((entry) => entry.props('item'))).toEqual([bob, carol])
+		expect(wrapper.findAll('li.tag').map((tag) => tag.text())).toEqual(['#nextcloud', '#fediverse'])
+		expect(wrapper.findAllComponents(RouterLinkStub).map((link) => link.props('to'))).toEqual([
+			{ name: 'tags', params: { tag: 'nextcloud' } },
+			{ name: 'tags', params: { tag: 'fediverse' } },
+		])
+		expect(store.getters.getAccount('bob@remote.example')).toEqual(bob)
+		expect(store.getters.getAccount('carol@cloud.example.org')).toEqual(carol)
+	})
+
+	it('shows only the exact match when the server found one', async () => {
+		get.mockResolvedValue(response({ exact: carol, accounts: [bob] }))
+		const wrapper = mountSearch('carol')
+		await flushPromises()
+
+		expect(wrapper.findAllComponents(UserEntryStub).map((entry) => entry.props('item'))).toEqual([carol])
+		expect(wrapper.find('li.tag').exists()).toBe(false)
+		// both the exact match and the other candidates end up in the store
+		expect(store.getters.getAccount('bob@remote.example')).toEqual(bob)
+	})
+
+	it('shows an empty state with the decoded term when nothing matches', async () => {
+		get.mockResolvedValue(response())
+		const wrapper = mountSearch('foo%20bar')
+		await flushPromises()
+
+		const empty = wrapper.find('#emptycontent')
+		expect(empty.classes()).not.toContain('icon-loading')
+		expect(empty.find('h2').text()).toBe('No results found')
+		expect(empty.find('p').text()).toBe('There were no results for your search: foo bar')
+		expect(wrapper.find('h3').exists()).toBe(false)
+	})
+
+	it('searches again when the term changes after the previous search finished', async () => {
+		get.mockResolvedValue(response({ accounts: [bob] }))
+		const wrapper = mountSearch('bob')
+		await flushPromises()
+
+		get.mockResolvedValue(response({ hashtags: ['other'] }))
+		await wrapper.setProps({ term: 'other' })
+		await flushPromises()
+
+		expect(get).toHaveBeenCalledTimes(2)
+		expect(get).toHaveBeenLastCalledWith('/index.php/apps/social/api/v1/search?search=other')
+		expect(wrapper.findAllComponents(UserEntryStub)).toHaveLength(0)
+		expect(wrapper.find('li.tag').text()).toBe('#other')
+	})
+})

--- a/tests/js/components/SubmitStatusButton.test.js
+++ b/tests/js/components/SubmitStatusButton.test.js
@@ -1,0 +1,53 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import SubmitStatusButton from '../../../src/components/Composer/SubmitStatusButton.vue'
+
+const mountButton = (props) => mount(SubmitStatusButton, { props })
+
+describe('SubmitStatusButton', () => {
+	it.each([
+		['public', 'Post', 'Post publicly'],
+		['unlisted', 'Post', 'Post unlisted'],
+		['followers', 'Post to followers', 'Post to followers'],
+		['direct', 'Send message to mentioned users', 'Post to recipients'],
+	])('for %s visibility reads "%s" and is labelled "%s"', (visibility, text, value) => {
+		const button = mountButton({ visibility, disabled: false }).find('button')
+		expect(button.text()).toBe(text)
+		expect(button.attributes('value')).toBe(value)
+		expect(button.find('.send-icon').exists()).toBe(true)
+	})
+
+	it('has no label for an unknown visibility', () => {
+		const button = mountButton({ visibility: 'secret', disabled: false }).find('button')
+		expect(button.text()).toBe('')
+		expect(button.attributes('value')).toBeUndefined()
+	})
+
+	it('is disabled unless explicitly enabled', () => {
+		expect(mountButton({ visibility: 'public' }).find('button').attributes('disabled')).toBeDefined()
+		expect(mountButton({ visibility: 'public', disabled: false }).find('button').attributes('disabled')).toBeUndefined()
+	})
+
+	it('emits click when enabled', async () => {
+		const wrapper = mountButton({ visibility: 'public', disabled: false })
+		await wrapper.find('button').trigger('click')
+		expect(wrapper.emitted('click')).toHaveLength(1)
+	})
+
+	it('ignores clicks while disabled', async () => {
+		const wrapper = mountButton({ visibility: 'public', disabled: true })
+		await wrapper.find('button').trigger('click')
+		expect(wrapper.emitted('click')).toBeUndefined()
+	})
+
+	it('updates the label when the visibility changes', async () => {
+		const wrapper = mountButton({ visibility: 'public', disabled: false })
+		await wrapper.setProps({ visibility: 'direct' })
+		expect(wrapper.find('button').text()).toBe('Send message to mentioned users')
+	})
+})

--- a/tests/js/components/TimelineAvatar.test.js
+++ b/tests/js/components/TimelineAvatar.test.js
@@ -1,0 +1,60 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import TimelineAvatar from '../../../src/components/TimelineAvatar.vue'
+
+const NcAvatarStub = {
+	name: 'NcAvatar',
+	props: ['url', 'user', 'displayName', 'size', 'disableTooltip', 'showUserStatus', 'menuPosition'],
+	template: '<span class="nc-avatar-stub" />',
+}
+
+const mountAvatar = (item) => mount(TimelineAvatar, {
+	props: { item },
+	global: { stubs: { NcAvatar: NcAvatarStub } },
+})
+
+const localStatus = {
+	id: '1',
+	account: { username: 'bob', acct: 'bob', display_name: 'Bob', avatar: 'https://cloud.example.org/avatar/bob/128' },
+}
+const remoteStatus = {
+	id: '2',
+	account: { username: 'carol', acct: 'carol@remote.example', display_name: 'Carol', avatar: 'https://remote.example/media/carol.png' },
+}
+
+describe('TimelineAvatar', () => {
+	it('shows a local author through the server avatar of their uid', () => {
+		const wrapper = mountAvatar(localStatus)
+		const avatar = wrapper.findComponent(NcAvatarStub)
+		expect(wrapper.find('.post-avatar').exists()).toBe(true)
+		expect(avatar.props('user')).toBe('bob')
+		expect(avatar.props('displayName')).toBe('Bob')
+		expect(avatar.props('url')).toBeUndefined()
+		expect(avatar.props('menuPosition')).toBe('left')
+		expect(avatar.props('showUserStatus')).toBe(false)
+		expect(avatar.props('disableTooltip')).toBe(true)
+	})
+
+	it('shows a remote author through the avatar URL delivered with the status', () => {
+		const avatar = mountAvatar(remoteStatus).findComponent(NcAvatarStub)
+		expect(avatar.props('url')).toBe('https://remote.example/media/carol.png')
+		expect(avatar.props('user')).toBeUndefined()
+		expect(avatar.props('disableTooltip')).toBe(true)
+	})
+
+	it('passes no URL for a remote author without an avatar so NcAvatar falls back', () => {
+		const avatar = mountAvatar({ id: '3', account: { username: 'dave', acct: 'dave@remote.example' } }).findComponent(NcAvatarStub)
+		expect(avatar.props('url')).toBeUndefined()
+		expect(avatar.props('user')).toBeUndefined()
+	})
+
+	it('renders nothing when the status has no account', () => {
+		const wrapper = mountAvatar({ id: '4' })
+		expect(wrapper.find('.post-avatar').exists()).toBe(false)
+		expect(wrapper.findComponent(NcAvatarStub).exists()).toBe(false)
+	})
+})

--- a/tests/js/components/TimelineEntry.test.js
+++ b/tests/js/components/TimelineEntry.test.js
@@ -1,0 +1,200 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mount, RouterLinkStub } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import TimelineEntry from '../../../src/components/TimelineEntry.vue'
+
+const alice = {
+	id: '1',
+	acct: 'alice',
+	username: 'alice',
+	display_name: 'Alice',
+	url: 'https://cloud.example.org/@alice',
+	avatar: 'https://cloud.example.org/avatar/alice/64',
+}
+
+const bob = {
+	id: '2',
+	acct: 'bob@remote.example',
+	username: 'bob',
+	display_name: 'Bob',
+	url: 'https://remote.example/@bob',
+	avatar: 'https://remote.example/avatar.png',
+}
+
+const post = {
+	id: 'p1',
+	created_at: '2026-09-01T10:00:00Z',
+	content: '<p>Original post</p>',
+	visibility: 'public',
+	reblog: null,
+	account: alice,
+}
+
+const storedPost = { ...post, content: '<p>Original post, as kept in the store</p>' }
+
+const boost = {
+	id: 'b1',
+	created_at: '2026-09-02T10:00:00Z',
+	content: '',
+	visibility: 'public',
+	reblog: post,
+	account: bob,
+}
+
+const notification = (type, extra = {}) => ({
+	id: `n-${type}`,
+	type,
+	created_at: '2026-09-03T10:00:00Z',
+	account: bob,
+	status: post,
+	...extra,
+})
+
+const TimelinePostStub = {
+	name: 'TimelinePost',
+	props: ['item', 'type'],
+	template: '<div class="timeline-post-stub" />',
+}
+const TimelineAvatarStub = {
+	name: 'TimelineAvatar',
+	props: ['item'],
+	template: '<div class="timeline-avatar-stub" />',
+}
+const UserEntryStub = {
+	name: 'UserEntry',
+	props: ['item', 'displayFollowButton'],
+	template: '<div class="user-entry-stub" />',
+}
+
+const mountEntry = (item, props = {}) => {
+	const $store = { getters: { getStatus: vi.fn((id) => (id === 'p1' ? storedPost : undefined)), getServerData: {} } }
+	const wrapper = mount(TimelineEntry, {
+		props: { item, type: 'home', ...props },
+		global: {
+			mocks: { $store, $route: { name: 'timeline', params: { type: 'home' } } },
+			stubs: {
+				TimelinePost: TimelinePostStub,
+				TimelineAvatar: TimelineAvatarStub,
+				UserEntry: UserEntryStub,
+				RouterLink: RouterLinkStub,
+			},
+		},
+	})
+	return { wrapper, $store }
+}
+
+describe('TimelineEntry', () => {
+	describe('a plain post', () => {
+		it('renders the avatar and the post itself without any header', () => {
+			const { wrapper } = mountEntry(post)
+
+			expect(wrapper.element.tagName).toBe('LI')
+			expect(wrapper.classes()).toContain('timeline-entry')
+			expect(wrapper.classes()).not.toContain('with-header')
+			expect(wrapper.classes()).not.toContain('notification')
+			expect(wrapper.find('.boost').exists()).toBe(false)
+			expect(wrapper.find('.notification__header').exists()).toBe(false)
+
+			expect(wrapper.findComponent(TimelineAvatarStub).props('item')).toEqual(post)
+			expect(wrapper.findComponent(TimelinePostStub).props()).toEqual({ item: post, type: 'home' })
+			expect(wrapper.findComponent(UserEntryStub).exists()).toBe(false)
+		})
+
+		it('can be rendered as another element', () => {
+			const { wrapper } = mountEntry(post, { element: 'div' })
+			expect(wrapper.element.tagName).toBe('DIV')
+		})
+	})
+
+	describe('a boost', () => {
+		it('shows who boosted and links to their profile', () => {
+			const { wrapper } = mountEntry(boost)
+
+			expect(wrapper.classes()).toContain('with-header')
+			const header = wrapper.find('.boost')
+			expect(header.find('.repeat-icon').exists()).toBe(true)
+			expect(header.find('img').attributes('src')).toBe(bob.avatar)
+			expect(header.find('.post-author').text()).toBe('Bob')
+			expect(header.text()).toMatch(/Bob\s+boosted$/)
+			expect(header.findComponent(RouterLinkStub).props('to')).toEqual({ name: 'profile', params: { account: 'bob@remote.example' } })
+		})
+
+		it('renders the boosted post from the store so later actions are reflected', () => {
+			const { wrapper, $store } = mountEntry(boost)
+
+			expect($store.getters.getStatus).toHaveBeenCalledWith('p1')
+			expect(wrapper.findComponent(TimelinePostStub).props('item')).toEqual(storedPost)
+			expect(wrapper.findComponent(TimelineAvatarStub).props('item')).toEqual(storedPost)
+		})
+	})
+
+	describe('a notification about a post', () => {
+		it.each([
+			['favourite', 'heart-icon', 'bob@remote.example liked your post'],
+			['reblog', 'repeat-icon', 'bob@remote.example boosted your post'],
+			['mention', 'at-icon', 'bob@remote.example mentioned you'],
+			['status', 'message-outline-icon', 'bob@remote.example posted a status'],
+			['update', 'message-plus-outline-icon', 'bob@remote.example edited a status'],
+			['poll', 'poll-icon', 'bob@remote.example ended the poll'],
+		])('describes a %s with its icon and summary', (type, iconClass, summary) => {
+			const { wrapper } = mountEntry(notification(type), { type: 'notifications' })
+
+			expect(wrapper.classes()).toContain('notification')
+			expect(wrapper.classes()).toContain('with-header')
+			const header = wrapper.find('.notification__header')
+			expect(header.find('img').attributes('src')).toBe(bob.avatar)
+			expect(header.findAll('.material-design-icon')).toHaveLength(1)
+			expect(header.find('.material-design-icon').classes()).toContain(iconClass)
+			expect(header.find('.notification__summary').text()).toBe(summary)
+		})
+
+		it('renders the post concerned without an avatar and links to it', () => {
+			const { wrapper } = mountEntry(notification('favourite'), { type: 'notifications' })
+
+			expect(wrapper.findComponent(TimelinePostStub).props()).toEqual({ item: post, type: 'notifications' })
+			expect(wrapper.findComponent(TimelineAvatarStub).exists()).toBe(false)
+			expect(wrapper.findComponent(UserEntryStub).exists()).toBe(false)
+
+			const link = wrapper.find('.notification__details').findComponent(RouterLinkStub)
+			expect(link.props('to')).toMatchObject({ name: 'single-post', params: { id: 'p1', type: 'single-post' } })
+			expect(link.attributes('data-timestamp')).toBe('2026-09-03T10:00:00Z')
+		})
+	})
+
+	describe('a notification about an account', () => {
+		it.each([
+			['follow', 'account-plus-outline-icon', 'bob@remote.example started to follow you'],
+			['follow_request', 'account-question-icon', 'bob@remote.example requested to follow you'],
+		])('shows the %s as an account entry without a follow button', (type, iconClass, summary) => {
+			const { wrapper } = mountEntry(notification(type, { status: undefined }), { type: 'notifications' })
+
+			const header = wrapper.find('.notification__header')
+			expect(header.find('.material-design-icon').classes()).toContain(iconClass)
+			expect(header.find('.notification__summary').text()).toBe(summary)
+
+			expect(wrapper.findComponent(UserEntryStub).props()).toEqual({ item: bob, displayFollowButton: false })
+			expect(wrapper.findComponent(TimelinePostStub).exists()).toBe(false)
+			expect(wrapper.findComponent(TimelineAvatarStub).exists()).toBe(false)
+
+			// nothing to open, so the timestamp is not a link
+			expect(wrapper.find('.notification__details').findComponent(RouterLinkStub).exists()).toBe(false)
+			expect(wrapper.find('.notification__details .post-timestamp').attributes('data-timestamp')).toBe('2026-09-03T10:00:00Z')
+		})
+	})
+
+	describe('an unknown notification type', () => {
+		it('still shows the actor and the post, with an empty summary and no icon', () => {
+			const { wrapper } = mountEntry(notification('something.new'), { type: 'notifications' })
+
+			const header = wrapper.find('.notification__header')
+			expect(header.find('img').attributes('src')).toBe(bob.avatar)
+			expect(header.find('.material-design-icon').exists()).toBe(false)
+			expect(header.find('.notification__summary').text()).toBe('')
+			expect(wrapper.findComponent(TimelinePostStub).props('item')).toEqual(post)
+		})
+	})
+})

--- a/tests/js/components/TimelineList.test.js
+++ b/tests/js/components/TimelineList.test.js
@@ -1,0 +1,341 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { showError } from '@nextcloud/dialogs'
+import TimelineList from '../../../src/components/TimelineList.vue'
+import EmptyContent from '../../../src/components/EmptyContent.vue'
+
+vi.mock('@nextcloud/dialogs', () => ({ showError: vi.fn() }))
+
+// @nextcloud/auth reads the user from <head>, which the harness does not set
+vi.mock('@nextcloud/auth', async (importOriginal) => ({
+	...(await importOriginal()),
+	getCurrentUser: () => ({ uid: 'alice', displayName: 'Alice', isAdmin: false }),
+}))
+
+class FakeIntersectionObserver {
+
+	static instances = []
+
+	constructor(callback, options) {
+		this.callback = callback
+		this.options = options
+		this.observe = vi.fn()
+		this.unobserve = vi.fn()
+		this.disconnect = vi.fn()
+		FakeIntersectionObserver.instances.push(this)
+	}
+
+}
+
+const observer = () => FakeIntersectionObserver.instances.at(-1)
+
+const intersect = async (isIntersecting = true) => {
+	observer().callback([{ isIntersecting }])
+	await flushPromises()
+}
+
+const status = (id) => ({
+	id,
+	created_at: `2026-09-0${id.length}T10:00:00Z`,
+	content: `<p>Status ${id}</p>`,
+	reblog: null,
+	account: { id: '1', acct: 'alice', username: 'alice', display_name: 'Alice' },
+})
+
+const TimelineEntryStub = {
+	name: 'TimelineEntry',
+	props: ['item', 'type'],
+	template: '<li class="timeline-entry-stub" :data-id="item.id" />',
+}
+
+const entryIds = (wrapper) => wrapper.findAll('.timeline-entry-stub').map((entry) => entry.attributes('data-id'))
+
+// `responses` are the successive results of `fetchTimeline`; an Error rejects
+const mountList = ({
+	timeline = [],
+	parents = [],
+	searchQuery = '',
+	route = { name: 'timeline', params: { type: 'home' } },
+	serverData = { public: false, cloudAddress: 'https://cloud.example.org' },
+	responses = [[]],
+	props = {},
+} = {}) => {
+	const dispatch = vi.fn()
+	for (const response of responses) {
+		if (response instanceof Error) {
+			dispatch.mockRejectedValueOnce(response)
+		} else {
+			dispatch.mockResolvedValueOnce(response)
+		}
+	}
+	dispatch.mockResolvedValue([])
+
+	const $store = {
+		dispatch,
+		commit: vi.fn(),
+		getters: {
+			// fresh arrays, as the real getters return, so reverse() cannot leak
+			get getTimeline() {
+				return [...timeline]
+			},
+			get getParentsTimeline() {
+				return [...parents]
+			},
+			getSearchQuery: searchQuery,
+			getServerData: serverData,
+		},
+	}
+	const wrapper = mount(TimelineList, {
+		props: { type: 'home', ...props },
+		global: {
+			mocks: { $store, $route: route },
+			stubs: { TimelineEntry: TimelineEntryStub },
+		},
+	})
+	return { wrapper, dispatch }
+}
+
+const emptyTitle = (wrapper) => wrapper.findComponent(EmptyContent).props('item').title
+
+describe('TimelineList', () => {
+	beforeEach(() => {
+		FakeIntersectionObserver.instances = []
+		vi.stubGlobal('IntersectionObserver', FakeIntersectionObserver)
+		vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] })
+		showError.mockClear()
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+		vi.unstubAllGlobals()
+	})
+
+	describe('entries', () => {
+		it('renders one entry per status of the timeline', () => {
+			const { wrapper } = mountList({ timeline: [status('30'), status('20')] })
+			expect(entryIds(wrapper)).toEqual(['30', '20'])
+			expect(wrapper.findAllComponents(TimelineEntryStub).map((entry) => entry.props('type'))).toEqual(['home', 'home'])
+		})
+
+		it('shows the ancestors instead when asked for the parents', () => {
+			const { wrapper } = mountList({ timeline: [status('30')], parents: [status('5')], props: { showParents: true } })
+			expect(entryIds(wrapper)).toEqual(['5'])
+		})
+
+		it('reverses the order on request', () => {
+			const { wrapper } = mountList({ timeline: [status('30'), status('20')], props: { reverseOrder: true } })
+			expect(entryIds(wrapper)).toEqual(['20', '30'])
+		})
+	})
+
+	describe('loading pages', () => {
+		it('requests the first page on mount', async () => {
+			const { dispatch } = mountList()
+			await flushPromises()
+			expect(dispatch).toHaveBeenCalledTimes(1)
+			expect(dispatch).toHaveBeenCalledWith('fetchTimeline', {})
+		})
+
+		it('requests the statuses older than the last one shown', async () => {
+			const { dispatch } = mountList({ timeline: [status('30'), status('20')] })
+			await flushPromises()
+			expect(dispatch).toHaveBeenCalledWith('fetchTimeline', { max_id: 20 })
+		})
+
+		it('requests the statuses newer than the first one shown in reverse order', async () => {
+			const { dispatch } = mountList({ timeline: [status('30'), status('20')], props: { reverseOrder: true } })
+			await flushPromises()
+			expect(dispatch).toHaveBeenCalledWith('fetchTimeline', { min_id: 20 })
+		})
+
+		it('shows a spinner while a page is loading and the end marker afterwards', async () => {
+			let finish
+			const { wrapper } = mountList({ responses: [new Promise((resolve) => { finish = resolve })] })
+			await flushPromises()
+			expect(wrapper.find('.icon-loading').exists()).toBe(true)
+			expect(wrapper.find('.list-end').exists()).toBe(false)
+
+			finish([status('1')])
+			await flushPromises()
+
+			expect(wrapper.find('.icon-loading').exists()).toBe(false)
+			expect(wrapper.find('.list-end').exists()).toBe(true)
+			expect(wrapper.findComponent(EmptyContent).exists()).toBe(false)
+		})
+
+		it('reports a failed page and stops loading', async () => {
+			const { wrapper, dispatch } = mountList({ responses: [new Error('network')] })
+			await flushPromises()
+
+			expect(showError).toHaveBeenCalledWith('Failed to load more timeline entries')
+			expect(wrapper.find('.icon-loading').exists()).toBe(false)
+			expect(wrapper.findComponent(EmptyContent).exists()).toBe(true)
+
+			await intersect()
+			expect(dispatch).toHaveBeenCalledTimes(1)
+		})
+	})
+
+	describe('infinite scroll', () => {
+		it('watches the sentinel below the list with a margin', async () => {
+			const { wrapper } = mountList()
+			await flushPromises()
+			expect(observer().options).toEqual({ rootMargin: '200px' })
+			expect(observer().observe).toHaveBeenCalledWith(wrapper.find('.list-sentinel').element)
+		})
+
+		it('loads the next page when the sentinel comes into view', async () => {
+			const { dispatch } = mountList({ timeline: [status('30'), status('20')], responses: [[status('20')], [status('10')]] })
+			await flushPromises()
+			expect(dispatch).toHaveBeenCalledTimes(1)
+
+			await intersect()
+
+			expect(dispatch).toHaveBeenCalledTimes(2)
+			expect(dispatch).toHaveBeenLastCalledWith('fetchTimeline', { max_id: 20 })
+		})
+
+		it('does nothing when the sentinel leaves the view', async () => {
+			const { dispatch } = mountList({ responses: [[status('1')]] })
+			await flushPromises()
+			await intersect(false)
+			expect(dispatch).toHaveBeenCalledTimes(1)
+		})
+
+		it('does not request a page while one is still loading', async () => {
+			let finish
+			const { dispatch } = mountList({ responses: [new Promise((resolve) => { finish = resolve })] })
+
+			await intersect()
+			expect(dispatch).toHaveBeenCalledTimes(1)
+
+			finish([status('1')])
+			await flushPromises()
+			await intersect()
+			expect(dispatch).toHaveBeenCalledTimes(2)
+		})
+
+		it('stops requesting once the server returned an empty page', async () => {
+			const { dispatch } = mountList({ responses: [[]] })
+			await flushPromises()
+			await intersect()
+			expect(dispatch).toHaveBeenCalledTimes(1)
+		})
+	})
+
+	describe('polling for new statuses', () => {
+		it('asks for statuses newer than the first one every 30 seconds', async () => {
+			const { dispatch } = mountList({ timeline: [status('30'), status('20')] })
+			await flushPromises()
+			dispatch.mockClear()
+
+			vi.advanceTimersByTime(30 * 1000)
+			await flushPromises()
+
+			expect(dispatch).toHaveBeenCalledTimes(1)
+			expect(dispatch).toHaveBeenCalledWith('fetchTimeline', { min_id: '30' })
+		})
+
+		it('does not poll for ancestors', async () => {
+			const { dispatch } = mountList({ parents: [status('5')], props: { showParents: true } })
+			await flushPromises()
+			dispatch.mockClear()
+
+			vi.advanceTimersByTime(30 * 1000)
+			await flushPromises()
+
+			expect(dispatch).not.toHaveBeenCalled()
+		})
+
+		it('stops polling and observing when unmounted', async () => {
+			const { wrapper, dispatch } = mountList()
+			await flushPromises()
+			dispatch.mockClear()
+
+			wrapper.unmount()
+			vi.advanceTimersByTime(60 * 1000)
+			await flushPromises()
+
+			expect(observer().disconnect).toHaveBeenCalled()
+			expect(dispatch).not.toHaveBeenCalled()
+		})
+	})
+
+	describe('empty state', () => {
+		it('is not shown while more statuses may still arrive', async () => {
+			const { wrapper } = mountList({ responses: [[status('1')]] })
+			await flushPromises()
+			expect(wrapper.findComponent(EmptyContent).exists()).toBe(false)
+		})
+
+		it('is shown with the home illustration once the timeline turns out empty', async () => {
+			const { wrapper } = mountList()
+			await flushPromises()
+			expect(wrapper.findComponent(EmptyContent).props('item')).toEqual({
+				image: 'img/undraw/posts.svg',
+				title: 'No posts found',
+				description: 'Posts from people you follow will show up here',
+			})
+		})
+
+		it.each([
+			['direct', 'No direct messages found'],
+			['timeline', 'No local posts found'],
+			['federated', 'No global posts found'],
+			['notifications', 'No notifications found'],
+			['favourites', 'No liked posts found'],
+			['tags', 'No posts found for this tag'],
+		])('describes an empty %s timeline', async (type, title) => {
+			const { wrapper } = mountList({ route: { name: 'timeline', params: { type } } })
+			await flushPromises()
+			expect(emptyTitle(wrapper)).toBe(title)
+		})
+
+		it('addresses the viewer on their own empty profile', async () => {
+			const { wrapper } = mountList({ route: { name: 'profile', params: { account: 'alice' } } })
+			await flushPromises()
+			expect(emptyTitle(wrapper)).toBe('You have not tooted yet')
+		})
+
+		it('names the account on somebody else\'s empty profile', async () => {
+			const { wrapper } = mountList({ route: { name: 'profile', params: { account: 'bob' } } })
+			await flushPromises()
+			expect(emptyTitle(wrapper)).toBe('bob hasn\'t tooted yet')
+		})
+
+		it('names the account on the public profile page even for the owner', async () => {
+			const { wrapper } = mountList({
+				route: { name: 'profile', params: { account: 'alice' } },
+				serverData: { public: true, cloudAddress: 'https://cloud.example.org' },
+			})
+			await flushPromises()
+			expect(emptyTitle(wrapper)).toBe('alice hasn\'t tooted yet')
+		})
+
+		it('explains an empty search result', async () => {
+			const { wrapper } = mountList({ searchQuery: 'nothing-matches' })
+			await flushPromises()
+			expect(wrapper.findComponent(EmptyContent).props('item')).toEqual({
+				title: 'No posts match your search',
+				description: 'Try a different search term',
+			})
+		})
+
+		it('mentions missing replies below a single post but stays silent for its ancestors', async () => {
+			const route = { name: 'single-post', params: { type: 'single-post', id: '1' } }
+
+			const replies = mountList({ route })
+			await flushPromises()
+			expect(emptyTitle(replies.wrapper)).toBe('No replies found')
+
+			const parents = mountList({ route, props: { showParents: true } })
+			await flushPromises()
+			expect(parents.wrapper.findComponent(EmptyContent).exists()).toBe(false)
+		})
+	})
+})

--- a/tests/js/components/TimelinePost.test.js
+++ b/tests/js/components/TimelinePost.test.js
@@ -1,0 +1,339 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { flushPromises, mount, RouterLinkStub } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import TimelinePost from '../../../src/components/TimelinePost.vue'
+import eventBus from '../../../src/services/eventBus.js'
+
+const alice = {
+	id: '1',
+	acct: 'alice',
+	username: 'alice',
+	display_name: 'Alice',
+	url: 'https://cloud.example.org/@alice',
+	avatar: 'https://cloud.example.org/avatar/alice/64',
+	note: '',
+}
+
+const bob = {
+	id: '2',
+	acct: 'bob@remote.example',
+	username: 'bob',
+	display_name: 'Bob',
+	url: 'https://remote.example/@bob',
+	avatar: 'https://remote.example/avatar.png',
+	note: '',
+}
+
+const makeItem = (overrides = {}) => ({
+	id: '101',
+	uri: 'https://cloud.example.org/@alice/101',
+	created_at: '2026-09-01T10:00:00Z',
+	content: '<p>Hello <strong>world</strong></p>',
+	visibility: 'public',
+	replies_count: 0,
+	reblogs_count: 0,
+	favourites_count: 0,
+	reblogged: false,
+	favourited: false,
+	media_attachments: [],
+	mentions: [],
+	tags: [],
+	account: alice,
+	...overrides,
+})
+
+// NcActions only renders its entries inside a popover once opened; these
+// stand-ins render them inline so the menu content can be asserted.
+const NcActionsStub = { name: 'NcActions', template: '<div class="post-menu"><slot /></div>' }
+const NcActionButtonStub = {
+	name: 'NcActionButton',
+	emits: ['click'],
+	template: '<button class="post-menu__item" @click="$emit(\'click\')"><slot /></button>',
+}
+
+const mountPost = ({
+	item = makeItem(),
+	route = { name: 'timeline', params: { type: 'home' } },
+	currentAccount = alice,
+	serverData = { public: false, cloudAddress: 'https://cloud.example.org' },
+} = {}) => {
+	const $store = {
+		dispatch: vi.fn().mockResolvedValue(undefined),
+		commit: vi.fn(),
+		getters: { currentAccount, getServerData: serverData },
+	}
+	const $router = { push: vi.fn() }
+	const wrapper = mount(TimelinePost, {
+		props: { item, type: 'home' },
+		global: {
+			mocks: { $store, $route: route, $router },
+			stubs: {
+				NcActions: NcActionsStub,
+				NcActionButton: NcActionButtonStub,
+				PostAttachment: true,
+				RouterLink: RouterLinkStub,
+			},
+		},
+	})
+	return { wrapper, item, $store, $router }
+}
+
+const actionButton = (wrapper, label) => wrapper.find(`.post-actions button[aria-label="${label}"]`)
+const menuItem = (wrapper, label) => wrapper.findAll('.post-menu__item').find((button) => button.text() === label)
+
+describe('TimelinePost', () => {
+	afterEach(() => {
+		eventBus.all.clear()
+	})
+
+	describe('header and body', () => {
+		it('shows the author and links to the profile', () => {
+			const { wrapper } = mountPost()
+
+			expect(wrapper.find('.post-author').text()).toBe('Alice')
+			expect(wrapper.find('.post-author-id').text()).toBe('@alice')
+			expect(wrapper.findComponent(RouterLinkStub).props('to')).toEqual({ name: 'profile', params: { account: 'alice' } })
+			expect(wrapper.attributes('data-social-status')).toBe('101')
+		})
+
+		it('renders the status content through MessageContent', () => {
+			const { wrapper } = mountPost()
+			expect(wrapper.find('.post-message strong').text()).toBe('world')
+		})
+
+		it('shows the post visibility as an icon with the label as tooltip', () => {
+			const { wrapper } = mountPost({ item: makeItem({ visibility: 'followers' }) })
+			const icon = wrapper.find('.post-visibility')
+			expect(icon.classes()).toContain('account-multiple-icon')
+			expect(icon.find('title').text()).toBe('Followers')
+		})
+
+		it('exposes the creation time on the timestamp', () => {
+			const { wrapper } = mountPost()
+			expect(wrapper.find('.post-timestamp').attributes('data-timestamp')).toBe(String(Date.parse('2026-09-01T10:00:00Z')))
+		})
+
+		it('falls back to the sanitised author bio when the status has no content', () => {
+			const { wrapper } = mountPost({
+				item: makeItem({ content: '', account: { ...alice, note: '<p>bio <b>bold</b><script>alert(1)</script></p>' } }),
+			})
+
+			const message = wrapper.find('.post-message')
+			expect(message.find('b').text()).toBe('bold')
+			expect(message.find('script').exists()).toBe(false)
+			expect(message.text()).toBe('bio bold')
+		})
+
+		it('renders attachments only when the status has some', () => {
+			expect(mountPost().wrapper.findComponent({ name: 'PostAttachment' }).exists()).toBe(false)
+
+			const media = [{ id: 'm1', url: 'https://cloud.example.org/m1.jpg' }]
+			const { wrapper } = mountPost({ item: makeItem({ media_attachments: media }) })
+			expect(wrapper.findComponent({ name: 'PostAttachment' }).props('attachments')).toEqual(media)
+		})
+	})
+
+	describe('opening the single post view', () => {
+		it('navigates to the single-post route for a local post', async () => {
+			const { wrapper, $router } = mountPost()
+			await wrapper.find('.post-timestamp').trigger('click')
+			expect($router.push).toHaveBeenCalledWith({
+				name: 'single-post',
+				params: { account: 'alice', id: '101', type: 'single-post' },
+			})
+		})
+
+		it('does not navigate for a remote post', async () => {
+			const { wrapper, $router } = mountPost({ item: makeItem({ account: bob }) })
+			await wrapper.find('.post-timestamp').trigger('click')
+			expect($router.push).not.toHaveBeenCalled()
+		})
+	})
+
+	describe('action bar', () => {
+		it('is shown on a regular timeline for a logged-in user', () => {
+			const { wrapper } = mountPost()
+			expect(wrapper.find('.post-actions').exists()).toBe(true)
+			expect(actionButton(wrapper, 'Reply').exists()).toBe(true)
+		})
+
+		it('is hidden on the notifications timeline', () => {
+			const { wrapper } = mountPost({ route: { name: 'timeline', params: { type: 'notifications' } } })
+			expect(wrapper.find('.post-actions').exists()).toBe(false)
+		})
+
+		it('is hidden on the public page', () => {
+			const { wrapper } = mountPost({ serverData: { public: true, cloudAddress: 'https://cloud.example.org' } })
+			expect(wrapper.find('.post-actions').exists()).toBe(false)
+		})
+
+		it('shows a counter only when it is above zero', () => {
+			expect(mountPost().wrapper.findAll('.post-action-count')).toHaveLength(0)
+
+			const { wrapper } = mountPost({ item: makeItem({ replies_count: 3, reblogs_count: 0, favourites_count: 12 }) })
+			expect(wrapper.findAll('.post-action-count').map((count) => count.text())).toEqual(['3', '12'])
+		})
+	})
+
+	describe('reply', () => {
+		it('opens the composer and hands it the status to reply to', async () => {
+			const onReply = vi.fn()
+			eventBus.on('composer-reply', onReply)
+			const { wrapper, item, $store } = mountPost()
+
+			await actionButton(wrapper, 'Reply').trigger('click')
+
+			expect($store.commit).toHaveBeenCalledWith('setComposerDisplayStatus', true)
+			expect(onReply).toHaveBeenCalledTimes(1)
+			expect(onReply.mock.calls[0][0]).toEqual(item)
+		})
+	})
+
+	describe('boost', () => {
+		it.each(['public', 'unlisted'])('is offered for a %s post', (visibility) => {
+			const { wrapper } = mountPost({ item: makeItem({ visibility }) })
+			expect(actionButton(wrapper, 'Boost').exists()).toBe(true)
+		})
+
+		it.each(['followers', 'direct'])('is not offered for a %s post', (visibility) => {
+			const { wrapper } = mountPost({ item: makeItem({ visibility }) })
+			expect(actionButton(wrapper, 'Boost').exists()).toBe(false)
+			expect(actionButton(wrapper, 'Undo boost').exists()).toBe(false)
+		})
+
+		it('boosts a post that is not boosted yet', async () => {
+			const { wrapper, item, $store } = mountPost()
+			await actionButton(wrapper, 'Boost').trigger('click')
+			expect($store.dispatch).toHaveBeenCalledTimes(1)
+			expect($store.dispatch).toHaveBeenCalledWith('postBoost', expect.objectContaining({ status: item }))
+		})
+
+		it('undoes the boost of an already boosted post', async () => {
+			const { wrapper, item, $store } = mountPost({ item: makeItem({ reblogged: true }) })
+			expect(actionButton(wrapper, 'Boost').exists()).toBe(false)
+
+			await actionButton(wrapper, 'Undo boost').trigger('click')
+
+			expect($store.dispatch).toHaveBeenCalledTimes(1)
+			expect($store.dispatch).toHaveBeenCalledWith('postUnBoost', expect.objectContaining({ status: item }))
+		})
+	})
+
+	describe('like', () => {
+		it('likes a post that is not liked yet', async () => {
+			const { wrapper, item, $store } = mountPost()
+			expect(actionButton(wrapper, 'Like').find('.heart-outline-icon').exists()).toBe(true)
+			expect(actionButton(wrapper, 'Undo Like').exists()).toBe(false)
+
+			await actionButton(wrapper, 'Like').trigger('click')
+
+			expect($store.dispatch).toHaveBeenCalledTimes(1)
+			expect($store.dispatch).toHaveBeenCalledWith('postLike', expect.objectContaining({ status: item }))
+		})
+
+		it('removes the like from a liked post', async () => {
+			const { wrapper, item, $store } = mountPost({ item: makeItem({ favourited: true }) })
+			expect(actionButton(wrapper, 'Like').exists()).toBe(false)
+			expect(actionButton(wrapper, 'Undo Like').find('.heart-icon').exists()).toBe(true)
+
+			await actionButton(wrapper, 'Undo Like').trigger('click')
+
+			expect($store.dispatch).toHaveBeenCalledTimes(1)
+			expect($store.dispatch).toHaveBeenCalledWith('postUnlike', expect.objectContaining({ status: item }))
+		})
+	})
+
+	describe('edit and delete', () => {
+		it('are offered for the viewer\'s own post', () => {
+			const { wrapper } = mountPost()
+			expect(menuItem(wrapper, 'Edit')).toBeDefined()
+			expect(menuItem(wrapper, 'Delete')).toBeDefined()
+		})
+
+		it('are withheld for somebody else\'s post', () => {
+			const { wrapper } = mountPost({ item: makeItem({ account: bob }) })
+			expect(wrapper.findAll('.post-menu__item')).toHaveLength(0)
+		})
+
+		it('are withheld while the current account is unknown', () => {
+			const { wrapper } = mountPost({ currentAccount: null })
+			expect(wrapper.findAll('.post-menu__item')).toHaveLength(0)
+		})
+
+		it('deletes the post', async () => {
+			const { wrapper, item, $store } = mountPost()
+			await menuItem(wrapper, 'Delete').trigger('click')
+			expect($store.dispatch).toHaveBeenCalledWith('postDelete', item)
+		})
+
+		it('opens an inline editor prefilled with the plain text of the post', async () => {
+			const { wrapper } = mountPost({ item: makeItem({ content: '<p>Line one</p><p>Line <b>two</b><br>three</p>' }) })
+
+			await menuItem(wrapper, 'Edit').trigger('click')
+
+			expect(wrapper.find('.post-message').exists()).toBe(false)
+			expect(wrapper.find('textarea.post-edit-textarea').element.value).toBe('Line one\nLine two\nthree')
+		})
+
+		it('saves the trimmed text and leaves edit mode', async () => {
+			const { wrapper, item, $store } = mountPost()
+			await menuItem(wrapper, 'Edit').trigger('click')
+
+			await wrapper.find('textarea').setValue('  Edited text  ')
+			await wrapper.find('.post-edit-actions button[aria-label="Save"]').trigger('click')
+			await flushPromises()
+
+			expect($store.dispatch).toHaveBeenCalledWith('postEdit', {
+				status: item,
+				content: 'Edited text',
+				spoiler_text: '',
+				sensitive: false,
+			})
+			expect(wrapper.find('textarea').exists()).toBe(false)
+			expect(wrapper.find('.post-message').exists()).toBe(true)
+		})
+
+		it('saves on Ctrl+Enter', async () => {
+			const { wrapper, $store } = mountPost()
+			await menuItem(wrapper, 'Edit').trigger('click')
+
+			await wrapper.find('textarea').setValue('Quick fix')
+			await wrapper.find('textarea').trigger('keydown', { key: 'Enter', ctrlKey: true })
+			await flushPromises()
+
+			expect($store.dispatch).toHaveBeenCalledWith('postEdit', expect.objectContaining({ content: 'Quick fix' }))
+		})
+
+		it('refuses to save an empty edit and stays in edit mode', async () => {
+			const { wrapper, $store } = mountPost()
+			await menuItem(wrapper, 'Edit').trigger('click')
+
+			await wrapper.find('textarea').setValue('   ')
+			await wrapper.find('.post-edit-actions button[aria-label="Save"]').trigger('click')
+			await flushPromises()
+
+			expect($store.dispatch).not.toHaveBeenCalled()
+			expect(wrapper.find('textarea').exists()).toBe(true)
+		})
+
+		it('cancels without saving and restores the content', async () => {
+			const { wrapper, $store } = mountPost()
+			await menuItem(wrapper, 'Edit').trigger('click')
+			await wrapper.find('textarea').setValue('Never saved')
+
+			await wrapper.find('.post-edit-actions button[aria-label="Cancel"]').trigger('click')
+
+			expect($store.dispatch).not.toHaveBeenCalled()
+			expect(wrapper.find('textarea').exists()).toBe(false)
+			expect(wrapper.find('.post-message strong').text()).toBe('world')
+
+			// the draft is not kept for the next edit
+			await menuItem(wrapper, 'Edit').trigger('click')
+			expect(wrapper.find('textarea').element.value).toBe('Hello world')
+		})
+	})
+})

--- a/tests/js/components/UserEntry.test.js
+++ b/tests/js/components/UserEntry.test.js
@@ -1,0 +1,156 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createStore } from 'vuex'
+import UserEntry from '../../../src/components/UserEntry.vue'
+import account from '../../../src/store/account.js'
+import settings from '../../../src/store/settings.js'
+
+vi.hoisted(() => {
+	document.head.dataset.user = 'alice'
+	document.head.dataset.userDisplayname = 'Alice'
+})
+
+const pristine = structuredClone(account.state)
+
+const NcAvatarStub = {
+	name: 'NcAvatar',
+	props: ['url', 'user', 'size', 'disableTooltip'],
+	template: '<span class="nc-avatar-stub" />',
+}
+const FollowButtonStub = {
+	name: 'FollowButton',
+	props: ['uid'],
+	template: '<button class="follow-button-stub" />',
+}
+const RouterLinkStub = {
+	name: 'RouterLink',
+	props: ['to'],
+	template: '<a class="router-link-stub"><slot /></a>',
+}
+
+const local = {
+	id: 'https://cloud.example.org/users/carol',
+	url: 'https://cloud.example.org/users/carol',
+	acct: 'carol',
+	username: 'carol',
+	display_name: 'Carol',
+	avatar: 'https://cloud.example.org/avatar/carol/128',
+	note: '<p>Local <strong>bio</strong></p>',
+}
+const remote = {
+	id: 'https://remote.example/users/bob',
+	url: 'https://remote.example/users/bob',
+	acct: 'bob@remote.example',
+	username: 'bob',
+	display_name: 'Bob',
+	avatar: 'https://remote.example/media/bob.png',
+	note: '<p>Hi <script>alert(1)</script><a href="javascript:alert(2)" onclick="x()">link</a> <a href="https://remote.example/bob" target="_self" rel="opener">site</a></p>',
+}
+
+let store
+
+const makeStore = (serverData = {}) => {
+	Object.assign(account.state, structuredClone(pristine))
+	store = createStore({ modules: { account, settings } })
+	store.commit('setServerData', { public: false, cloudAddress: 'https://cloud.example.org', ...serverData })
+	vi.spyOn(store, 'dispatch').mockResolvedValue([])
+	return store
+}
+
+const mountEntry = (item, props = {}) => mount(UserEntry, {
+	props: { item, ...props },
+	global: {
+		plugins: [store],
+		stubs: { NcAvatar: NcAvatarStub, FollowButton: FollowButtonStub, RouterLink: RouterLinkStub },
+	},
+})
+
+describe('UserEntry', () => {
+	beforeEach(() => {
+		makeStore()
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('shows the names and links a local account to its profile', () => {
+		const wrapper = mountEntry(local)
+		expect(wrapper.find('.post-author').text()).toBe('Carol')
+		expect(wrapper.find('.user-description').text()).toBe('carol')
+		expect(wrapper.findComponent(RouterLinkStub).props('to')).toEqual({ name: 'profile', params: { account: 'carol' } })
+		expect(wrapper.find('a[target="_blank"]').exists()).toBe(false)
+	})
+
+	it('uses the server avatar for a local account', () => {
+		const avatar = mountEntry(local).findComponent(NcAvatarStub)
+		expect(avatar.props('user')).toBe('carol')
+		expect(avatar.props('size')).toBe(32)
+		expect(avatar.props('disableTooltip')).toBe(true)
+		expect(avatar.props('url')).toBeUndefined()
+	})
+
+	it('uses the delivered avatar URL for a remote account and links to its full handle', () => {
+		const wrapper = mountEntry(remote)
+		expect(wrapper.findComponent(NcAvatarStub).props('url')).toBe('https://remote.example/media/bob.png')
+		expect(wrapper.findComponent(NcAvatarStub).props('user')).toBeUndefined()
+		expect(wrapper.findComponent(RouterLinkStub).props('to')).toEqual({ name: 'profile', params: { account: 'bob@remote.example' } })
+	})
+
+	it('injects the bio only after sanitising the remote HTML', () => {
+		const bio = mountEntry(remote).find('.user-details p')
+		expect(bio.text()).toBe('Hi link site')
+		expect(bio.html()).not.toContain('<script')
+		expect(bio.html()).not.toContain('javascript:')
+		expect(bio.html()).not.toContain('onclick')
+		const [dangerous, safe] = bio.findAll('a')
+		// the javascript: target is dropped, the text is kept
+		expect(dangerous.attributes('href')).toBeUndefined()
+		// a real link is forced to open safely in a new tab
+		expect(safe.attributes('href')).toBe('https://remote.example/bob')
+		expect(safe.attributes('rel')).toBe('nofollow noopener noreferrer')
+		expect(safe.attributes('target')).toBe('_blank')
+	})
+
+	it('keeps the formatting of a harmless bio', () => {
+		expect(mountEntry(local).find('.user-details p').html()).toContain('<p>Local <strong>bio</strong></p>')
+	})
+
+	it('renders an empty bio paragraph when the account has no note', () => {
+		expect(mountEntry({ ...local, note: undefined }).find('.user-details p').text()).toBe('')
+	})
+
+	it('fetches the relationship with the account for logged-in viewers', () => {
+		mountEntry(remote)
+		expect(store.dispatch).toHaveBeenCalledWith('fetchAccountRelationshipInfo', ['https://remote.example/users/bob'])
+	})
+
+	it('shows the follow button by default and hides it on request', () => {
+		expect(mountEntry(remote).findComponent(FollowButtonStub).props('uid')).toBe('bob@remote.example')
+		expect(mountEntry(remote, { displayFollowButton: false }).findComponent(FollowButtonStub).exists()).toBe(false)
+	})
+
+	describe('on the public page', () => {
+		beforeEach(() => {
+			makeStore({ public: true })
+		})
+
+		it('links straight to the remote profile in a new tab instead of the app route', () => {
+			const wrapper = mountEntry(remote)
+			const link = wrapper.find('a[target="_blank"]')
+			expect(wrapper.findComponent(RouterLinkStub).exists()).toBe(false)
+			expect(link.attributes('href')).toBe('https://remote.example/users/bob')
+			expect(link.attributes('rel')).toBe('noreferrer')
+			expect(link.find('.post-author').text()).toBe('Bob')
+		})
+
+		it('does not ask the server for a relationship', () => {
+			mountEntry(remote)
+			expect(store.dispatch).not.toHaveBeenCalled()
+		})
+	})
+})

--- a/tests/js/components/VisibilitiesInfos.test.js
+++ b/tests/js/components/VisibilitiesInfos.test.js
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest'
+import visibilitiesInfo from '../../../src/components/Visibility/VisibilitiesInfos.js'
+
+describe('VisibilitiesInfos', () => {
+	it('lists the four Mastodon visibilities in menu order', () => {
+		expect(visibilitiesInfo.map(({ id }) => id)).toEqual(['public', 'unlisted', 'followers', 'direct'])
+	})
+
+	it('gives every visibility a non-empty label and description', () => {
+		for (const info of visibilitiesInfo) {
+			expect(info.text).toEqual(expect.any(String))
+			expect(info.text).not.toBe('')
+			expect(info.description).toEqual(expect.any(String))
+			expect(info.description).not.toBe('')
+		}
+	})
+
+	it('describes who gets to see a post of each visibility', () => {
+		const byId = Object.fromEntries(visibilitiesInfo.map((info) => [info.id, info]))
+		expect(byId.public).toMatchObject({ text: 'Public', description: 'Visible for all' })
+		expect(byId.unlisted).toMatchObject({ text: 'Unlisted' })
+		expect(byId.unlisted.description).toMatch(/opted-out of discovery/)
+		expect(byId.followers).toMatchObject({ text: 'Followers', description: 'Visible to followers only' })
+		expect(byId.direct).toMatchObject({ text: 'Direct message', description: 'Visible to mentioned users only' })
+	})
+
+	it('uses unique labels so the menu entries can be told apart', () => {
+		const texts = visibilitiesInfo.map(({ text }) => text)
+		expect(new Set(texts).size).toBe(texts.length)
+	})
+})

--- a/tests/js/components/VisibilityIcon.test.js
+++ b/tests/js/components/VisibilityIcon.test.js
@@ -1,0 +1,41 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import VisibilityIcon from '../../../src/components/Visibility/VisibilityIcon.vue'
+
+describe('VisibilityIcon', () => {
+	it.each([
+		['public', 'earth-icon'],
+		['unlisted', 'lock-open-icon'],
+		['followers', 'account-multiple-icon'],
+		['direct', 'at-icon'],
+	])('renders the %s visibility as a single %s', (visibility, iconClass) => {
+		const wrapper = mount(VisibilityIcon, { props: { visibility } })
+		const icons = wrapper.findAll('.material-design-icon')
+		expect(icons).toHaveLength(1)
+		expect(icons[0].classes()).toContain(iconClass)
+	})
+
+	it('renders no icon for an unknown visibility', () => {
+		const wrapper = mount(VisibilityIcon, { props: { visibility: 'secret' } })
+		expect(wrapper.find('.material-design-icon').exists()).toBe(false)
+		expect(wrapper.text()).toBe('')
+	})
+
+	it('switches the icon when the visibility changes', async () => {
+		const wrapper = mount(VisibilityIcon, { props: { visibility: 'public' } })
+		expect(wrapper.find('.earth-icon').exists()).toBe(true)
+		await wrapper.setProps({ visibility: 'direct' })
+		expect(wrapper.find('.earth-icon').exists()).toBe(false)
+		expect(wrapper.find('.at-icon').exists()).toBe(true)
+	})
+
+	it('lets a title fall through to the rendered icon for tooltips', () => {
+		const wrapper = mount(VisibilityIcon, { props: { visibility: 'public' }, attrs: { title: 'Public' } })
+		expect(wrapper.find('.earth-icon').find('title').text()).toBe('Public')
+	})
+})

--- a/tests/js/components/VisibilitySelect.test.js
+++ b/tests/js/components/VisibilitySelect.test.js
@@ -1,0 +1,107 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import VisibilitySelect from '../../../src/components/Visibility/VisibilitySelect.vue'
+import visibilitiesInfo from '../../../src/components/Visibility/VisibilitiesInfos.js'
+
+const ICON_CLASSES = {
+	public: 'earth-icon',
+	unlisted: 'lock-open-icon',
+	followers: 'account-multiple-icon',
+	direct: 'at-icon',
+}
+
+/**
+ * NcActions renders its menu into a popover appended to <body>, so the
+ * component is attached to the document and the entries are read from there.
+ *
+ * @param {string} visibility - Currently selected visibility id
+ */
+const mountSelect = (visibility) => mount(VisibilitySelect, {
+	props: { visibility },
+	attachTo: document.body,
+})
+
+const toggle = (wrapper) => wrapper.find('button.action-item__menutoggle')
+
+const menuEntries = () => Array.from(document.body.querySelectorAll('li.action'))
+
+// floating-vue shows the popover from a timer, so wait until the entries exist
+const openMenu = async (wrapper) => {
+	await toggle(wrapper).trigger('click')
+	for (let attempt = 0; attempt < 50 && menuEntries().length === 0; attempt++) {
+		await new Promise((resolve) => setTimeout(resolve, 10))
+	}
+	await flushPromises()
+}
+
+describe('VisibilitySelect', () => {
+	let wrapper
+
+	beforeEach(() => {
+		localStorage.clear()
+	})
+
+	afterEach(() => {
+		wrapper?.unmount()
+		wrapper = null
+		document.body.innerHTML = ''
+	})
+
+	it('shows the selected visibility on the closed trigger', () => {
+		wrapper = mountSelect('followers')
+		expect(toggle(wrapper).attributes('aria-label')).toBe('Choose a visibility')
+		expect(toggle(wrapper).find('.account-multiple-icon').exists()).toBe(true)
+		expect(toggle(wrapper).attributes('aria-expanded')).toBe('false')
+		expect(menuEntries()).toHaveLength(0)
+	})
+
+	it('offers every visibility with its description and icon once opened', async () => {
+		wrapper = mountSelect('public')
+		await openMenu(wrapper)
+
+		const entries = menuEntries()
+		expect(entries.map((entry) => entry.textContent.trim()))
+			.toEqual(visibilitiesInfo.map(({ description }) => description))
+		visibilitiesInfo.forEach(({ id }, index) => {
+			expect(entries[index].querySelector('.material-design-icon').classList.contains(ICON_CLASSES[id])).toBe(true)
+		})
+	})
+
+	it('highlights only the currently selected visibility', async () => {
+		wrapper = mountSelect('direct')
+		await openMenu(wrapper)
+
+		const selected = menuEntries().filter((entry) => entry.classList.contains('selected-visibility'))
+		expect(selected).toHaveLength(1)
+		expect(selected[0].textContent).toContain('Visible to mentioned users only')
+	})
+
+	it('emits the chosen visibility and remembers it for the next post', async () => {
+		wrapper = mountSelect('public')
+		await openMenu(wrapper)
+
+		const followers = menuEntries().find((entry) => entry.textContent.includes('Visible to followers only'))
+		followers.querySelector('button').click()
+		await flushPromises()
+
+		expect(wrapper.emitted('update:visibility')).toEqual([['followers']])
+		expect(localStorage.getItem('social.lastPostType')).toBe('followers')
+	})
+
+	it('does not write a preference before a choice is made', () => {
+		wrapper = mountSelect('unlisted')
+		expect(localStorage.getItem('social.lastPostType')).toBeNull()
+	})
+
+	it('follows the visibility prop when the parent changes it', async () => {
+		wrapper = mountSelect('public')
+		await wrapper.setProps({ visibility: 'direct' })
+		expect(toggle(wrapper).find('.at-icon').exists()).toBe(true)
+		expect(toggle(wrapper).find('.earth-icon').exists()).toBe(false)
+	})
+})

--- a/tests/js/directives/focusOnCreate.test.js
+++ b/tests/js/directives/focusOnCreate.test.js
@@ -1,0 +1,67 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { h, nextTick, withDirectives } from 'vue'
+
+import focusOnCreate from '../../../src/directives/focusOnCreate.js'
+
+const AutoFocusInput = {
+	render: () => withDirectives(h('input', { class: 'target' }), [[focusOnCreate]]),
+}
+
+const LateInput = {
+	data: () => ({ show: false }),
+	render() {
+		return h('div', [
+			h('input', { class: 'other' }),
+			this.show ? withDirectives(h('input', { class: 'late' }), [[focusOnCreate]]) : null,
+		])
+	},
+}
+
+describe('focusOnCreate directive', () => {
+	let wrapper
+
+	afterEach(() => {
+		wrapper?.unmount()
+	})
+
+	it('focuses the element on the tick after it is mounted', async () => {
+		wrapper = mount(AutoFocusInput, { attachTo: document.body })
+		const input = wrapper.get('input.target').element
+
+		expect(document.activeElement).not.toBe(input)
+
+		await nextTick()
+
+		expect(document.activeElement).toBe(input)
+	})
+
+	it('focuses an element that is created later, without touching its siblings', async () => {
+		wrapper = mount(LateInput, { attachTo: document.body })
+		await flushPromises()
+		expect(document.activeElement).toBe(document.body)
+
+		wrapper.vm.show = true
+		await flushPromises()
+
+		expect(document.activeElement).toBe(wrapper.get('input.late').element)
+	})
+
+	it('does not steal focus back after the user moves on', async () => {
+		wrapper = mount(LateInput, { attachTo: document.body })
+		wrapper.vm.show = true
+		await flushPromises()
+
+		const other = wrapper.get('input.other').element
+		other.focus()
+		wrapper.vm.$forceUpdate()
+		await flushPromises()
+
+		expect(document.activeElement).toBe(other)
+	})
+})

--- a/tests/js/mixins/accountMixins.test.js
+++ b/tests/js/mixins/accountMixins.test.js
@@ -1,0 +1,107 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createStore } from 'vuex'
+import { h } from 'vue'
+
+import accountMixins from '../../../src/mixins/accountMixins.js'
+import account from '../../../src/store/account.js'
+import settings from '../../../src/store/settings.js'
+
+const alice = { id: '11', acct: 'alice', username: 'alice', display_name: 'Alice', url: 'https://cloud.example.org/@alice' }
+const bob = { id: '22', acct: 'bob@remote.tld', username: 'bob', display_name: 'Bob', url: 'https://remote.tld/@bob' }
+
+const Probe = {
+	mixins: [accountMixins],
+	props: { uid: { type: String, default: '' } },
+	render: () => h('div'),
+}
+
+describe('accountMixins', () => {
+	let store
+	let wrapper
+
+	const mountWith = (uid) => {
+		wrapper = mount(Probe, { props: { uid }, global: { plugins: [store] } })
+		return wrapper.vm
+	}
+
+	beforeEach(() => {
+		vi.spyOn(console, 'debug').mockImplementation(() => {})
+		Object.assign(account.state, {
+			currentAccount: '',
+			accounts: {},
+			accountsFollowers: {},
+			accountsFollowings: {},
+			accountsRelationships: {},
+			accountIdMap: {},
+		})
+		settings.state.serverData = {}
+		store = createStore({ modules: { account, settings } })
+		store.commit('setServerData', { cloudAddress: 'https://cloud.example.org' })
+	})
+
+	afterEach(() => {
+		wrapper?.unmount()
+		vi.restoreAllMocks()
+	})
+
+	it('profileAccount qualifies a local user id with the cloud hostname', () => {
+		expect(mountWith('alice').profileAccount).toBe('alice@cloud.example.org')
+	})
+
+	it('profileAccount keeps a remote handle as it is', () => {
+		expect(mountWith('bob@remote.tld').profileAccount).toBe('bob@remote.tld')
+	})
+
+	it('profileAccount is empty without a uid', () => {
+		expect(mountWith('').profileAccount).toBe('')
+	})
+
+	it('accountInfo and accountLoaded reflect whether the account is in the store', async () => {
+		const vm = mountWith('alice')
+		expect(vm.accountLoaded).toBe(false)
+		expect(vm.accountInfo).toBeUndefined()
+
+		store.commit('addAccount', { actorId: alice.url, data: alice })
+		await wrapper.vm.$nextTick()
+
+		expect(vm.accountLoaded).toBe(true)
+		expect(vm.accountInfo).toEqual(alice)
+	})
+
+	it('isLocal is true for accounts of this server and false for remote ones', () => {
+		store.commit('addAccount', { actorId: alice.url, data: alice })
+		store.commit('addAccount', { actorId: bob.url, data: bob })
+
+		expect(mountWith('alice').isLocal).toBe(true)
+		wrapper.unmount()
+		expect(mountWith('bob@remote.tld').isLocal).toBe(false)
+	})
+
+	it('isLocal is falsy while the account is not loaded', () => {
+		expect(mountWith('alice').isLocal).toBeFalsy()
+	})
+
+	it('relationship looks up the relationship by the account id once both are loaded', async () => {
+		store.commit('addAccount', { actorId: bob.url, data: bob })
+		const vm = mountWith('bob@remote.tld')
+		expect(vm.relationship).toBeUndefined()
+
+		const relationship = { id: bob.id, following: true, requested: false }
+		store.commit('addRelationship', { actorId: bob.id, data: relationship })
+		await wrapper.vm.$nextTick()
+
+		expect(vm.relationship).toEqual(relationship)
+	})
+
+	it('relationship is falsy when the account itself is unknown', () => {
+		store.commit('addRelationship', { actorId: bob.id, data: { id: bob.id, following: true } })
+
+		expect(mountWith('bob@remote.tld').relationship).toBeFalsy()
+	})
+})

--- a/tests/js/mixins/currentUserMixin.test.js
+++ b/tests/js/mixins/currentUserMixin.test.js
@@ -1,0 +1,67 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createStore } from 'vuex'
+import { h } from 'vue'
+import { getCurrentUser } from '@nextcloud/auth'
+
+import currentUserMixin from '../../../src/mixins/currentUserMixin.js'
+import settings from '../../../src/store/settings.js'
+
+vi.mock('@nextcloud/auth', () => ({ getCurrentUser: vi.fn() }))
+
+const Probe = {
+	mixins: [currentUserMixin],
+	render: () => h('div'),
+}
+
+describe('currentUserMixin', () => {
+	let store
+	let wrapper
+
+	beforeEach(() => {
+		getCurrentUser.mockReturnValue({ uid: 'alice', displayName: 'Alice', isAdmin: false })
+		settings.state.serverData = {}
+		store = createStore({ modules: { settings } })
+	})
+
+	afterEach(() => {
+		wrapper?.unmount()
+		vi.clearAllMocks()
+	})
+
+	it('exposes the logged-in user from @nextcloud/auth', () => {
+		wrapper = mount(Probe, { global: { plugins: [store] } })
+
+		expect(wrapper.vm.currentUser).toEqual({ uid: 'alice', displayName: 'Alice', isAdmin: false })
+	})
+
+	it('builds the cloud id from the user id and the configured cloud address host', () => {
+		store.commit('setServerData', { cloudAddress: 'https://cloud.example.org:8443/nextcloud' })
+		wrapper = mount(Probe, { global: { plugins: [store] } })
+
+		expect(wrapper.vm.cloudId).toBe('alice@cloud.example.org')
+	})
+
+	it('socialId is the cloud id prefixed with @', () => {
+		store.commit('setServerData', { cloudAddress: 'https://cloud.example.org' })
+		wrapper = mount(Probe, { global: { plugins: [store] } })
+
+		expect(wrapper.vm.socialId).toBe('@alice@cloud.example.org')
+	})
+
+	it('recomputes the ids when the cloud address is loaded later', async () => {
+		wrapper = mount(Probe, { global: { plugins: [store] } })
+		const before = wrapper.vm.cloudId
+
+		store.commit('setServerData', { cloudAddress: 'https://social.example.net' })
+		await wrapper.vm.$nextTick()
+
+		expect(before).not.toBe('alice@social.example.net')
+		expect(wrapper.vm.cloudId).toBe('alice@social.example.net')
+	})
+})

--- a/tests/js/mixins/popoverMenu.test.js
+++ b/tests/js/mixins/popoverMenu.test.js
@@ -1,0 +1,67 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { h } from 'vue'
+
+import popoverMenu from '../../../src/mixins/popoverMenu.js'
+
+const Probe = {
+	mixins: [popoverMenu],
+	render() {
+		return h('div', { class: { open: this.menuOpened } })
+	},
+}
+
+describe('popoverMenu mixin', () => {
+	let wrapper
+
+	afterEach(() => {
+		wrapper?.unmount()
+	})
+
+	it('starts closed', () => {
+		wrapper = mount(Probe)
+
+		expect(wrapper.vm.menuOpened).toBe(false)
+		expect(wrapper.classes()).not.toContain('open')
+	})
+
+	it('togglePopoverMenu flips the state each time', async () => {
+		wrapper = mount(Probe)
+
+		wrapper.vm.togglePopoverMenu()
+		await wrapper.vm.$nextTick()
+		expect(wrapper.vm.menuOpened).toBe(true)
+		expect(wrapper.classes()).toContain('open')
+
+		wrapper.vm.togglePopoverMenu()
+		await wrapper.vm.$nextTick()
+		expect(wrapper.vm.menuOpened).toBe(false)
+	})
+
+	it('hidePopoverMenu closes an open menu and keeps a closed one closed', () => {
+		wrapper = mount(Probe)
+
+		wrapper.vm.togglePopoverMenu()
+		wrapper.vm.hidePopoverMenu()
+		expect(wrapper.vm.menuOpened).toBe(false)
+
+		wrapper.vm.hidePopoverMenu()
+		expect(wrapper.vm.menuOpened).toBe(false)
+	})
+
+	it('keeps the state per component instance', () => {
+		wrapper = mount(Probe)
+		const other = mount(Probe)
+
+		wrapper.vm.togglePopoverMenu()
+
+		expect(wrapper.vm.menuOpened).toBe(true)
+		expect(other.vm.menuOpened).toBe(false)
+		other.unmount()
+	})
+})

--- a/tests/js/mixins/serverData.test.js
+++ b/tests/js/mixins/serverData.test.js
@@ -1,0 +1,69 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createStore } from 'vuex'
+import { h } from 'vue'
+import { loadState } from '@nextcloud/initial-state'
+
+import serverData from '../../../src/mixins/serverData.js'
+import settings from '../../../src/store/settings.js'
+
+const { setInitialState } = globalThis
+
+const Probe = {
+	mixins: [serverData],
+	render: () => h('div'),
+}
+
+describe('serverData mixin', () => {
+	let store
+	let wrapper
+
+	beforeEach(() => {
+		settings.state.serverData = {}
+		store = createStore({ modules: { settings } })
+	})
+
+	afterEach(() => {
+		wrapper?.unmount()
+	})
+
+	it('returns the server data the app loaded from the initial state', () => {
+		const injected = {
+			cloudAddress: 'https://cloud.example.org',
+			firstrun: true,
+			isAdmin: false,
+			public: false,
+			setup: false,
+			cliUrl: 'https://cloud.example.org',
+		}
+		setInitialState('social', 'serverData', injected)
+		store.commit('setServerData', loadState('social', 'serverData'))
+		wrapper = mount(Probe, { global: { plugins: [store] } })
+
+		expect(wrapper.vm.serverData).toEqual(injected)
+	})
+
+	it('derives the hostname from the cloud address, ignoring scheme, port and path', () => {
+		store.commit('setServerData', { cloudAddress: 'https://cloud.example.org:8443/nextcloud/index.php' })
+		wrapper = mount(Probe, { global: { plugins: [store] } })
+
+		expect(wrapper.vm.hostname).toBe('cloud.example.org')
+	})
+
+	it('falls back to the page host while the cloud address is not loaded', () => {
+		wrapper = mount(Probe, { global: { plugins: [store] } })
+
+		expect(wrapper.vm.hostname).toBe(window.location.hostname)
+	})
+
+	it('returns an empty object when no store is installed', () => {
+		wrapper = mount(Probe)
+
+		expect(wrapper.vm.serverData).toEqual({})
+	})
+})

--- a/tests/js/router.test.js
+++ b/tests/js/router.test.js
@@ -1,0 +1,143 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import router from '../../src/router.js'
+
+// The views are lazy-loaded chunks; navigation would otherwise pull in the
+// whole component tree. Stubs keep the routing table under test.
+vi.mock('../../src/views/Timeline.vue', () => ({ default: { name: 'Timeline', render: () => null } }))
+vi.mock('../../src/views/TimelineSinglePost.vue', () => ({ default: { name: 'TimelineSinglePost', render: () => null } }))
+vi.mock('../../src/views/Profile.vue', () => ({ default: { name: 'Profile', render: () => null } }))
+vi.mock('../../src/views/ProfileTimeline.vue', () => ({ default: { name: 'ProfileTimeline', render: () => null } }))
+vi.mock('../../src/views/ProfileFollowers.vue', () => ({ default: { name: 'ProfileFollowers', render: () => null } }))
+
+describe('router', () => {
+	it('is served under the app web root and uses the "active" link class', () => {
+		expect(router.options.history.base).toBe('/apps/social')
+		expect(router.options.linkActiveClass).toBe('active')
+	})
+
+	it('redirects / to the default timeline', async () => {
+		await router.push('/')
+
+		const route = router.currentRoute.value
+		expect(route.name).toBe('timeline')
+		expect(route.path).toBe('/timeline')
+		expect(route.redirectedFrom.path).toBe('/')
+		expect(route.params.type).toBeFalsy()
+	})
+
+	it('exposes the timeline type as a route param passed to the view as a prop', () => {
+		const route = router.resolve('/timeline/notifications')
+
+		expect(route.name).toBe('timeline')
+		expect(route.params).toEqual({ type: 'notifications' })
+		expect(route.matched).toHaveLength(1)
+		expect(route.matched[0].props.default).toBe(true)
+	})
+
+	it.each(['home', 'direct', 'federated', 'favourites'])('builds /timeline/%s from the named timeline route', (type) => {
+		expect(router.resolve({ name: 'timeline', params: { type } }).fullPath).toBe(`/timeline/${type}`)
+	})
+
+	it('routes hashtag timelines to the "tags" child of the timeline route', () => {
+		const route = router.resolve('/timeline/tags/nextcloud')
+
+		expect(route.name).toBe('tags')
+		expect(route.params.tag).toBe('nextcloud')
+		expect(route.matched.map(record => record.name)).toEqual(['timeline', 'tags'])
+		expect(router.resolve({ name: 'tags', params: { tag: 'nextcloud' } }).fullPath).toBe('/timeline/tags/nextcloud')
+	})
+
+	it('routes /@account to the profile with the profile timeline in the details view', () => {
+		const route = router.resolve('/@alice')
+
+		expect(route.name).toBe('profile')
+		expect(route.params).toEqual({ account: 'alice' })
+		expect(route.matched).toHaveLength(2)
+		expect(route.matched[0].path).toBe('/@:account')
+		expect(Object.keys(route.matched[0].components)).toEqual(['default', 'details'])
+		expect(route.matched[0].props.default).toBe(true)
+		expect(Object.keys(route.matched[1].components)).toEqual(['details'])
+	})
+
+	it('keeps remote handles intact in the account param', () => {
+		expect(router.resolve('/@bob@remote.tld').params.account).toBe('bob@remote.tld')
+		expect(router.resolve({ name: 'profile', params: { account: 'bob@remote.tld' } }).fullPath).toBe('/@bob@remote.tld')
+	})
+
+	it.each([
+		['/@alice/followers', 'profile.followers'],
+		['/@alice/following', 'profile.following'],
+		['/@bob@remote.tld/followers', 'profile.followers'],
+	])('routes %s to the %s child view rather than to a single post', (path, name) => {
+		const route = router.resolve(path)
+
+		expect(route.name).toBe(name)
+		expect(route.params.id).toBeUndefined()
+		expect(route.matched[0].path).toBe('/@:account')
+		expect(Object.keys(route.matched[1].components)).toEqual(['details'])
+	})
+
+	it('routes /@account/:id to the single post view', () => {
+		const route = router.resolve('/@alice/12345')
+
+		expect(route.name).toBe('single-post')
+		expect(route.params).toEqual({ account: 'alice', id: '12345' })
+		expect(route.matched).toHaveLength(1)
+		expect(route.matched[0].props.default).toBe(true)
+		expect(router.resolve({ name: 'single-post', params: { account: 'bob@remote.tld', id: '99' } }).fullPath).toBe('/@bob@remote.tld/99')
+	})
+
+	it('serves the OStatus follow page with the profile layout', () => {
+		const route = router.resolve('/ostatus/follow')
+
+		expect(route.matched).toHaveLength(1)
+		expect(route.matched[0].path).toBe('/ostatus/follow')
+		expect(route.name).toBeUndefined()
+		expect(Object.keys(route.matched[0].components)).toEqual(['default', 'details'])
+		expect(route.matched[0].props.default).toBe(true)
+	})
+
+	it('does not match unknown paths', () => {
+		expect(router.resolve('/nope/nope').matched).toEqual([])
+	})
+})
+
+describe('router base detection', () => {
+	afterEach(() => {
+		window.OC.webroot = ''
+		window.history.replaceState({}, '', '/')
+	})
+
+	it('prefers the server-provided web root', async () => {
+		window.OC.webroot = '/nextcloud'
+		vi.resetModules()
+
+		const { default: freshRouter } = await import('../../src/router.js')
+
+		expect(freshRouter.options.history.base).toBe('/nextcloud/apps/social')
+	})
+
+	it('falls back to the part of the current path before /apps/social/', async () => {
+		window.history.replaceState({}, '', '/cloud/apps/social/timeline/home')
+		vi.resetModules()
+
+		const { default: freshRouter } = await import('../../src/router.js')
+
+		expect(freshRouter.options.history.base).toBe('/cloud/apps/social')
+	})
+
+	it('uses /apps/social when nothing else is known', async () => {
+		window.history.replaceState({}, '', '/somewhere/else')
+		vi.resetModules()
+
+		const { default: freshRouter } = await import('../../src/router.js')
+
+		expect(freshRouter.options.history.base).toBe('/apps/social')
+	})
+})

--- a/tests/js/services/eventBus.test.js
+++ b/tests/js/services/eventBus.test.js
@@ -1,0 +1,85 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import eventBus from '../../../src/services/eventBus.js'
+
+describe('eventBus', () => {
+	beforeEach(() => {
+		eventBus.all.clear()
+	})
+
+	it('is a single shared instance so a post can reach the composer', async () => {
+		const { default: again } = await import('../../../src/services/eventBus.js')
+
+		expect(again).toBe(eventBus)
+	})
+
+	it('delivers the emitted payload object itself to the handler', () => {
+		const handler = vi.fn()
+		const post = { id: '1', content: '<p>hi</p>' }
+		eventBus.on('composer-reply', handler)
+
+		eventBus.emit('composer-reply', post)
+
+		expect(handler).toHaveBeenCalledTimes(1)
+		expect(handler.mock.calls[0][0]).toBe(post)
+	})
+
+	it('calls every handler of an event in registration order and nothing else', () => {
+		const calls = []
+		eventBus.on('composer-reply', () => calls.push('first'))
+		eventBus.on('composer-reply', () => calls.push('second'))
+		eventBus.on('other', () => calls.push('other'))
+
+		eventBus.emit('composer-reply', {})
+
+		expect(calls).toEqual(['first', 'second'])
+	})
+
+	it('off with a handler removes only that handler', () => {
+		const keep = vi.fn()
+		const drop = vi.fn()
+		eventBus.on('composer-reply', keep)
+		eventBus.on('composer-reply', drop)
+
+		eventBus.off('composer-reply', drop)
+		eventBus.emit('composer-reply', {})
+
+		expect(keep).toHaveBeenCalledTimes(1)
+		expect(drop).not.toHaveBeenCalled()
+	})
+
+	it('off without a handler removes every handler of that event, as the composer does on unmount', () => {
+		const first = vi.fn()
+		const second = vi.fn()
+		const other = vi.fn()
+		eventBus.on('composer-reply', first)
+		eventBus.on('composer-reply', second)
+		eventBus.on('other', other)
+
+		eventBus.off('composer-reply')
+		eventBus.emit('composer-reply', {})
+		eventBus.emit('other', {})
+
+		expect(first).not.toHaveBeenCalled()
+		expect(second).not.toHaveBeenCalled()
+		expect(other).toHaveBeenCalledTimes(1)
+	})
+
+	it('emitting without listeners is a no-op', () => {
+		expect(() => eventBus.emit('composer-reply', { id: '1' })).not.toThrow()
+	})
+
+	it('supports a wildcard listener receiving the type and payload', () => {
+		const any = vi.fn()
+		eventBus.on('*', any)
+
+		eventBus.emit('composer-reply', { id: '1' })
+
+		expect(any).toHaveBeenCalledWith('composer-reply', { id: '1' })
+	})
+})

--- a/tests/js/services/logger.test.js
+++ b/tests/js/services/logger.test.js
@@ -1,0 +1,67 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getCurrentUser } = vi.hoisted(() => ({ getCurrentUser: vi.fn() }))
+vi.mock('@nextcloud/auth', () => ({ getCurrentUser }))
+
+const loadLogger = async () => {
+	vi.resetModules()
+	const { default: logger } = await import('../../../src/services/logger.js')
+	return logger
+}
+
+describe('logger service', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'error').mockImplementation(() => {})
+		vi.spyOn(console, 'warn').mockImplementation(() => {})
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('prefixes messages with the social app name', async () => {
+		getCurrentUser.mockReturnValue(null)
+		const logger = await loadLogger()
+
+		logger.error('Failed to like status', { code: 42 })
+		logger.warn('Could not find status in timeline', { statusId: '7' })
+
+		expect(console.error).toHaveBeenCalledWith('[ERROR] social: Failed to like status', expect.objectContaining({ app: 'social', code: 42 }))
+		expect(console.warn).toHaveBeenCalledWith('[WARN] social: Could not find status in timeline', expect.objectContaining({ app: 'social', statusId: '7' }))
+	})
+
+	it('adds the current user id to the logging context when someone is logged in', async () => {
+		getCurrentUser.mockReturnValue({ uid: 'alice', displayName: 'Alice', isAdmin: false })
+		const logger = await loadLogger()
+
+		logger.error('boom')
+
+		expect(console.error).toHaveBeenCalledWith('[ERROR] social: boom', expect.objectContaining({ app: 'social', uid: 'alice' }))
+	})
+
+	it('omits the user id on public pages', async () => {
+		getCurrentUser.mockReturnValue(null)
+		const logger = await loadLogger()
+
+		logger.error('boom')
+
+		const context = console.error.mock.calls[0][1]
+		expect(context.app).toBe('social')
+		expect(context).not.toHaveProperty('uid')
+	})
+
+	it('attaches an error passed as context to the log entry', async () => {
+		getCurrentUser.mockReturnValue(null)
+		const logger = await loadLogger()
+		const error = new Error('network down')
+
+		logger.error('Failed to create a status', { error })
+
+		expect(console.error).toHaveBeenCalledWith('[ERROR] social: Failed to create a status', expect.objectContaining({ error }))
+	})
+})

--- a/tests/js/services/notifications.test.js
+++ b/tests/js/services/notifications.test.js
@@ -1,0 +1,45 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { notificationSummary } from '../../../src/services/notifications.js'
+
+const notification = (type, acct = 'bob@remote.tld') => ({
+	id: '1',
+	type,
+	created_at: '2026-09-07T10:00:00.000Z',
+	account: { id: '22', acct, username: acct.split('@')[0] },
+})
+
+describe('notificationSummary', () => {
+	it.each([
+		['mention', 'bob@remote.tld mentioned you'],
+		['status', 'bob@remote.tld posted a status'],
+		['reblog', 'bob@remote.tld boosted your post'],
+		['follow', 'bob@remote.tld started to follow you'],
+		['follow_request', 'bob@remote.tld requested to follow you'],
+		['favourite', 'bob@remote.tld liked your post'],
+		['poll', 'bob@remote.tld ended the poll'],
+		['update', 'bob@remote.tld edited a status'],
+		['admin.sign_up', 'bob@remote.tld signed up'],
+		['admin.report', 'bob@remote.tld filed a report'],
+	])('describes a %s notification with the acting account', (type, expected) => {
+		expect(notificationSummary(notification(type))).toBe(expected)
+	})
+
+	it('uses the full handle of the acting account, local or remote', () => {
+		expect(notificationSummary(notification('mention', 'alice'))).toBe('alice mentioned you')
+	})
+
+	it('returns an empty summary for unknown notification types', () => {
+		expect(notificationSummary(notification('something.new'))).toBe('')
+		expect(notificationSummary({ type: undefined, account: { acct: 'x' } })).toBe('')
+	})
+
+	it('does not let a handle inject markup into the summary', () => {
+		expect(notificationSummary(notification('mention', '<b>evil</b>@remote.tld'))).toBe('&lt;b&gt;evil&lt;/b&gt;@remote.tld mentioned you')
+	})
+})

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -1,0 +1,104 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Global test environment for the Vue frontend.
+ *
+ * Nextcloud injects `t`, `n`, `OC` and `OCA` as globals at runtime; the app
+ * also relies on them being registered as Vue global properties in main.js.
+ * Tests get the same surface here, minimal and deterministic.
+ */
+import { config } from '@vue/test-utils'
+import { vi } from 'vitest'
+
+const translate = (app, text, vars = {}) => Object.entries(vars)
+	.reduce((str, [key, value]) => str.replaceAll(`{${key}}`, String(value)), text)
+const translatePlural = (app, singular, plural, count, vars = {}) => translate(app, count === 1 ? singular : plural, { count, ...vars })
+
+globalThis.t = translate
+globalThis.n = translatePlural
+
+globalThis.OC = {
+	requestToken: 'test-request-token',
+	linkTo: (app, file) => `/apps/${app}/${file}`,
+	generateUrl: (url) => `/index.php${url}`,
+	getCurrentUser: () => ({ uid: 'alice', displayName: 'Alice' }),
+	config: { modRewriteWorking: false },
+	theme: { name: 'Nextcloud' },
+	Notification: { showTemporary: vi.fn() },
+	MimeType: { getIconUrl: () => '/core/img/filetypes/file.svg' },
+	isUserAdmin: () => false,
+}
+globalThis.OCA = {}
+globalThis.OCP = {}
+
+// @nextcloud/router resolves app URLs from these server-injected globals.
+globalThis._oc_webroot = ''
+globalThis._oc_appswebroots = { social: '/apps/social' }
+globalThis.OC.webroot = ''
+globalThis.OC.appswebroots = globalThis._oc_appswebroots
+document.body.dataset.webroot = ''
+document.body.dataset.locale = 'en'
+document.body.dataset.user = 'alice'
+
+// @nextcloud/initial-state reads from <input type="hidden" id="initial-state-{app}-{key}">.
+globalThis.setInitialState = (app, key, value) => {
+	const id = `initial-state-${app}-${key}`
+	let el = document.getElementById(id)
+	if (!el) {
+		el = document.createElement('input')
+		el.type = 'hidden'
+		el.id = id
+		document.head.appendChild(el)
+	}
+	el.value = btoa(JSON.stringify(value))
+}
+
+config.global.mocks = {
+	t: translate,
+	n: translatePlural,
+	OC: globalThis.OC,
+	OCA: globalThis.OCA,
+}
+
+// Node 26 ships an experimental global localStorage that shadows jsdom's and
+// throws without a backing file. Replace it with a plain in-memory Storage.
+const memoryStorage = () => {
+	const data = new Map()
+	return {
+		getItem: (key) => (data.has(key) ? data.get(key) : null),
+		setItem: (key, value) => data.set(key, String(value)),
+		removeItem: (key) => data.delete(key),
+		clear: () => data.clear(),
+		key: (index) => [...data.keys()][index] ?? null,
+		get length() {
+			return data.size
+		},
+	}
+}
+Object.defineProperty(globalThis, 'localStorage', { value: memoryStorage(), configurable: true, writable: true })
+Object.defineProperty(globalThis, 'sessionStorage', { value: memoryStorage(), configurable: true, writable: true })
+
+// jsdom lacks these; components touch them during mount.
+if (!globalThis.matchMedia) {
+	globalThis.matchMedia = () => ({ matches: false, addEventListener: () => {}, removeEventListener: () => {}, addListener: () => {}, removeListener: () => {} })
+}
+if (!globalThis.ResizeObserver) {
+	globalThis.ResizeObserver = class {
+
+		observe() {} unobserve() {} disconnect() {}
+
+	}
+}
+if (!globalThis.IntersectionObserver) {
+	globalThis.IntersectionObserver = class {
+
+		observe() {} unobserve() {} disconnect() {}
+
+	}
+}
+if (!Element.prototype.scrollIntoView) {
+	Element.prototype.scrollIntoView = () => {}
+}

--- a/tests/js/store/account.test.js
+++ b/tests/js/store/account.test.js
@@ -1,0 +1,479 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createStore } from 'vuex'
+import { flushPromises } from '@vue/test-utils'
+import axios from '@nextcloud/axios'
+import { showError } from '@nextcloud/dialogs'
+
+import account from '../../../src/store/account.js'
+import errors from '../../../src/store/errors.js'
+import logger from '../../../src/services/logger.js'
+
+vi.mock('@nextcloud/axios', () => ({
+	default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+}))
+vi.mock('@nextcloud/dialogs', () => ({ showError: vi.fn() }))
+vi.mock('../../../src/services/logger.js', () => ({
+	default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+const API = '/index.php/apps/social/api/v1'
+
+const alice = { id: '11', acct: 'alice', username: 'alice', display_name: 'Alice', url: 'https://cloud.example.org/@alice' }
+const bob = { id: '22', acct: 'bob@remote.tld', username: 'bob', display_name: 'Bob', url: 'https://remote.tld/@bob' }
+const carol = { id: '33', acct: 'carol@remote.tld', username: 'carol', display_name: 'Carol', url: 'https://remote.tld/@carol' }
+const ALICE = 'alice@cloud.example.org'
+
+const freshState = () => ({
+	currentAccount: '',
+	accounts: {},
+	accountsFollowers: {},
+	accountsFollowings: {},
+	accountsRelationships: {},
+	accountIdMap: {},
+	accountsFollowersMaxId: {},
+	accountsFollowingsMaxId: {},
+	accountsFollowersLoading: {},
+	accountsFollowingsLoading: {},
+	accountsFollowersAllLoaded: {},
+	accountsFollowingsAllLoaded: {},
+})
+
+const defaultRelationship = (id, following) => ({
+	id,
+	following,
+	showing_reblogs: false,
+	notifying: false,
+	followed_by: false,
+	blocking: false,
+	blocked_by: false,
+	muting: false,
+	muting_notifications: false,
+	requested: false,
+	domain_blocking: false,
+	endorsed: false,
+})
+
+let store
+
+beforeEach(() => {
+	vi.resetAllMocks()
+	vi.spyOn(console, 'debug').mockImplementation(() => {})
+	vi.spyOn(console, 'error').mockImplementation(() => {})
+	// The module keeps a single state object that its helpers read directly,
+	// so it is reset in place rather than replaced.
+	Object.assign(account.state, freshState())
+	errors.state.errors = []
+	store = createStore({ modules: { account, errors } })
+})
+
+afterEach(() => {
+	vi.restoreAllMocks()
+})
+
+describe('account store state', () => {
+	it('starts with empty maps and no current account', () => {
+		expect(store.state.account).toEqual(freshState())
+	})
+})
+
+describe('account store mutations and getters', () => {
+	it('addAccount indexes a local account by actor url and maps acct@host to it', () => {
+		store.commit('addAccount', { actorId: alice.url, data: alice })
+
+		const state = store.state.account
+		expect(state.accounts[alice.url]).toEqual(alice)
+		expect(state.accountIdMap).toEqual({ [ALICE]: alice.url })
+		expect(state.accountsFollowers[alice.url]).toEqual([])
+		expect(state.accountsFollowings[alice.url]).toEqual([])
+	})
+
+	it('addAccount keeps a remote acct as the map key and merges partial updates', () => {
+		store.commit('addAccount', { actorId: bob.url, data: bob })
+		store.commit('addAccount', { actorId: bob.url, data: { id: '22', acct: bob.acct, url: bob.url, note: '<p>hi</p>' } })
+
+		expect(store.state.account.accountIdMap).toEqual({ 'bob@remote.tld': bob.url })
+		expect(store.state.account.accounts[bob.url]).toEqual({ ...bob, note: '<p>hi</p>' })
+	})
+
+	it('addAccount without an acct stores the account but adds no handle mapping', () => {
+		store.commit('addAccount', { actorId: 'https://x.tld/y', data: { id: '1', url: 'https://x.tld/y' } })
+
+		expect(store.state.account.accounts['https://x.tld/y']).toEqual({ id: '1', url: 'https://x.tld/y' })
+		expect(store.state.account.accountIdMap).toEqual({})
+	})
+
+	it('getAccount, accountLoaded, getAllAccounts and getActorIdForAccount resolve a handle through the map', () => {
+		store.commit('addAccount', { actorId: alice.url, data: alice })
+
+		expect(store.getters.getAccount(ALICE)).toEqual(alice)
+		expect(store.getters.accountLoaded(ALICE)).toEqual(alice)
+		expect(store.getters.getAccount('nobody@remote.tld')).toBeUndefined()
+		expect(store.getters.accountLoaded('nobody@remote.tld')).toBeUndefined()
+		expect(store.getters.getAllAccounts()).toEqual({ [alice.url]: alice })
+		expect(store.getters.getActorIdForAccount(ALICE)).toBe(alice.url)
+	})
+
+	it('currentAccount is the account named by setCurrentAccount', () => {
+		store.commit('addAccount', { actorId: alice.url, data: alice })
+		expect(store.getters.currentAccount).toBeUndefined()
+
+		store.commit('setCurrentAccount', ALICE)
+
+		expect(store.state.account.currentAccount).toBe(ALICE)
+		expect(store.getters.currentAccount).toEqual(alice)
+	})
+
+	it('addRelationship stores a relationship by account id', () => {
+		const relationship = { id: '22', following: true, followed_by: false }
+
+		store.commit('addRelationship', { actorId: '22', data: relationship })
+
+		expect(store.getters.getRelationshipWith('22')).toEqual(relationship)
+		expect(store.getters.getRelationshipWith('11')).toBeUndefined()
+	})
+
+	it('addFollowers replaces the list, indexes each follower and remembers the last id', () => {
+		store.commit('addAccount', { actorId: alice.url, data: alice })
+
+		store.commit('addFollowers', { account: ALICE, data: [bob, carol] })
+
+		expect(store.getters.getAccountFollowers(ALICE)).toEqual([bob, carol])
+		expect(store.getters.getAccount('carol@remote.tld')).toEqual(carol)
+		expect(store.state.account.accountsFollowersMaxId[alice.url]).toBe('33')
+		expect(store.state.account.accountsFollowersAllLoaded[alice.url]).toBe(false)
+
+		store.commit('addFollowers', { account: ALICE, data: [carol] })
+		expect(store.getters.getAccountFollowers(ALICE)).toEqual([carol])
+	})
+
+	it('addFollowersAppend extends the list with the next page', () => {
+		store.commit('addAccount', { actorId: alice.url, data: alice })
+		store.commit('addFollowers', { account: ALICE, data: [bob] })
+
+		store.commit('addFollowersAppend', { account: ALICE, data: [carol] })
+
+		expect(store.getters.getAccountFollowers(ALICE)).toEqual([bob, carol])
+		expect(store.state.account.accountsFollowersMaxId[alice.url]).toBe('33')
+	})
+
+	it('addFollowing and addFollowingAppend maintain the following list the same way', () => {
+		store.commit('addAccount', { actorId: alice.url, data: alice })
+
+		store.commit('addFollowing', { account: ALICE, data: [bob] })
+		expect(store.getters.getAccountFollowing(ALICE)).toEqual([bob])
+		expect(store.state.account.accountsFollowingsMaxId[alice.url]).toBe('22')
+		expect(store.state.account.accountsFollowingsAllLoaded[alice.url]).toBe(false)
+
+		store.commit('addFollowingAppend', { account: ALICE, data: [carol] })
+		expect(store.getters.getAccountFollowing(ALICE)).toEqual([bob, carol])
+		expect(store.state.account.accountsFollowingsMaxId[alice.url]).toBe('33')
+
+		store.commit('addFollowing', { account: ALICE, data: [] })
+		expect(store.getters.getAccountFollowing(ALICE)).toEqual([])
+	})
+
+	it('follower lists use the raw key for accounts that are not loaded', () => {
+		store.commit('addFollowers', { account: 'dave@remote.tld', data: [bob] })
+
+		expect(store.state.account.accountsFollowers['dave@remote.tld']).toEqual([bob.url])
+		expect(store.getters.getAccountFollowers('dave@remote.tld')).toEqual([bob])
+		expect(store.getters.getAccountFollowers('nobody@remote.tld')).toEqual([])
+	})
+
+	it('followAccount flips the relationship of a loaded account to following', () => {
+		store.commit('addAccount', { actorId: bob.url, data: bob })
+		store.commit('addRelationship', { actorId: bob.id, data: { id: bob.id, following: false, followed_by: true } })
+
+		store.commit('followAccount', bob.acct)
+
+		expect(store.getters.getRelationshipWith(bob.id)).toEqual({ id: bob.id, following: true, followed_by: true })
+	})
+
+	it('followAccount creates a default relationship when none was loaded yet', () => {
+		store.commit('addAccount', { actorId: bob.url, data: bob })
+
+		store.commit('followAccount', bob.acct)
+
+		expect(store.getters.getRelationshipWith(bob.id)).toEqual(defaultRelationship(bob.id, true))
+	})
+
+	it('unfollowAccount flips the relationship back, creating a default one if needed', () => {
+		store.commit('addAccount', { actorId: bob.url, data: bob })
+		store.commit('addAccount', { actorId: carol.url, data: carol })
+		store.commit('addRelationship', { actorId: bob.id, data: { id: bob.id, following: true } })
+
+		store.commit('unfollowAccount', bob.acct)
+		store.commit('unfollowAccount', carol.acct)
+
+		expect(store.getters.getRelationshipWith(bob.id)).toEqual({ id: bob.id, following: false })
+		expect(store.getters.getRelationshipWith(carol.id)).toEqual(defaultRelationship(carol.id, false))
+	})
+
+	it('followAccount and unfollowAccount leave relationships alone for accounts that are not loaded', () => {
+		store.commit('followAccount', 'nobody@remote.tld')
+		store.commit('unfollowAccount', 'nobody@remote.tld')
+
+		expect(store.state.account.accountsRelationships).toEqual({})
+	})
+})
+
+describe('account store actions', () => {
+	describe('fetchAccountInfo', () => {
+		it('GETs the global account info and indexes the result', async () => {
+			axios.get.mockResolvedValue({ data: bob })
+
+			const result = await store.dispatch('fetchAccountInfo', bob.acct)
+
+			expect(axios.get).toHaveBeenCalledWith(`${API}/global/account/info?account=bob@remote.tld`)
+			expect(result).toEqual(bob)
+			expect(store.getters.getAccount(bob.acct)).toEqual(bob)
+		})
+
+		it('records an app error instead of throwing when the lookup fails', async () => {
+			axios.get.mockRejectedValue(new Error('unreachable'))
+
+			await expect(store.dispatch('fetchAccountInfo', bob.acct)).resolves.toBeUndefined()
+
+			expect(store.getters.appErrors).toEqual([expect.objectContaining({
+				title: 'Account lookup failed',
+				message: 'Could not load account bob@remote.tld. The remote server may be unreachable.',
+			})])
+			expect(logger.error).toHaveBeenCalledWith('Failed to load account details', { error: expect.any(Error) })
+			expect(store.getters.getAccount(bob.acct)).toBeUndefined()
+		})
+	})
+
+	describe('fetchPublicAccountInfo', () => {
+		it('GETs the public info of a local user and indexes the result', async () => {
+			axios.get.mockResolvedValue({ data: alice })
+
+			const result = await store.dispatch('fetchPublicAccountInfo', 'alice')
+
+			expect(axios.get).toHaveBeenCalledWith(`${API}/account/alice/info`)
+			expect(result).toEqual(alice)
+			expect(store.getters.getAccount(ALICE)).toEqual(alice)
+		})
+
+		it('records an app error naming the uid when the lookup fails', async () => {
+			axios.get.mockRejectedValue(new Error('boom'))
+
+			await expect(store.dispatch('fetchPublicAccountInfo', 'alice')).resolves.toBeUndefined()
+
+			expect(store.getters.appErrors).toEqual([expect.objectContaining({
+				title: 'Account lookup failed',
+				message: 'Could not load account alice. The remote server may be unreachable.',
+			})])
+		})
+	})
+
+	describe('fetchAccountRelationshipInfo', () => {
+		it('GETs the relationships for the given ids and stores each one by id', async () => {
+			const relationships = [{ id: '11', following: false }, { id: '22', following: true }]
+			axios.get.mockResolvedValue({ data: relationships })
+
+			const result = await store.dispatch('fetchAccountRelationshipInfo', ['11', '22'])
+
+			expect(axios.get).toHaveBeenCalledWith(`${API}/accounts/relationships`, { params: { id: ['11', '22'] } })
+			expect(result).toEqual(relationships)
+			expect(store.getters.getRelationshipWith('11')).toEqual(relationships[0])
+			expect(store.getters.getRelationshipWith('22')).toEqual(relationships[1])
+		})
+
+		it('shows an error and resolves to undefined when the request fails', async () => {
+			axios.get.mockRejectedValue(new Error('boom'))
+
+			await expect(store.dispatch('fetchAccountRelationshipInfo', ['11'])).resolves.toBeUndefined()
+
+			expect(showError).toHaveBeenCalledWith('Failed to load relationship info')
+			expect(store.state.account.accountsRelationships).toEqual({})
+		})
+	})
+
+	it('fetchCurrentAccountInfo remembers the current account and loads its info', async () => {
+		axios.get.mockResolvedValue({ data: alice })
+
+		await store.dispatch('fetchCurrentAccountInfo', ALICE)
+		await flushPromises()
+
+		expect(store.state.account.currentAccount).toBe(ALICE)
+		expect(axios.get).toHaveBeenCalledWith(`${API}/global/account/info?account=${ALICE}`)
+		expect(store.getters.currentAccount).toEqual(alice)
+	})
+
+	describe('followAccount', () => {
+		beforeEach(() => {
+			store.commit('addAccount', { actorId: bob.url, data: bob })
+		})
+
+		it('PUTs to the follow endpoint with the encoded handle and marks the relationship as following', async () => {
+			const response = { data: { status: 1, result: [] } }
+			axios.put.mockResolvedValue(response)
+
+			await expect(store.dispatch('followAccount', { accountToFollow: bob.acct })).resolves.toBe(response)
+
+			expect(axios.put).toHaveBeenCalledWith(`${API}/current/follow?account=bob%40remote.tld`)
+			expect(store.getters.getRelationshipWith(bob.id)).toMatchObject({ following: true })
+			expect(showError).not.toHaveBeenCalled()
+		})
+
+		it('rejects with the response and changes nothing when the server reports status -1', async () => {
+			const response = { data: { status: -1, message: 'nope' } }
+			axios.put.mockResolvedValue(response)
+
+			await expect(store.dispatch('followAccount', { accountToFollow: bob.acct })).rejects.toBe(response)
+
+			expect(store.getters.getRelationshipWith(bob.id)).toBeUndefined()
+			expect(showError).not.toHaveBeenCalled()
+		})
+
+		it('shows an error and resolves to undefined on a network failure', async () => {
+			axios.put.mockRejectedValue(new Error('boom'))
+
+			await expect(store.dispatch('followAccount', { accountToFollow: bob.acct })).resolves.toBeUndefined()
+
+			expect(showError).toHaveBeenCalledWith('Failed to follow user bob@remote.tld')
+			expect(logger.error).toHaveBeenCalledWith('Failed to follow user bob@remote.tld', { error: expect.any(Error) })
+			expect(store.getters.getRelationshipWith(bob.id)).toBeUndefined()
+		})
+	})
+
+	describe('unfollowAccount', () => {
+		beforeEach(() => {
+			store.commit('addAccount', { actorId: bob.url, data: bob })
+			store.commit('addRelationship', { actorId: bob.id, data: { id: bob.id, following: true } })
+		})
+
+		it('DELETEs the follow and marks the relationship as not following', async () => {
+			const response = { data: { status: 1, result: [] } }
+			axios.delete.mockResolvedValue(response)
+
+			await expect(store.dispatch('unfollowAccount', { accountToUnfollow: bob.acct })).resolves.toBe(response)
+
+			expect(axios.delete).toHaveBeenCalledWith(`${API}/current/follow?account=bob%40remote.tld`)
+			expect(store.getters.getRelationshipWith(bob.id)).toEqual({ id: bob.id, following: false })
+		})
+
+		it('rejects with the response and keeps following when the server reports status -1', async () => {
+			const response = { data: { status: -1, message: 'nope' } }
+			axios.delete.mockResolvedValue(response)
+
+			await expect(store.dispatch('unfollowAccount', { accountToUnfollow: bob.acct })).rejects.toBe(response)
+
+			expect(store.getters.getRelationshipWith(bob.id)).toMatchObject({ following: true })
+		})
+
+		it('shows an error and resolves with the error on a network failure', async () => {
+			const error = new Error('boom')
+			axios.delete.mockRejectedValue(error)
+
+			await expect(store.dispatch('unfollowAccount', { accountToUnfollow: bob.acct })).resolves.toBe(error)
+
+			expect(showError).toHaveBeenCalledWith('Failed to unfollow user bob@remote.tld')
+			expect(store.getters.getRelationshipWith(bob.id)).toMatchObject({ following: true })
+		})
+	})
+
+	describe('fetchAccountFollowers', () => {
+		beforeEach(() => {
+			store.commit('addAccount', { actorId: alice.url, data: alice })
+		})
+
+		it('loads the first page, marks a short page as complete and clears the loading flag', async () => {
+			let loadingDuringRequest
+			axios.get.mockImplementation(async () => {
+				loadingDuringRequest = store.state.account.accountsFollowersLoading[alice.url]
+				return { data: [bob, carol] }
+			})
+
+			const result = await store.dispatch('fetchAccountFollowers', { account: ALICE })
+
+			expect(axios.get).toHaveBeenCalledWith(`${API}/accounts/${ALICE}/followers`, { params: {} })
+			expect(result).toEqual([bob, carol])
+			expect(loadingDuringRequest).toBe(true)
+			expect(store.getters.getAccountFollowers(ALICE)).toEqual([bob, carol])
+			expect(store.state.account.accountsFollowersAllLoaded[alice.url]).toBe(true)
+			expect(store.state.account.accountsFollowersLoading[alice.url]).toBe(false)
+		})
+
+		it('passes max_id for the next page, appends it and keeps paging while pages are full', async () => {
+			store.commit('addFollowers', { account: ALICE, data: [bob] })
+			const page = Array.from({ length: 20 }, (_, i) => ({
+				id: String(100 + i),
+				acct: `u${i}@remote.tld`,
+				url: `https://remote.tld/@u${i}`,
+			}))
+			axios.get.mockResolvedValue({ data: page })
+
+			await store.dispatch('fetchAccountFollowers', { account: ALICE, maxId: '22' })
+
+			expect(axios.get).toHaveBeenCalledWith(`${API}/accounts/${ALICE}/followers`, { params: { max_id: '22' } })
+			expect(store.getters.getAccountFollowers(ALICE)).toHaveLength(21)
+			expect(store.state.account.accountsFollowersMaxId[alice.url]).toBe('119')
+			expect(store.state.account.accountsFollowersAllLoaded[alice.url]).toBe(false)
+		})
+
+		it('does not start a second request while one is running', async () => {
+			store.commit('setFollowersLoading', { actorId: alice.url, loading: true })
+
+			await expect(store.dispatch('fetchAccountFollowers', { account: ALICE })).resolves.toBeUndefined()
+
+			expect(axios.get).not.toHaveBeenCalled()
+		})
+
+		it('shows an error and clears the loading flag when the request fails', async () => {
+			axios.get.mockRejectedValue(new Error('boom'))
+
+			await expect(store.dispatch('fetchAccountFollowers', { account: ALICE })).resolves.toBeUndefined()
+
+			expect(showError).toHaveBeenCalledWith('Failed to fetch followers list')
+			expect(store.state.account.accountsFollowersLoading[alice.url]).toBe(false)
+			expect(store.getters.getAccountFollowers(ALICE)).toEqual([])
+		})
+	})
+
+	describe('fetchAccountFollowing', () => {
+		beforeEach(() => {
+			store.commit('addAccount', { actorId: alice.url, data: alice })
+		})
+
+		it('loads the first page into the following list and marks a short page as complete', async () => {
+			axios.get.mockResolvedValue({ data: [bob] })
+
+			const result = await store.dispatch('fetchAccountFollowing', { account: ALICE })
+
+			expect(axios.get).toHaveBeenCalledWith(`${API}/accounts/${ALICE}/following`, { params: {} })
+			expect(result).toEqual([bob])
+			expect(store.getters.getAccountFollowing(ALICE)).toEqual([bob])
+			expect(store.state.account.accountsFollowingsAllLoaded[alice.url]).toBe(true)
+			expect(store.state.account.accountsFollowingsLoading[alice.url]).toBe(false)
+		})
+
+		it('appends the next page when max_id is given', async () => {
+			store.commit('addFollowing', { account: ALICE, data: [bob] })
+			axios.get.mockResolvedValue({ data: [carol] })
+
+			await store.dispatch('fetchAccountFollowing', { account: ALICE, maxId: '22' })
+
+			expect(axios.get).toHaveBeenCalledWith(`${API}/accounts/${ALICE}/following`, { params: { max_id: '22' } })
+			expect(store.getters.getAccountFollowing(ALICE)).toEqual([bob, carol])
+		})
+
+		it('skips the request while one is running and reports failures', async () => {
+			store.commit('setFollowingsLoading', { actorId: alice.url, loading: true })
+			await store.dispatch('fetchAccountFollowing', { account: ALICE })
+			expect(axios.get).not.toHaveBeenCalled()
+
+			store.commit('setFollowingsLoading', { actorId: alice.url, loading: false })
+			axios.get.mockRejectedValue(new Error('boom'))
+			await store.dispatch('fetchAccountFollowing', { account: ALICE })
+
+			expect(showError).toHaveBeenCalledWith('Failed to fetch following list')
+			expect(store.state.account.accountsFollowingsLoading[alice.url]).toBe(false)
+		})
+	})
+})

--- a/tests/js/store/errors.test.js
+++ b/tests/js/store/errors.test.js
@@ -1,0 +1,95 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createStore } from 'vuex'
+
+import errors from '../../../src/store/errors.js'
+import logger from '../../../src/services/logger.js'
+
+vi.mock('../../../src/services/logger.js', () => ({
+	default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+describe('errors store', () => {
+	let store
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		vi.useFakeTimers()
+		vi.setSystemTime(new Date('2026-09-07T10:00:00.000Z'))
+		errors.state.errors = []
+		store = createStore({ modules: { errors } })
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+	})
+
+	it('starts without errors', () => {
+		expect(store.getters.appErrors).toEqual([])
+		expect(store.getters.hasErrors).toBe(false)
+	})
+
+	it('addError appends an entry stamped with the current time as id', () => {
+		store.commit('addError', { title: 'Account lookup failed', message: 'Could not load account bob' })
+
+		expect(store.getters.appErrors).toEqual([
+			{ id: Date.now(), title: 'Account lookup failed', message: 'Could not load account bob' },
+		])
+		expect(store.getters.hasErrors).toBe(true)
+	})
+
+	it('keeps errors in the order they were added', () => {
+		store.commit('addError', { title: 'first', message: 'a' })
+		vi.advanceTimersByTime(5)
+		store.commit('addError', { title: 'second', message: 'b' })
+
+		expect(store.getters.appErrors.map(e => e.title)).toEqual(['first', 'second'])
+		expect(store.getters.appErrors[1].id - store.getters.appErrors[0].id).toBe(5)
+	})
+
+	it('dismissError removes only the entry with that id', () => {
+		store.commit('addError', { title: 'first', message: 'a' })
+		vi.advanceTimersByTime(1)
+		store.commit('addError', { title: 'second', message: 'b' })
+		const [first, second] = store.getters.appErrors
+
+		store.commit('dismissError', first.id)
+
+		expect(store.getters.appErrors).toEqual([second])
+
+		store.commit('dismissError', 'unknown')
+
+		expect(store.getters.appErrors).toEqual([second])
+	})
+
+	it('clearErrors removes everything', () => {
+		store.commit('addError', { title: 'first', message: 'a' })
+		vi.advanceTimersByTime(1)
+		store.commit('addError', { title: 'second', message: 'b' })
+
+		store.commit('clearErrors')
+
+		expect(store.getters.appErrors).toEqual([])
+		expect(store.getters.hasErrors).toBe(false)
+	})
+
+	it('addAppError logs the error and stores it', async () => {
+		await store.dispatch('addAppError', { title: 'Account lookup failed', message: 'nope' })
+
+		expect(logger.error).toHaveBeenCalledWith('App error', { title: 'Account lookup failed', message: 'nope' })
+		expect(store.getters.appErrors).toEqual([{ id: Date.now(), title: 'Account lookup failed', message: 'nope' }])
+	})
+
+	it('dismissAppError dismisses by id', async () => {
+		await store.dispatch('addAppError', { title: 'x', message: 'y' })
+		const { id } = store.getters.appErrors[0]
+
+		await store.dispatch('dismissAppError', id)
+
+		expect(store.getters.hasErrors).toBe(false)
+	})
+})

--- a/tests/js/store/index.test.js
+++ b/tests/js/store/index.test.js
@@ -1,0 +1,55 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import store from '../../../src/store/index.js'
+
+describe('root store', () => {
+	afterEach(() => {
+		vi.unstubAllEnvs()
+		vi.restoreAllMocks()
+	})
+
+	it('registers the timeline, account, settings and errors modules without namespaces', () => {
+		expect(store.hasModule('timeline')).toBe(true)
+		expect(store.hasModule('account')).toBe(true)
+		expect(store.hasModule('settings')).toBe(true)
+		expect(store.hasModule('errors')).toBe(true)
+		expect(Object.keys(store.state).sort()).toEqual(['account', 'errors', 'settings', 'timeline'])
+
+		expect(store.getters.getTimeline).toEqual([])
+		expect(typeof store.getters.getAccount).toBe('function')
+		expect(store.getters.getServerData).toEqual({})
+		expect(store.getters.hasErrors).toBe(false)
+	})
+
+	it('lets modules dispatch each other\'s actions through the shared namespace', async () => {
+		await store.dispatch('addAppError', { title: 't', message: 'm' })
+
+		expect(store.getters.appErrors).toHaveLength(1)
+
+		store.commit('clearErrors')
+	})
+
+	it('runs in strict mode outside production and rejects mutations made outside a handler', () => {
+		vi.spyOn(console, 'warn').mockImplementation(() => {})
+		expect(store.strict).toBe(true)
+
+		expect(() => {
+			store.state.settings.serverData = { tampered: true }
+		}).toThrow(/do not mutate vuex store state outside mutation handlers/)
+	})
+
+	it('disables strict mode in production builds', async () => {
+		vi.stubEnv('NODE_ENV', 'production')
+		vi.resetModules()
+
+		const { default: productionStore } = await import('../../../src/store/index.js')
+
+		expect(productionStore.strict).toBe(false)
+		expect(productionStore.hasModule('timeline')).toBe(true)
+	})
+})

--- a/tests/js/store/settings.test.js
+++ b/tests/js/store/settings.test.js
@@ -1,0 +1,44 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createStore } from 'vuex'
+
+import settings from '../../../src/store/settings.js'
+
+describe('settings store', () => {
+	let store
+
+	beforeEach(() => {
+		settings.state.serverData = {}
+		store = createStore({ modules: { settings } })
+	})
+
+	it('starts with an empty serverData object', () => {
+		expect(store.state.settings.serverData).toEqual({})
+		expect(store.getters.getServerData).toEqual({})
+	})
+
+	it('setServerData replaces the whole server data object', () => {
+		const serverData = { cloudAddress: 'https://cloud.example.org', firstrun: true, isAdmin: false, public: false, setup: false }
+
+		store.commit('setServerData', serverData)
+
+		expect(store.getters.getServerData).toEqual(serverData)
+
+		store.commit('setServerData', { public: true })
+
+		expect(store.getters.getServerData).toEqual({ public: true })
+	})
+
+	it('exposes the getter reactively so components see the data loaded later', () => {
+		const before = store.getters.getServerData
+
+		store.commit('setServerData', { firstrun: false })
+
+		expect(before).toEqual({})
+		expect(store.getters.getServerData).toEqual({ firstrun: false })
+	})
+})

--- a/tests/js/store/timeline.test.js
+++ b/tests/js/store/timeline.test.js
@@ -1,0 +1,547 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createStore } from 'vuex'
+import axios from '@nextcloud/axios'
+import { showError } from '@nextcloud/dialogs'
+
+import timeline from '../../../src/store/timeline.js'
+import logger from '../../../src/services/logger.js'
+
+vi.mock('@nextcloud/axios', () => ({
+	default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+}))
+vi.mock('@nextcloud/dialogs', () => ({ showError: vi.fn() }))
+vi.mock('../../../src/services/logger.js', () => ({
+	default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+const API = '/index.php/apps/social/api/v1'
+
+const freshState = () => ({
+	statuses: {},
+	timeline: [],
+	parentsTimeline: [],
+	type: 'home',
+	params: {},
+	account: '',
+	composerDisplayStatus: false,
+	searchQuery: '',
+})
+
+const makeStatus = (id, extra = {}) => ({
+	id,
+	uri: `https://cloud.example.org/users/alice/statuses/${id}`,
+	content: `<p>post ${id}</p>`,
+	created_at: '2026-01-01T10:00:00.000Z',
+	favourited: false,
+	favourites_count: 0,
+	reblogged: false,
+	reblogs_count: 0,
+	account: { acct: 'alice', display_name: 'Alice' },
+	...extra,
+})
+
+describe('timeline store mutations', () => {
+	const { mutations } = timeline
+	let state
+
+	beforeEach(() => {
+		state = freshState()
+	})
+
+	it('addToStatuses indexes a status by id and also the boosted status of a boost wrapper', () => {
+		const inner = makeStatus('1')
+		const wrapper = makeStatus('2', { reblog: inner, content: '' })
+
+		mutations.addToStatuses(state, wrapper)
+
+		expect(state.statuses['2']).toBe(wrapper)
+		expect(state.statuses['1']).toBe(inner)
+		expect(state.timeline).toEqual([])
+	})
+
+	it('addToTimeline appends ids in the order given and indexes every status', () => {
+		const [a, b, c] = [makeStatus('1'), makeStatus('2'), makeStatus('3')]
+
+		mutations.addToTimeline(state, [b, a, c])
+
+		expect(state.timeline).toEqual(['2', '1', '3'])
+		expect(Object.keys(state.statuses).sort()).toEqual(['1', '2', '3'])
+		expect(state.parentsTimeline).toEqual([])
+	})
+
+	it('addToTimeline de-duplicates ids but refreshes the stored status', () => {
+		mutations.addToTimeline(state, [makeStatus('1'), makeStatus('2')])
+		const edited = makeStatus('2', { content: '<p>edited</p>' })
+
+		mutations.addToTimeline(state, [edited, makeStatus('3')])
+
+		expect(state.timeline).toEqual(['1', '2', '3'])
+		expect(state.statuses['2']).toBe(edited)
+	})
+
+	it('addToTimeline with a status context puts ancestors and descendants in separate lists', () => {
+		const parent = makeStatus('1')
+		const reply = makeStatus('3')
+
+		mutations.addToTimeline(state, { ancestors: [parent], descendants: [reply] })
+
+		expect(state.parentsTimeline).toEqual(['1'])
+		expect(state.timeline).toEqual(['3'])
+		expect(state.statuses['1']).toBe(parent)
+		expect(state.statuses['3']).toBe(reply)
+
+		mutations.addToTimeline(state, { ancestors: [parent], descendants: [reply, makeStatus('4')] })
+
+		expect(state.parentsTimeline).toEqual(['1'])
+		expect(state.timeline).toEqual(['3', '4'])
+	})
+
+	it('removeStatus drops the id from the timeline but keeps the status indexed', () => {
+		mutations.addToTimeline(state, [makeStatus('1'), makeStatus('2'), makeStatus('3')])
+
+		mutations.removeStatus(state, { id: '2' })
+
+		expect(state.timeline).toEqual(['1', '3'])
+		expect(state.statuses['2']).toBeDefined()
+	})
+
+	it('removeStatus ignores ids that are not in the timeline', () => {
+		mutations.addToTimeline(state, { ancestors: [makeStatus('1')], descendants: [makeStatus('2')] })
+
+		mutations.removeStatus(state, { id: 'missing' })
+
+		expect(state.timeline).toEqual(['2'])
+		expect(state.parentsTimeline).toEqual(['1'])
+	})
+
+	it('resetTimeline empties both id lists but keeps the index and the type', () => {
+		state.type = 'tags'
+		mutations.addToTimeline(state, { ancestors: [makeStatus('1')], descendants: [makeStatus('2')] })
+
+		mutations.resetTimeline(state)
+
+		expect(state.timeline).toEqual([])
+		expect(state.parentsTimeline).toEqual([])
+		expect(state.statuses['1']).toBeDefined()
+		expect(state.type).toBe('tags')
+	})
+
+	it('setters replace their field', () => {
+		mutations.setTimelineType(state, 'federated')
+		mutations.setTimelineParams(state, { tag: 'nextcloud' })
+		mutations.setAccount(state, 'bob@remote.tld')
+		mutations.setSearchQuery(state, 'hello')
+		mutations.setComposerDisplayStatus(state, true)
+
+		expect(state).toMatchObject({
+			type: 'federated',
+			params: { tag: 'nextcloud' },
+			account: 'bob@remote.tld',
+			searchQuery: 'hello',
+			composerDisplayStatus: true,
+		})
+	})
+
+	it('likeStatus marks the status favourited and bumps the counter without touching the payload object', () => {
+		const original = makeStatus('1', { favourites_count: 4 })
+		mutations.addToStatuses(state, original)
+
+		mutations.likeStatus(state, { status: original })
+
+		expect(state.statuses['1']).toMatchObject({ favourited: true, favourites_count: 5 })
+		expect(original).toMatchObject({ favourited: false, favourites_count: 4 })
+	})
+
+	it('unlikeStatus reverses a like', () => {
+		mutations.addToStatuses(state, makeStatus('1', { favourited: true, favourites_count: 1 }))
+
+		mutations.unlikeStatus(state, { status: { id: '1' } })
+
+		expect(state.statuses['1']).toMatchObject({ favourited: false, favourites_count: 0 })
+	})
+
+	it('boostStatus and unboostStatus toggle reblogged and the reblogs counter', () => {
+		mutations.addToStatuses(state, makeStatus('1', { reblogs_count: 2 }))
+
+		mutations.boostStatus(state, { status: { id: '1' } })
+		expect(state.statuses['1']).toMatchObject({ reblogged: true, reblogs_count: 3 })
+
+		mutations.unboostStatus(state, { status: { id: '1' } })
+		expect(state.statuses['1']).toMatchObject({ reblogged: false, reblogs_count: 2 })
+	})
+
+	it('like and boost mutations are no-ops for statuses that are not indexed', () => {
+		mutations.likeStatus(state, { status: { id: 'x' } })
+		mutations.unlikeStatus(state, { status: { id: 'x' } })
+		mutations.boostStatus(state, { status: { id: 'x' } })
+		mutations.unboostStatus(state, { status: { id: 'x' } })
+
+		expect(state.statuses).toEqual({})
+	})
+
+	it('like and boost only touch the entry whose id is given, for boost wrappers and boosted statuses alike', () => {
+		const inner = makeStatus('1', { favourites_count: 1, reblogs_count: 1 })
+		const wrapper = makeStatus('2', { reblog: inner, content: '' })
+		mutations.addToStatuses(state, wrapper)
+
+		mutations.likeStatus(state, { status: inner })
+		expect(state.statuses['1']).toMatchObject({ favourited: true, favourites_count: 2 })
+		expect(state.statuses['2']).toMatchObject({ favourited: false, favourites_count: 0 })
+
+		mutations.boostStatus(state, { status: wrapper })
+		expect(state.statuses['2']).toMatchObject({ reblogged: true, reblogs_count: 1 })
+		expect(state.statuses['1']).toMatchObject({ reblogged: false, reblogs_count: 1 })
+	})
+
+	it('updateStatus replaces an indexed status and ignores unknown ones', () => {
+		mutations.addToStatuses(state, makeStatus('1'))
+		const edited = makeStatus('1', { content: '<p>edited</p>' })
+
+		mutations.updateStatus(state, edited)
+		mutations.updateStatus(state, makeStatus('9'))
+
+		expect(state.statuses['1']).toBe(edited)
+		expect(state.statuses['9']).toBeUndefined()
+	})
+})
+
+describe('timeline store getters', () => {
+	const { getters, mutations } = timeline
+	let state
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		state = freshState()
+	})
+
+	it('getTimeline returns statuses newest first regardless of insertion order and skips unknown ids', () => {
+		const older = makeStatus('1', { created_at: '2026-01-01T10:00:00.000Z' })
+		const newer = makeStatus('2', { created_at: '2026-01-02T10:00:00.000Z' })
+		mutations.addToTimeline(state, [older, newer])
+		state.timeline.push('ghost')
+
+		expect(getters.getTimeline(state)).toEqual([newer, older])
+	})
+
+	it('getTimeline filters by content, display name and acct, case-insensitively', () => {
+		mutations.addToTimeline(state, [
+			makeStatus('1', { created_at: '2026-01-03T10:00:00.000Z', content: '<p>Hello Fediverse</p>' }),
+			makeStatus('2', { created_at: '2026-01-02T10:00:00.000Z', content: '<p>nothing</p>', account: { acct: 'bob@remote.tld', display_name: 'Bob' } }),
+			makeStatus('3', { created_at: '2026-01-01T10:00:00.000Z', content: '<p>nothing</p>', account: { acct: 'carol', display_name: 'Carol FEDI' } }),
+		])
+
+		state.searchQuery = 'fedi'
+		expect(getters.getTimeline(state).map(s => s.id)).toEqual(['1', '3'])
+
+		state.searchQuery = 'REMOTE.TLD'
+		expect(getters.getTimeline(state).map(s => s.id)).toEqual(['2'])
+
+		state.searchQuery = ''
+		expect(getters.getTimeline(state)).toHaveLength(3)
+	})
+
+	it('getParentsTimeline sorts and filters the ancestors the same way', () => {
+		mutations.addToTimeline(state, {
+			ancestors: [
+				makeStatus('1', { created_at: '2026-01-01T10:00:00.000Z', content: '<p>root</p>' }),
+				makeStatus('2', { created_at: '2026-01-02T10:00:00.000Z', content: '<p>middle</p>' }),
+			],
+			descendants: [makeStatus('3', { content: '<p>root reply</p>' })],
+		})
+
+		expect(getters.getParentsTimeline(state).map(s => s.id)).toEqual(['2', '1'])
+
+		state.searchQuery = 'root'
+		expect(getters.getParentsTimeline(state).map(s => s.id)).toEqual(['1'])
+	})
+
+	it('getStatus, getSinglePost, getSearchQuery and getComposerDisplayStatus read from the state', () => {
+		const post = makeStatus('7')
+		mutations.addToStatuses(state, post)
+		state.params = { singlePost: '7' }
+		state.searchQuery = 'q'
+		state.composerDisplayStatus = true
+
+		expect(getters.getStatus(state)('7')).toBe(post)
+		expect(getters.getStatus(state)('8')).toBeUndefined()
+		expect(getters.getSinglePost(state)).toBe(post)
+		expect(getters.getSearchQuery(state)).toBe('q')
+		expect(getters.getComposerDisplayStatus(state)).toBe(true)
+	})
+
+	it('getPostFromTimeline returns the status, or warns and returns undefined', () => {
+		const post = makeStatus('7')
+		mutations.addToStatuses(state, post)
+
+		expect(getters.getPostFromTimeline(state)('7')).toBe(post)
+		expect(logger.warn).not.toHaveBeenCalled()
+
+		expect(getters.getPostFromTimeline(state)('8')).toBeUndefined()
+		expect(logger.warn).toHaveBeenCalledWith('Could not find status in timeline', { statusId: '8' })
+	})
+})
+
+describe('timeline store actions', () => {
+	let store
+	const tl = () => store.state.timeline
+
+	beforeEach(() => {
+		vi.resetAllMocks()
+		// The module keeps a single state object that its actions read directly,
+		// so it is reset in place rather than replaced.
+		Object.assign(timeline.state, freshState())
+		store = createStore({ modules: { timeline } })
+	})
+
+	it('changeTimelineType resets the lists and stores type and params', async () => {
+		store.commit('addToTimeline', { ancestors: [makeStatus('1')], descendants: [makeStatus('2')] })
+		store.commit('setAccount', 'bob@remote.tld')
+
+		await store.dispatch('changeTimelineType', { type: 'tags', params: { tag: 'nextcloud' } })
+
+		expect(tl()).toMatchObject({
+			timeline: [],
+			parentsTimeline: [],
+			type: 'tags',
+			params: { tag: 'nextcloud' },
+			account: '',
+		})
+		expect(tl().statuses['1']).toBeDefined()
+	})
+
+	it('changeTimelineTypeAccount switches to the statuses of one account', async () => {
+		store.commit('addToTimeline', [makeStatus('1')])
+
+		await store.dispatch('changeTimelineTypeAccount', 'bob@remote.tld')
+
+		expect(tl()).toMatchObject({ timeline: [], type: 'account', account: 'bob@remote.tld' })
+	})
+
+	it('addToTimeline action commits the given statuses', async () => {
+		await store.dispatch('addToTimeline', [makeStatus('1'), makeStatus('2')])
+
+		expect(tl().timeline).toEqual(['1', '2'])
+	})
+
+	describe('createMedia', () => {
+		it('uploads the file as multipart form data and returns the media entity', async () => {
+			const file = new File(['png'], 'cat.png', { type: 'image/png' })
+			const media = { id: '42', url: 'https://cloud.example.org/media/42' }
+			axios.post.mockResolvedValue({ data: media })
+
+			const result = await store.dispatch('createMedia', file)
+
+			expect(result).toEqual(media)
+			const [url, body, config] = axios.post.mock.calls[0]
+			expect(url).toBe(`${API}/media`)
+			expect(body).toBeInstanceOf(FormData)
+			expect(body.get('file')).toBe(file)
+			expect([...body.keys()]).toEqual(['file'])
+			expect(config.headers['Content-Type']).toBe('multipart/form-data')
+		})
+
+		it('shows an error and resolves to undefined when the upload fails', async () => {
+			axios.post.mockRejectedValue(new Error('boom'))
+
+			await expect(store.dispatch('createMedia', new File(['x'], 'x.txt'))).resolves.toBeUndefined()
+
+			expect(showError).toHaveBeenCalledWith('Failed to create a media')
+			expect(logger.error).toHaveBeenCalledWith('Failed to create a media', { error: expect.any(Error) })
+		})
+	})
+
+	describe('post', () => {
+		it('POSTs the status payload to /statuses', async () => {
+			axios.post.mockResolvedValue({ data: { id: '1' } })
+			const payload = { status: 'hello', visibility: 'public', spoiler_text: '', media_ids: ['42'] }
+
+			await store.dispatch('post', payload)
+
+			expect(axios.post).toHaveBeenCalledWith(`${API}/statuses`, payload)
+			expect(showError).not.toHaveBeenCalled()
+		})
+
+		it('reports a failure instead of throwing', async () => {
+			axios.post.mockRejectedValue(new Error('boom'))
+
+			await expect(store.dispatch('post', { status: 'x' })).resolves.toBeUndefined()
+
+			expect(showError).toHaveBeenCalledWith('Failed to create a status')
+			expect(logger.error).toHaveBeenCalledWith('Failed to create a status', { error: expect.any(Error) })
+		})
+	})
+
+	describe('postEdit', () => {
+		it('PUTs the new content and stores the status returned by the server', async () => {
+			const status = makeStatus('1')
+			store.commit('addToTimeline', [status])
+			const edited = makeStatus('1', { content: '<p>edited</p>' })
+			axios.put.mockResolvedValue({ data: edited })
+
+			const response = await store.dispatch('postEdit', { status, content: 'edited', spoiler_text: 'cw', sensitive: true })
+
+			expect(axios.put).toHaveBeenCalledWith(`${API}/statuses/1`, { status: 'edited', spoiler_text: 'cw', sensitive: true })
+			expect(tl().statuses['1']).toEqual(edited)
+			expect(response.data).toEqual(edited)
+		})
+
+		it('leaves the status untouched and shows an error when editing fails', async () => {
+			const status = makeStatus('1')
+			store.commit('addToTimeline', [status])
+			axios.put.mockRejectedValue(new Error('boom'))
+
+			await expect(store.dispatch('postEdit', { status, content: 'x', spoiler_text: '', sensitive: false })).resolves.toBeUndefined()
+
+			expect(tl().statuses['1']).toEqual(status)
+			expect(showError).toHaveBeenCalledWith('Failed to edit the status')
+		})
+	})
+
+	describe('postDelete', () => {
+		it('removes the post from the timeline before sending DELETE with the post uri', async () => {
+			const status = makeStatus('1')
+			store.commit('addToTimeline', [status, makeStatus('2')])
+			let timelineDuringRequest
+			axios.delete.mockImplementation(async () => {
+				timelineDuringRequest = [...tl().timeline]
+				return { data: { status: 1, result: [] } }
+			})
+
+			await store.dispatch('postDelete', status)
+
+			expect(axios.delete).toHaveBeenCalledWith(`${API}/post?id=${status.uri}`)
+			expect(timelineDuringRequest).toEqual(['2'])
+			expect(tl().timeline).toEqual(['2'])
+			expect(showError).not.toHaveBeenCalled()
+		})
+
+		it('re-indexes the status and shows an error when the deletion fails', async () => {
+			const status = makeStatus('1')
+			store.commit('addToTimeline', [status])
+			axios.delete.mockRejectedValue(new Error('boom'))
+
+			await store.dispatch('postDelete', status)
+
+			expect(tl().statuses['1']).toEqual(status)
+			expect(showError).toHaveBeenCalledWith('Failed to delete the status')
+		})
+	})
+
+	describe.each([
+		['postLike', 'favourite', 'favourited', 'favourites_count', false, 1, 'Failed to like status'],
+		['postUnlike', 'unfavourite', 'favourited', 'favourites_count', true, -1, 'Failed to unlike status'],
+		['postBoost', 'reblog', 'reblogged', 'reblogs_count', false, 1, 'Failed to create a boost status'],
+		['postUnBoost', 'unreblog', 'reblogged', 'reblogs_count', true, -1, 'Failed to delete the boost'],
+	])('%s', (action, endpoint, flag, counter, initialFlag, delta, errorMessage) => {
+		const initial = () => makeStatus('1', { [flag]: initialFlag, [counter]: 3 })
+
+		it(`applies the change optimistically, POSTs to /statuses/:id/${endpoint} and stores the server copy`, async () => {
+			const status = initial()
+			store.commit('addToTimeline', [status])
+			const serverCopy = makeStatus('1', { [flag]: !initialFlag, [counter]: 3 + delta, content: '<p>from server</p>' })
+			let duringRequest
+			axios.post.mockImplementation(async () => {
+				duringRequest = { ...tl().statuses['1'] }
+				return { data: serverCopy }
+			})
+
+			const response = await store.dispatch(action, { status })
+
+			expect(axios.post).toHaveBeenCalledWith(`${API}/statuses/1/${endpoint}`)
+			expect(duringRequest).toMatchObject({ [flag]: !initialFlag, [counter]: 3 + delta })
+			expect(tl().statuses['1']).toEqual(serverCopy)
+			expect(response.data).toEqual(serverCopy)
+			expect(showError).not.toHaveBeenCalled()
+		})
+
+		it('rolls the optimistic change back and shows an error when the request fails', async () => {
+			const status = initial()
+			store.commit('addToTimeline', [status])
+			axios.post.mockRejectedValue(new Error('boom'))
+
+			await expect(store.dispatch(action, { status })).resolves.toBeUndefined()
+
+			expect(tl().statuses['1']).toMatchObject({ [flag]: initialFlag, [counter]: 3 })
+			expect(tl().timeline).toEqual(['1'])
+			expect(showError).toHaveBeenCalledWith(errorMessage)
+		})
+	})
+
+	describe('fetchTimeline', () => {
+		const statuses = [makeStatus('1'), makeStatus('2')]
+
+		beforeEach(() => {
+			axios.get.mockResolvedValue({ data: statuses })
+		})
+
+		it.each([
+			['home', {}, `${API}/timelines/home`, { limit: 15 }],
+			['direct', {}, `${API}/timelines/direct`, { limit: 15 }],
+			['favourites', {}, `${API}/timelines/favourites`, { limit: 15 }],
+			['notifications', {}, `${API}/notifications`, { limit: 15 }],
+			['timeline', {}, `${API}/timelines/public`, { limit: 15, local: true }],
+			['federated', {}, `${API}/timelines/public`, { limit: 15 }],
+			['tags', { tag: 'nextcloud' }, `${API}/timelines/tag/nextcloud`, { limit: 15 }],
+		])('requests the %s timeline from its endpoint and appends the result', async (type, params, url, query) => {
+			await store.dispatch('changeTimelineType', { type, params })
+
+			const result = await store.dispatch('fetchTimeline')
+
+			expect(axios.get).toHaveBeenCalledTimes(1)
+			expect(axios.get).toHaveBeenCalledWith(url, { params: query })
+			expect(result).toEqual(statuses)
+			expect(tl().timeline).toEqual(['1', '2'])
+		})
+
+		it('requests the statuses of one account for the account timeline', async () => {
+			await store.dispatch('changeTimelineTypeAccount', 'bob@remote.tld')
+
+			await store.dispatch('fetchTimeline')
+
+			expect(axios.get).toHaveBeenCalledWith(`${API}/accounts/bob@remote.tld/statuses`, { params: { limit: 15 } })
+			expect(tl().timeline).toEqual(['1', '2'])
+		})
+
+		it('loads the context of a single post and splits it into parents and replies', async () => {
+			const parent = makeStatus('1')
+			const reply = makeStatus('3')
+			axios.get.mockResolvedValue({ data: { ancestors: [parent], descendants: [reply] } })
+			await store.dispatch('changeTimelineType', { type: 'single-post', params: { id: '2', singlePost: '2' } })
+
+			await store.dispatch('fetchTimeline')
+
+			expect(axios.get).toHaveBeenCalledWith(`${API}/statuses/2/context`, { params: { limit: 15 } })
+			expect(tl().parentsTimeline).toEqual(['1'])
+			expect(tl().timeline).toEqual(['3'])
+		})
+
+		it('forwards since, max_id and an explicit limit', async () => {
+			await store.dispatch('fetchTimeline', { since: '100', max_id: '50', limit: 30 })
+
+			expect(axios.get).toHaveBeenCalledWith(`${API}/timelines/home`, { params: { since: '100', max_id: '50', limit: 30 } })
+		})
+
+		it('does not swallow request errors and leaves the timeline untouched', async () => {
+			axios.get.mockRejectedValue(new Error('boom'))
+
+			await expect(store.dispatch('fetchTimeline')).rejects.toThrow('boom')
+
+			expect(tl().timeline).toEqual([])
+			expect(showError).not.toHaveBeenCalled()
+		})
+
+		it('refreshTimeline re-fetches the current timeline', async () => {
+			await store.dispatch('changeTimelineType', { type: 'federated', params: {} })
+
+			const result = await store.dispatch('refreshTimeline')
+
+			expect(axios.get).toHaveBeenCalledWith(`${API}/timelines/public`, { params: { limit: 15 } })
+			expect(result).toEqual(statuses)
+		})
+	})
+})

--- a/tests/js/views/Dashboard.test.js
+++ b/tests/js/views/Dashboard.test.js
@@ -1,0 +1,152 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import axios from '@nextcloud/axios'
+import { showError } from '@nextcloud/dialogs'
+import Dashboard from '../../../src/views/Dashboard.vue'
+
+vi.hoisted(() => {
+	document.head.dataset.user = 'alice'
+	document.head.dataset.userDisplayname = 'Alice'
+})
+
+vi.mock('@nextcloud/dialogs', async (importOriginal) => ({
+	...await importOriginal(),
+	showError: vi.fn(),
+}))
+
+const NcDashboardWidgetStub = {
+	name: 'NcDashboardWidget',
+	props: ['items', 'showMoreUrl', 'loading'],
+	template: '<div class="widget-stub"><slot v-if="!loading && items.length === 0" name="empty-content" /></div>',
+}
+
+const bob = { acct: 'bob@remote.example', display_name: 'Bob', avatar: 'https://remote.example/media/bob.png' }
+const carol = { acct: 'carol', display_name: 'Carol', avatar: 'https://cloud.example.org/avatar/carol/64' }
+const notifications = [
+	{ id: 'n3', type: 'follow', created_at: '2026-03-01T10:00:00Z', account: bob },
+	{ id: 'n2', type: 'favourite', created_at: '2026-03-01T09:00:00Z', account: carol },
+	{ id: 'n1', type: 'mention', created_at: '2026-03-01T08:00:00Z', account: carol },
+]
+
+let get
+
+const mountWidget = () => mount(Dashboard, {
+	props: { title: 'Social notifications' },
+	global: { stubs: { NcDashboardWidget: NcDashboardWidgetStub } },
+})
+
+describe('Dashboard', () => {
+	beforeEach(() => {
+		vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] })
+		get = vi.spyOn(axios, 'get')
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+		vi.useRealTimers()
+		vi.mocked(showError).mockClear()
+	})
+
+	it('loads the notifications on mount and shows the widget as loading meanwhile', async () => {
+		get.mockReturnValue(new Promise(() => {}))
+		const wrapper = mountWidget()
+		expect(get).toHaveBeenCalledWith('/index.php/apps/social/api/v1/notifications')
+		expect(wrapper.findComponent(NcDashboardWidgetStub).props('loading')).toBe(true)
+		expect(wrapper.findComponent(NcDashboardWidgetStub).props('showMoreUrl')).toBe('/index.php/apps/social/timeline/notifications')
+	})
+
+	it('maps the notifications to widget items', async () => {
+		get.mockResolvedValue({ data: notifications })
+		const wrapper = mountWidget()
+		await flushPromises()
+
+		const widget = wrapper.findComponent(NcDashboardWidgetStub)
+		expect(widget.props('loading')).toBe(false)
+		expect(widget.props('items')).toEqual([
+			{
+				id: 'n3',
+				targetUrl: '/index.php/apps/social/@bob@remote.example/',
+				avatarUrl: 'https://remote.example/media/bob.png',
+				avatarUsername: 'Bob',
+				overlayIconUrl: '/index.php/svg/social/add_user',
+				mainText: 'bob@remote.example started to follow you',
+				subText: 'bob@remote.example',
+			},
+			{
+				id: 'n2',
+				targetUrl: '/index.php/apps/social/timeline/notifications',
+				avatarUrl: 'https://cloud.example.org/avatar/carol/64',
+				avatarUsername: 'Carol',
+				overlayIconUrl: '',
+				mainText: 'carol liked your post',
+				subText: 'carol',
+			},
+			{
+				id: 'n1',
+				targetUrl: '/index.php/apps/social/timeline/notifications',
+				avatarUrl: 'https://cloud.example.org/avatar/carol/64',
+				avatarUsername: 'Carol',
+				overlayIconUrl: '',
+				mainText: 'carol mentioned you',
+				subText: '',
+			},
+		])
+	})
+
+	it('renders an empty state without items and keeps polling', async () => {
+		get.mockResolvedValue({ data: [] })
+		const wrapper = mountWidget()
+		await flushPromises()
+		expect(wrapper.findComponent(NcDashboardWidgetStub).props('items')).toEqual([])
+		expect(wrapper.find('.empty-content').exists()).toBe(true)
+		expect(showError).not.toHaveBeenCalled()
+
+		vi.advanceTimersByTime(10000)
+		expect(get).toHaveBeenCalledTimes(2)
+	})
+
+	it('polls the server every ten seconds', async () => {
+		get.mockResolvedValue({ data: notifications })
+		mountWidget()
+		await flushPromises()
+		expect(get).toHaveBeenCalledTimes(1)
+
+		vi.advanceTimersByTime(9999)
+		expect(get).toHaveBeenCalledTimes(1)
+		vi.advanceTimersByTime(1)
+		expect(get).toHaveBeenCalledTimes(2)
+		vi.advanceTimersByTime(20000)
+		expect(get).toHaveBeenCalledTimes(4)
+	})
+
+	it('reports a server error, shows the error state and stops polling', async () => {
+		get.mockRejectedValue({ response: { status: 500 } })
+		const wrapper = mountWidget()
+		await flushPromises()
+
+		expect(showError).toHaveBeenCalledWith('Failed to get Social notifications')
+		const widget = wrapper.findComponent(NcDashboardWidgetStub)
+		expect(widget.props('loading')).toBe(false)
+		expect(widget.props('items')).toEqual([])
+		expect(wrapper.find('.empty-content').exists()).toBe(true)
+
+		vi.advanceTimersByTime(30000)
+		expect(get).toHaveBeenCalledTimes(1)
+	})
+
+	it('stops polling on a non-HTTP failure without bothering the user', async () => {
+		vi.spyOn(console, 'error').mockImplementation(() => {})
+		get.mockRejectedValue(new Error('network down'))
+		const wrapper = mountWidget()
+		await flushPromises()
+
+		expect(showError).not.toHaveBeenCalled()
+		expect(wrapper.findComponent(NcDashboardWidgetStub).props('loading')).toBe(true)
+		vi.advanceTimersByTime(30000)
+		expect(get).toHaveBeenCalledTimes(1)
+	})
+})

--- a/tests/js/views/OAuth2Authorize.test.js
+++ b/tests/js/views/OAuth2Authorize.test.js
@@ -1,0 +1,58 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/* global setInitialState */
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it } from 'vitest'
+import OAuth2Authorize from '../../../src/views/OAuth2Authorize.vue'
+
+const setState = (key, value) => {
+	setInitialState('social', key, value)
+	window._nc_initial_state?.clear()
+}
+
+describe('OAuth2Authorize', () => {
+	let wrapper
+
+	beforeEach(() => {
+		setState('appName', 'Tusky')
+		wrapper = mount(OAuth2Authorize)
+	})
+
+	it('names the third party application asking for access', () => {
+		expect(wrapper.find('h1').text()).toBe('Authorization required')
+		const text = wrapper.find('p').text()
+		expect(text).toContain('Tusky would like permission to access your account. It is a third party application.')
+		expect(wrapper.find('p b').text()).toBe('If you do not trust it, then you should not authorize it.')
+	})
+
+	it('posts the decision back to the authorize endpoint that rendered the page', () => {
+		const form = wrapper.find('form.guest-box')
+		expect(form.attributes('method')).toBe('post')
+		expect(form.attributes('action')).toBeUndefined()
+	})
+
+	it('sends the CSRF request token as a hidden field', () => {
+		const token = wrapper.find('form input[name="requesttoken"]')
+		expect(token.attributes('type')).toBe('hidden')
+		expect(token.element.value).toBe('test-request-token')
+	})
+
+	it('submits the form through the authorize button', () => {
+		const submit = wrapper.find('form button[type="submit"]')
+		expect(submit.text()).toBe('Authorize')
+		expect(wrapper.findAll('form button[type="submit"]')).toHaveLength(1)
+	})
+
+	it('lets the user deny by leaving for the app home page', () => {
+		const deny = wrapper.find('form a')
+		expect(deny.text()).toBe('Deny')
+		expect(deny.attributes('href')).toBe('/index.php/apps/social/')
+	})
+
+	it('picks up a different app name from the initial state', () => {
+		setState('appName', 'Ivory')
+		expect(mount(OAuth2Authorize).find('p').text()).toContain('Ivory would like permission')
+	})
+})

--- a/tests/js/views/OStatus.test.js
+++ b/tests/js/views/OStatus.test.js
@@ -1,0 +1,158 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/* global setInitialState */
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createStore } from 'vuex'
+import axios from '@nextcloud/axios'
+import OStatus from '../../../src/views/OStatus.vue'
+import account from '../../../src/store/account.js'
+import errors from '../../../src/store/errors.js'
+import settings from '../../../src/store/settings.js'
+
+const pristine = structuredClone(account.state)
+
+const NcAvatarStub = {
+	name: 'NcAvatar',
+	props: ['url', 'user', 'size', 'disableTooltip'],
+	template: '<span class="nc-avatar-stub" />',
+}
+
+const bob = { id: 'https://remote.example/users/bob', url: 'https://remote.example/users/bob', acct: 'bob@remote.example', username: 'bob', display_name: 'Bob' }
+const currentUser = { uid: 'alice', displayName: 'Alice' }
+
+let store
+let dispatch
+let pending
+const fetchAccount = vi.fn(() => pending)
+
+const setState = (key, value) => {
+	setInitialState('social', key, value)
+	window._nc_initial_state?.clear()
+}
+
+const makeStore = () => {
+	Object.assign(account.state, structuredClone(pristine))
+	store = createStore({
+		modules: {
+			settings,
+			errors,
+			account: {
+				...account,
+				actions: { ...account.actions, fetchAccountInfo: fetchAccount, fetchPublicAccountInfo: fetchAccount, followAccount: vi.fn() },
+			},
+		},
+	})
+	dispatch = vi.spyOn(store, 'dispatch')
+	return store
+}
+
+const mountView = () => mount(OStatus, { global: { plugins: [store], stubs: { NcAvatar: NcAvatarStub } } })
+
+describe('OStatus', () => {
+	beforeEach(() => {
+		pending = new Promise(() => {})
+		fetchAccount.mockClear()
+		makeStore()
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+		delete window.oc_current_user
+	})
+
+	describe('following a remote account from this instance', () => {
+		const serverData = { public: false, cloudAddress: 'https://cloud.example.org', account: 'bob@remote.example', local: '', currentUser }
+
+		beforeEach(() => {
+			setState('serverData', serverData)
+		})
+
+		it('imports the server data and current user and looks up the remote account', () => {
+			mountView()
+			expect(store.state.settings.serverData).toEqual(serverData)
+			expect(window.oc_current_user).toEqual(currentUser)
+			expect(dispatch).toHaveBeenCalledWith('fetchAccountInfo', 'bob@remote.example')
+			expect(dispatch).not.toHaveBeenCalledWith('fetchPublicAccountInfo', expect.anything())
+		})
+
+		it('asks the logged-in user to confirm, naming the account before it is loaded', () => {
+			const wrapper = mountView()
+			const headings = wrapper.findAll('h2').map((heading) => heading.text())
+			expect(headings).toEqual(['Follow on Nextcloud Social', 'bob@remote.example'])
+			expect(wrapper.text()).toContain('Hello')
+			expect(wrapper.text()).toContain('Alice')
+			expect(wrapper.text()).toContain('Please confirm that you want to follow this account:')
+			expect(wrapper.find('form input[type="submit"]').element.value).toBe('Follow')
+			expect(wrapper.text()).not.toContain('You are following this account')
+		})
+
+		it('shows the avatar of the remote account through the app proxy once loaded', async () => {
+			pending = Promise.resolve(bob)
+			const wrapper = mountView()
+			await flushPromises()
+			expect(wrapper.findComponent(NcAvatarStub).props('url'))
+				.toBe('/index.php/apps/social/api/v1/global/actor/avatar?id=https://remote.example/users/bob')
+			expect(wrapper.findComponent(NcAvatarStub).props('size')).toBe(128)
+		})
+
+		it('dispatches the follow with the cloud id of the current user on submit', async () => {
+			pending = Promise.resolve(bob)
+			const wrapper = mountView()
+			await flushPromises()
+			await wrapper.find('form').trigger('submit')
+			expect(dispatch).toHaveBeenCalledWith('followAccount', expect.objectContaining({ currentAccount: 'alice@cloud.example.org' }))
+		})
+	})
+
+	describe('following a local account from another instance', () => {
+		const serverData = { public: true, cloudAddress: 'https://cloud.example.org', account: '', local: 'carol' }
+
+		beforeEach(() => {
+			setState('serverData', serverData)
+		})
+
+		it('looks up the local account publicly and explains the redirect', () => {
+			const wrapper = mountView()
+			expect(dispatch).toHaveBeenCalledWith('fetchPublicAccountInfo', 'carol')
+			expect(dispatch).not.toHaveBeenCalledWith('fetchAccountInfo', expect.anything())
+			expect(wrapper.text()).toContain('You are going to follow:')
+			expect(wrapper.find('h2').text()).toBe('carol')
+			expect(wrapper.findComponent(NcAvatarStub).props('user')).toBe('carol')
+			expect(wrapper.find('input[type="text"]').attributes('placeholder')).toBe('name@domain of your federation account')
+			expect(wrapper.find('input[type="submit"]').element.value).toBe('Continue')
+			expect(wrapper.text()).toContain('We will redirect you to your homeserver to follow this account.')
+		})
+
+		it('resolves the remote follow link for the entered handle and redirects there', async () => {
+			const get = vi.spyOn(axios, 'get').mockResolvedValue({ data: { result: { url: 'https://other.example/authorize_interaction?uri=carol@cloud.example.org' } } })
+			// jsdom cannot navigate: intercept the assignment to window.location
+			const descriptor = Object.getOwnPropertyDescriptor(window, 'location')
+			const location = window.location
+			const navigate = vi.fn()
+			Object.defineProperty(window, 'location', { get: () => location, set: navigate, configurable: true })
+			try {
+				const wrapper = mountView()
+				await wrapper.find('input[type="text"]').setValue('dave@other.example')
+				await wrapper.find('form').trigger('submit')
+				await flushPromises()
+
+				expect(get).toHaveBeenCalledWith('/index.php/apps/social/api/v1/ostatus/link/carol/dave@other.example')
+				expect(navigate).toHaveBeenCalledWith('https://other.example/authorize_interaction?uri=carol@cloud.example.org')
+			} finally {
+				Object.defineProperty(window, 'location', descriptor)
+			}
+		})
+	})
+
+	it('shows a spinner while no account was resolved yet', async () => {
+		setState('serverData', { public: true, cloudAddress: 'https://cloud.example.org', local: 'carol' })
+		pending = Promise.resolve(undefined)
+		const wrapper = mountView()
+		await flushPromises()
+		expect(wrapper.find('.icon-loading-dark').exists()).toBe(true)
+		expect(wrapper.find('h2').exists()).toBe(false)
+	})
+})

--- a/tests/js/views/Profile.test.js
+++ b/tests/js/views/Profile.test.js
@@ -1,0 +1,203 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { reactive } from 'vue'
+import { createStore } from 'vuex'
+import Profile from '../../../src/views/Profile.vue'
+import account from '../../../src/store/account.js'
+import errors from '../../../src/store/errors.js'
+import settings from '../../../src/store/settings.js'
+import timeline from '../../../src/store/timeline.js'
+
+vi.hoisted(() => {
+	document.head.dataset.user = 'alice'
+	document.head.dataset.userDisplayname = 'Alice'
+})
+
+const pristine = structuredClone(account.state)
+
+const ProfileInfoStub = { name: 'ProfileInfo', props: ['uid'], template: '<section class="profile-info-stub" />' }
+const ComposerStub = { name: 'Composer', props: ['initialMention', 'defaultVisibility'], template: '<div class="composer-stub" />' }
+const RouterViewStub = { name: 'RouterView', props: ['name'], template: '<div class="router-view-stub" :data-name="name" />' }
+
+const bob = {
+	id: 'https://remote.example/users/bob',
+	nid: '77',
+	url: 'https://remote.example/users/bob',
+	acct: 'bob@remote.example',
+	username: 'bob',
+	display_name: 'Bob',
+}
+const carol = {
+	id: 'https://cloud.example.org/users/carol',
+	url: 'https://cloud.example.org/users/carol',
+	acct: 'carol',
+	username: 'carol',
+	display_name: 'Carol',
+}
+const alice = {
+	id: 'https://cloud.example.org/users/alice',
+	url: 'https://cloud.example.org/users/alice',
+	acct: 'alice',
+	username: 'alice',
+	display_name: 'Alice',
+}
+const known = { 'bob@remote.example': bob, 'carol@cloud.example.org': carol, 'alice@cloud.example.org': alice }
+
+let store
+let dispatch
+
+// Simulates the server: known handles are put into the store, unknown ones
+// resolve to nothing like the real action does after an error.
+const fetchAccount = vi.fn(async ({ commit }, handle) => {
+	await Promise.resolve()
+	const data = known[handle]
+	if (!data) {
+		return undefined
+	}
+	commit('addAccount', { actorId: data.url, data })
+	return data
+})
+
+const makeStore = (serverData = {}) => {
+	Object.assign(account.state, structuredClone(pristine))
+	store = createStore({
+		modules: {
+			timeline,
+			settings,
+			errors,
+			account: {
+				...account,
+				actions: {
+					...account.actions,
+					fetchAccountInfo: fetchAccount,
+					fetchPublicAccountInfo: fetchAccount,
+					fetchAccountRelationshipInfo: vi.fn(async () => []),
+				},
+			},
+		},
+	})
+	store.commit('setServerData', { public: false, cloudAddress: 'https://cloud.example.org', ...serverData })
+	dispatch = vi.spyOn(store, 'dispatch')
+	return store
+}
+
+const mountProfile = (route) => mount(Profile, {
+	global: {
+		plugins: [store],
+		mocks: { $route: route },
+		stubs: { ProfileInfo: ProfileInfoStub, Composer: ComposerStub, RouterView: RouterViewStub },
+	},
+})
+
+describe('Profile', () => {
+	beforeEach(() => {
+		makeStore()
+		fetchAccount.mockClear()
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('loads the routed remote account, then its relationship, and shows the profile with the details view', async () => {
+		const wrapper = mountProfile({ name: 'profile', params: { account: 'bob@remote.example' } })
+		expect(wrapper.classes()).toContain('icon-loading')
+		expect(wrapper.findComponent(ProfileInfoStub).exists()).toBe(false)
+		expect(dispatch).toHaveBeenCalledWith('fetchAccountInfo', 'bob@remote.example')
+
+		await flushPromises()
+		expect(dispatch).toHaveBeenCalledWith('fetchAccountRelationshipInfo', ['77'])
+		expect(wrapper.classes()).not.toContain('icon-loading')
+		expect(wrapper.findComponent(ProfileInfoStub).props('uid')).toBe('bob@remote.example')
+		expect(wrapper.findComponent(RouterViewStub).props('name')).toBe('details')
+	})
+
+	it('completes a bare local uid with the instance host before asking the server', async () => {
+		const wrapper = mountProfile({ name: 'profile', params: { account: 'carol' } })
+		expect(dispatch).toHaveBeenCalledWith('fetchAccountInfo', 'carol@cloud.example.org')
+		await flushPromises()
+		// without a numeric id the relationship lookup falls back to the actor id
+		expect(dispatch).toHaveBeenCalledWith('fetchAccountRelationshipInfo', ['https://cloud.example.org/users/carol'])
+		expect(wrapper.findComponent(ProfileInfoStub).props('uid')).toBe('carol')
+	})
+
+	it('stays in the loading state when the account cannot be resolved', async () => {
+		const wrapper = mountProfile({ name: 'profile', params: { account: 'nobody@remote.example' } })
+		await flushPromises()
+		expect(wrapper.classes()).toContain('icon-loading')
+		expect(wrapper.findComponent(ProfileInfoStub).exists()).toBe(false)
+		expect(wrapper.findComponent(RouterViewStub).exists()).toBe(false)
+		expect(dispatch).not.toHaveBeenCalledWith('fetchAccountRelationshipInfo', expect.anything())
+	})
+
+	it('does nothing without an account in the route or the server data', () => {
+		mountProfile({ name: 'profile', params: {} })
+		expect(dispatch).not.toHaveBeenCalled()
+	})
+
+	it('reloads when the route switches to another account', async () => {
+		const route = reactive({ name: 'profile', params: { account: 'bob@remote.example' } })
+		const wrapper = mountProfile(route)
+		await flushPromises()
+
+		route.params.account = 'carol'
+		await flushPromises()
+		expect(dispatch).toHaveBeenCalledWith('fetchAccountInfo', 'carol@cloud.example.org')
+		expect(wrapper.findComponent(ProfileInfoStub).props('uid')).toBe('carol')
+	})
+
+	describe('composer', () => {
+		beforeEach(() => {
+			store.commit('addAccount', { actorId: alice.url, data: alice })
+			store.commit('setCurrentAccount', 'alice@cloud.example.org')
+		})
+
+		it('offers a direct message to the shown account on the posts tab', async () => {
+			const wrapper = mountProfile({ name: 'profile', params: { account: 'bob@remote.example' } })
+			await flushPromises()
+			const composer = wrapper.findComponent(ComposerStub)
+			expect(composer.props('defaultVisibility')).toBe('direct')
+			expect(composer.props('initialMention')).toEqual(bob)
+		})
+
+		it('does not pre-fill a mention on the own profile', async () => {
+			const wrapper = mountProfile({ name: 'profile', params: { account: 'alice' } })
+			await flushPromises()
+			expect(wrapper.findComponent(ComposerStub).props('initialMention')).toBeNull()
+		})
+
+		it('is hidden on the followers and following tabs', async () => {
+			const wrapper = mountProfile({ name: 'profile.followers', params: { account: 'bob@remote.example' } })
+			await flushPromises()
+			expect(wrapper.findComponent(ProfileInfoStub).exists()).toBe(true)
+			expect(wrapper.findComponent(ComposerStub).exists()).toBe(false)
+		})
+
+		it('is hidden while no current account is known', async () => {
+			store.commit('setCurrentAccount', '')
+			const wrapper = mountProfile({ name: 'profile', params: { account: 'bob@remote.example' } })
+			await flushPromises()
+			expect(wrapper.findComponent(ComposerStub).exists()).toBe(false)
+		})
+	})
+
+	describe('on the public page', () => {
+		beforeEach(() => {
+			makeStore({ public: true, account: 'carol' })
+		})
+
+		it('uses the public lookup for the account from the server data and skips the relationship', async () => {
+			const wrapper = mountProfile({ name: undefined, params: {} })
+			expect(dispatch).toHaveBeenCalledWith('fetchPublicAccountInfo', 'carol@cloud.example.org')
+			await flushPromises()
+			expect(dispatch).not.toHaveBeenCalledWith('fetchAccountRelationshipInfo', expect.anything())
+			expect(dispatch).not.toHaveBeenCalledWith('fetchAccountInfo', expect.anything())
+			expect(wrapper.findComponent(ProfileInfoStub).props('uid')).toBe('carol')
+			expect(wrapper.findComponent(ComposerStub).exists()).toBe(false)
+		})
+	})
+})

--- a/tests/js/views/ProfileFollowers.test.js
+++ b/tests/js/views/ProfileFollowers.test.js
@@ -1,0 +1,156 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, reactive } from 'vue'
+import { createStore } from 'vuex'
+import ProfileFollowers from '../../../src/views/ProfileFollowers.vue'
+import account from '../../../src/store/account.js'
+import settings from '../../../src/store/settings.js'
+
+vi.hoisted(() => {
+	document.head.dataset.user = 'alice'
+	document.head.dataset.userDisplayname = 'Alice'
+})
+
+const pristine = structuredClone(account.state)
+
+const UserEntryStub = { name: 'UserEntry', props: ['item'], template: '<div class="user-entry-stub" />' }
+
+const bob = { id: 'https://remote.example/users/bob', url: 'https://remote.example/users/bob', acct: 'bob@remote.example', username: 'bob' }
+const carol = { id: 'https://cloud.example.org/users/carol', url: 'https://cloud.example.org/users/carol', acct: 'carol', username: 'carol' }
+const dave = { id: 'https://other.example/users/dave', url: 'https://other.example/users/dave', acct: 'dave@other.example', username: 'dave' }
+const erin = { id: 'https://other.example/users/erin', url: 'https://other.example/users/erin', acct: 'erin@other.example', username: 'erin' }
+
+let store
+let dispatch
+
+const fetchFollowers = vi.fn(async ({ commit }, { account: handle }) => {
+	commit('addFollowers', { account: handle, data: [dave, erin] })
+})
+const fetchFollowing = vi.fn(async ({ commit }, { account: handle }) => {
+	commit('addFollowing', { account: handle, data: [carol] })
+})
+
+const mountView = (route) => mount(ProfileFollowers, {
+	global: { plugins: [store], mocks: { $route: route }, stubs: { UserEntry: UserEntryStub } },
+})
+
+const shown = (wrapper) => wrapper.findAllComponents(UserEntryStub).map((entry) => entry.props('item').acct)
+
+describe('ProfileFollowers', () => {
+	beforeEach(() => {
+		Object.assign(account.state, structuredClone(pristine))
+		store = createStore({
+			modules: {
+				settings,
+				account: {
+					...account,
+					actions: { ...account.actions, fetchAccountFollowers: fetchFollowers, fetchAccountFollowing: fetchFollowing },
+				},
+			},
+		})
+		store.commit('setServerData', { public: false, cloudAddress: 'https://cloud.example.org' })
+		store.commit('addAccount', { actorId: bob.url, data: bob })
+		store.commit('addAccount', { actorId: carol.url, data: carol })
+		dispatch = vi.spyOn(store, 'dispatch')
+		fetchFollowers.mockClear()
+		fetchFollowing.mockClear()
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('fetches and lists the followers of the routed account', async () => {
+		const wrapper = mountView({ name: 'profile.followers', params: { account: 'bob@remote.example' } })
+		expect(dispatch).toHaveBeenCalledWith('fetchAccountFollowers', { account: 'bob@remote.example' })
+		expect(dispatch).not.toHaveBeenCalledWith('fetchAccountFollowing', expect.anything())
+		await flushPromises()
+		expect(shown(wrapper)).toEqual(['dave@other.example', 'erin@other.example'])
+	})
+
+	it('fetches and lists the accounts the routed account follows', async () => {
+		const wrapper = mountView({ name: 'profile.following', params: { account: 'bob@remote.example' } })
+		expect(dispatch).toHaveBeenCalledWith('fetchAccountFollowing', { account: 'bob@remote.example' })
+		await flushPromises()
+		expect(shown(wrapper)).toEqual(['carol'])
+	})
+
+	it('completes a bare local uid with the instance host', () => {
+		mountView({ name: 'profile.followers', params: { account: 'carol' } })
+		expect(dispatch).toHaveBeenCalledWith('fetchAccountFollowers', { account: 'carol@cloud.example.org' })
+	})
+
+	it('does nothing without an account in the route', () => {
+		const wrapper = mountView({ name: 'profile.followers', params: {} })
+		expect(dispatch).not.toHaveBeenCalled()
+		expect(shown(wrapper)).toEqual([])
+		expect(wrapper.find('.loading-indicator').exists()).toBe(false)
+	})
+
+	it('shows a loading indicator while the list is being fetched', async () => {
+		const wrapper = mountView({ name: 'profile.followers', params: { account: 'bob@remote.example' } })
+		await flushPromises()
+		expect(wrapper.find('.loading-indicator').exists()).toBe(false)
+
+		store.commit('setFollowersLoading', { actorId: bob.url, loading: true })
+		await nextTick()
+		expect(wrapper.find('.loading-indicator').text()).toBe('Loading…')
+
+		store.commit('setFollowersLoading', { actorId: bob.url, loading: false })
+		await nextTick()
+		expect(wrapper.find('.loading-indicator').exists()).toBe(false)
+	})
+
+	it('only reacts to the loading flag of the shown list', async () => {
+		const wrapper = mountView({ name: 'profile.following', params: { account: 'bob@remote.example' } })
+		store.commit('setFollowersLoading', { actorId: bob.url, loading: true })
+		await nextTick()
+		expect(wrapper.find('.loading-indicator').exists()).toBe(false)
+	})
+
+	it('switches lists when the route moves between followers and following', async () => {
+		const route = reactive({ name: 'profile.followers', params: { account: 'bob@remote.example' } })
+		const wrapper = mountView(route)
+		await flushPromises()
+		expect(shown(wrapper)).toEqual(['dave@other.example', 'erin@other.example'])
+
+		route.name = 'profile.following'
+		await flushPromises()
+		expect(dispatch).toHaveBeenCalledWith('fetchAccountFollowing', { account: 'bob@remote.example' })
+		expect(shown(wrapper)).toEqual(['carol'])
+	})
+
+	it('refetches when the route points to another account', async () => {
+		const route = reactive({ name: 'profile.followers', params: { account: 'bob@remote.example' } })
+		mountView(route)
+		route.params.account = 'carol'
+		await flushPromises()
+		expect(dispatch).toHaveBeenLastCalledWith('fetchAccountFollowers', { account: 'carol@cloud.example.org' })
+	})
+
+	it('watches the end of the list for infinite scrolling and stops on unmount', () => {
+		const observe = vi.fn()
+		const disconnect = vi.fn()
+		vi.stubGlobal('IntersectionObserver', class {
+
+			constructor(callback, options) {
+				this.options = options
+			}
+
+			observe = observe
+			disconnect = disconnect
+
+		})
+		const wrapper = mountView({ name: 'profile.followers', params: { account: 'bob@remote.example' } })
+		return nextTick().then(() => {
+			expect(observe).toHaveBeenCalledWith(wrapper.find('.list-sentinel').element)
+			wrapper.unmount()
+			expect(disconnect).toHaveBeenCalledTimes(1)
+			vi.unstubAllGlobals()
+		})
+	})
+})

--- a/tests/js/views/ProfilePageIntegration.test.js
+++ b/tests/js/views/ProfilePageIntegration.test.js
@@ -1,0 +1,68 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import axios from '@nextcloud/axios'
+import ProfilePageIntegration from '../../../src/views/ProfilePageIntegration.vue'
+
+vi.hoisted(() => {
+	document.head.dataset.user = 'alice'
+	document.head.dataset.userDisplayname = 'Alice'
+})
+
+const TimelineEntryStub = { name: 'TimelineEntry', props: ['item', 'type'], template: '<li class="timeline-entry-stub" />' }
+
+const bob = { id: 'https://cloud.example.org/users/bob', acct: 'bob', username: 'bob', display_name: 'Bob' }
+const statuses = [
+	{ id: '1', content: '<p>first</p>', account: bob },
+	{ id: '2', content: '<p>second</p>', account: bob },
+]
+
+let get
+
+const mountSection = (userId) => mount(ProfilePageIntegration, {
+	props: { userId },
+	global: { stubs: { TimelineEntry: TimelineEntryStub } },
+})
+
+describe('ProfilePageIntegration', () => {
+	beforeEach(() => {
+		get = vi.spyOn(axios, 'get').mockImplementation(async (url) => ({ data: url.endsWith('/statuses') ? statuses : bob }))
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('requests the account and its posts for the profile owner, URL-encoding the id', () => {
+		mountSection('bob@remote.example')
+		expect(get).toHaveBeenCalledTimes(2)
+		expect(get).toHaveBeenCalledWith('/index.php/apps/social/api/v1/global/account/info?account=bob%40remote.example')
+		expect(get).toHaveBeenCalledWith('/index.php/apps/social/api/v1/accounts/bob%40remote.example/statuses')
+	})
+
+	it('renders the section heading and one entry per post', async () => {
+		const wrapper = mountSection('bob')
+		expect(wrapper.find('h2').text()).toBe('Social')
+		expect(wrapper.findAllComponents(TimelineEntryStub)).toHaveLength(0)
+
+		await flushPromises()
+		expect(wrapper.findAllComponents(TimelineEntryStub).map((entry) => entry.props('item'))).toEqual(statuses)
+	})
+
+	it('does not contact the server without a user id', () => {
+		const wrapper = mountSection('')
+		expect(get).not.toHaveBeenCalled()
+		expect(wrapper.find('h2').text()).toBe('Social')
+	})
+
+	it('keeps the section usable when the posts cannot be loaded', async () => {
+		get.mockRejectedValue(new Error('404'))
+		const wrapper = mountSection('bob')
+		await flushPromises()
+		expect(wrapper.find('h2').text()).toBe('Social')
+		expect(wrapper.findAllComponents(TimelineEntryStub)).toHaveLength(0)
+	})
+})

--- a/tests/js/views/ProfileTimeline.test.js
+++ b/tests/js/views/ProfileTimeline.test.js
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, reactive } from 'vue'
+import { createStore } from 'vuex'
+import ProfileTimeline from '../../../src/views/ProfileTimeline.vue'
+import timeline from '../../../src/store/timeline.js'
+
+const pristine = structuredClone(timeline.state)
+
+const TimelineListStub = {
+	name: 'TimelineList',
+	props: ['type'],
+	template: '<ul class="timeline-list-stub" />',
+}
+
+let store
+let dispatch
+
+const mountView = (route) => mount(ProfileTimeline, {
+	global: { plugins: [store], mocks: { $route: route }, stubs: { TimelineList: TimelineListStub } },
+})
+
+describe('ProfileTimeline', () => {
+	beforeEach(() => {
+		Object.assign(timeline.state, structuredClone(pristine))
+		store = createStore({ modules: { timeline } })
+		store.commit('addToTimeline', [{ id: 'old', created_at: '2026-01-01T00:00:00Z' }])
+		dispatch = vi.spyOn(store, 'dispatch')
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('switches the store to the posts of the routed account and renders the list', () => {
+		const wrapper = mountView({ name: 'profile', params: { account: 'bob@remote.example' } })
+		expect(dispatch).toHaveBeenCalledWith('changeTimelineTypeAccount', 'bob@remote.example')
+		expect(store.state.timeline.type).toBe('account')
+		expect(store.state.timeline.account).toBe('bob@remote.example')
+		expect(store.state.timeline.timeline).toEqual([])
+		expect(wrapper.findComponent(TimelineListStub).exists()).toBe(true)
+	})
+
+	it('leaves the store alone without an account in the route', () => {
+		mountView({ name: 'profile', params: {} })
+		expect(dispatch).not.toHaveBeenCalled()
+		expect(store.state.timeline.timeline).toEqual(['old'])
+	})
+
+	it('reloads when the route points to another account', async () => {
+		const route = reactive({ name: 'profile', params: { account: 'bob@remote.example' } })
+		mountView(route)
+		route.params.account = 'carol'
+		await nextTick()
+		expect(dispatch).toHaveBeenLastCalledWith('changeTimelineTypeAccount', 'carol')
+		expect(store.state.timeline.account).toBe('carol')
+	})
+})

--- a/tests/js/views/Timeline.test.js
+++ b/tests/js/views/Timeline.test.js
@@ -1,0 +1,188 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { createStore } from 'vuex'
+import Timeline from '../../../src/views/Timeline.vue'
+import account from '../../../src/store/account.js'
+import errors from '../../../src/store/errors.js'
+import settings from '../../../src/store/settings.js'
+import timeline from '../../../src/store/timeline.js'
+
+vi.hoisted(() => {
+	document.head.dataset.user = 'alice'
+	document.head.dataset.userDisplayname = 'Alice'
+})
+
+const pristine = {
+	account: structuredClone(account.state),
+	timeline: structuredClone(timeline.state),
+}
+
+const ComposerStub = {
+	name: 'Composer',
+	props: ['defaultVisibility', 'initialMention'],
+	template: '<div class="composer-stub" />',
+}
+const TimelineListStub = {
+	name: 'TimelineList',
+	props: ['type', 'showParents', 'reverseOrder'],
+	template: '<ul class="timeline-list-stub" />',
+}
+
+const nextcloud = {
+	id: 'https://mastodon.xyz/users/nextcloud',
+	url: 'https://mastodon.xyz/users/nextcloud',
+	acct: 'nextcloud@mastodon.xyz',
+	username: 'nextcloud',
+	display_name: 'Nextcloud',
+}
+
+let store
+let dispatch
+
+const makeStore = (serverData = {}) => {
+	Object.assign(account.state, structuredClone(pristine.account))
+	Object.assign(timeline.state, structuredClone(pristine.timeline))
+	store = createStore({
+		modules: {
+			timeline,
+			settings,
+			errors,
+			// network actions are replaced, the synchronous ones stay real
+			account: { ...account, actions: { ...account.actions, fetchAccountInfo: vi.fn(), followAccount: vi.fn() } },
+		},
+	})
+	store.commit('setServerData', { public: false, cloudAddress: 'https://cloud.example.org', firstrun: false, ...serverData })
+	dispatch = vi.spyOn(store, 'dispatch')
+	return store
+}
+
+const mountTimeline = (route = {}) => mount(Timeline, {
+	global: {
+		plugins: [store],
+		mocks: { $route: { name: 'timeline', params: {}, ...route } },
+		stubs: { Composer: ComposerStub, TimelineList: TimelineListStub },
+	},
+})
+
+describe('Timeline', () => {
+	beforeEach(() => {
+		makeStore()
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('switches the store to the home timeline when no type is in the route', () => {
+		const wrapper = mountTimeline()
+		expect(dispatch).toHaveBeenCalledWith('changeTimelineType', { type: 'home', params: {} })
+		expect(store.state.timeline.type).toBe('home')
+		expect(wrapper.findComponent(TimelineListStub).props('type')).toBe('home')
+		expect(wrapper.find('h2').exists()).toBe(false)
+	})
+
+	it.each(['direct', 'timeline', 'federated', 'favourites'])('switches the store to the %s timeline from the route', (type) => {
+		const wrapper = mountTimeline({ params: { type } })
+		expect(dispatch).toHaveBeenCalledWith('changeTimelineType', { type, params: {} })
+		expect(wrapper.findComponent(TimelineListStub).props('type')).toBe(type)
+	})
+
+	it('resets the previously loaded posts when switching', () => {
+		store.commit('addToTimeline', [{ id: 'old', created_at: '2026-01-01T00:00:00Z' }])
+		mountTimeline({ params: { type: 'federated' } })
+		expect(store.state.timeline.timeline).toEqual([])
+	})
+
+	it('loads a hashtag timeline with the tag as parameter and shows the tag as heading', () => {
+		const wrapper = mountTimeline({ name: 'tags', params: { tag: 'nextcloud' } })
+		expect(dispatch).toHaveBeenCalledWith('changeTimelineType', { type: 'tags', params: { tag: 'nextcloud' } })
+		expect(wrapper.find('h2').text()).toBe('#nextcloud')
+		expect(wrapper.findComponent(TimelineListStub).props('type')).toBe('tags')
+		expect(wrapper.findComponent(ComposerStub).exists()).toBe(true)
+	})
+
+	it('shows the composer on the home timeline without a preset visibility', () => {
+		const composer = mountTimeline().findComponent(ComposerStub)
+		expect(composer.exists()).toBe(true)
+		expect(composer.props('defaultVisibility')).toBeUndefined()
+	})
+
+	it('presets the composer to direct messages on the direct timeline', () => {
+		expect(mountTimeline({ params: { type: 'direct' } }).findComponent(ComposerStub).props('defaultVisibility')).toBe('direct')
+	})
+
+	it('hides the composer on the notifications timeline and titles it', () => {
+		const wrapper = mountTimeline({ params: { type: 'notifications' } })
+		expect(wrapper.findComponent(ComposerStub).exists()).toBe(false)
+		expect(wrapper.find('h2').text()).toBe('Notifications')
+		expect(wrapper.findComponent(TimelineListStub).props('type')).toBe('notifications')
+	})
+
+	it('shows the active search with a way to clear it', async () => {
+		const wrapper = mountTimeline()
+		expect(wrapper.find('.search-active').exists()).toBe(false)
+
+		store.commit('setSearchQuery', 'fediverse')
+		await nextTick()
+		expect(wrapper.find('.search-active').text()).toContain('Search: «fediverse»')
+
+		await wrapper.find('.search-clear').trigger('click')
+		expect(store.state.timeline.searchQuery).toBe('')
+		expect(wrapper.find('.search-active').exists()).toBe(false)
+	})
+
+	it('does not show the welcome box or look up the Nextcloud account after the first run', () => {
+		const wrapper = mountTimeline()
+		expect(wrapper.find('.social__welcome').exists()).toBe(false)
+		expect(dispatch).not.toHaveBeenCalledWith('fetchAccountInfo', expect.anything())
+	})
+
+	describe('on the first run', () => {
+		beforeEach(() => {
+			makeStore({ firstrun: true })
+		})
+
+		it('welcomes the user with their social id and looks up the official account', () => {
+			const wrapper = mountTimeline()
+			expect(wrapper.find('.social__welcome').exists()).toBe(true)
+			expect(wrapper.find('.social-id').text()).toBe('@alice@cloud.example.org')
+			expect(dispatch).toHaveBeenCalledWith('fetchAccountInfo', 'nextcloud@mastodon.xyz')
+		})
+
+		it('can be closed', async () => {
+			const wrapper = mountTimeline()
+			await wrapper.find('.social__welcome .close').trigger('click')
+			expect(wrapper.find('.social__welcome').exists()).toBe(false)
+		})
+
+		it('suggests following the Nextcloud account and dispatches the follow', async () => {
+			const wrapper = mountTimeline()
+			const follow = wrapper.find('.follow-nextcloud input[type="button"]')
+			expect(follow.element.value).toBe('Follow Nextcloud on mastodon.xyz')
+			await follow.trigger('click')
+			expect(dispatch).toHaveBeenCalledWith('followAccount', { accountToFollow: 'nextcloud@mastodon.xyz' })
+		})
+
+		it('hides the suggestion while the account is unknown and once it is followed', async () => {
+			const wrapper = mountTimeline()
+			// v-show toggles display: none
+			const hidden = () => wrapper.find('.follow-nextcloud').element.style.display === 'none'
+			// unknown yet: treated as followed so nothing flashes
+			expect(hidden()).toBe(true)
+
+			store.commit('addAccount', { actorId: nextcloud.url, data: nextcloud })
+			store.commit('addRelationship', { actorId: nextcloud.id, data: { id: nextcloud.id, following: false } })
+			await nextTick()
+			expect(hidden()).toBe(false)
+
+			store.commit('followAccount', nextcloud.acct)
+			await nextTick()
+			expect(hidden()).toBe(true)
+		})
+	})
+})

--- a/tests/js/views/TimelineSinglePost.test.js
+++ b/tests/js/views/TimelineSinglePost.test.js
@@ -1,0 +1,189 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/* global setInitialState */
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { createStore } from 'vuex'
+import TimelineSinglePost from '../../../src/views/TimelineSinglePost.vue'
+import eventBus from '../../../src/services/eventBus.js'
+import account from '../../../src/store/account.js'
+import errors from '../../../src/store/errors.js'
+import settings from '../../../src/store/settings.js'
+import timeline from '../../../src/store/timeline.js'
+
+vi.hoisted(() => {
+	document.head.dataset.user = 'alice'
+	document.head.dataset.userDisplayname = 'Alice'
+})
+
+const pristine = {
+	account: structuredClone(account.state),
+	timeline: structuredClone(timeline.state),
+}
+
+const ComposerStub = { name: 'Composer', template: '<div class="composer-stub" />' }
+const TimelineListStub = {
+	name: 'TimelineList',
+	props: { type: String, showParents: Boolean, reverseOrder: Boolean },
+	template: '<ul class="timeline-list-stub"><li data-social-status="reply-1" /></ul>',
+}
+const TimelineEntryStub = {
+	name: 'TimelineEntry',
+	props: ['item', 'type', 'element'],
+	template: '<div class="timeline-entry-stub" />',
+}
+
+const bob = { id: 'https://remote.example/users/bob', url: 'https://remote.example/users/bob', acct: 'bob@remote.example', username: 'bob' }
+const status = { id: '123', uri: 'https://remote.example/users/bob/statuses/123', content: '<p>Hello</p>', created_at: '2026-01-01T00:00:00Z', account: bob }
+const fromServer = { ...status, content: '<p>Server copy</p>' }
+
+let store
+let dispatch
+const fetchAccount = vi.fn(async () => bob)
+
+const setState = (key, value) => {
+	setInitialState('social', key, value)
+	window._nc_initial_state?.clear()
+}
+
+const makeStore = (serverData = {}) => {
+	Object.assign(account.state, structuredClone(pristine.account))
+	Object.assign(timeline.state, structuredClone(pristine.timeline))
+	store = createStore({
+		modules: {
+			timeline,
+			settings,
+			errors,
+			account: { ...account, actions: { ...account.actions, fetchAccountInfo: fetchAccount, fetchPublicAccountInfo: fetchAccount } },
+		},
+	})
+	store.commit('setServerData', { public: false, cloudAddress: 'https://cloud.example.org', ...serverData })
+	dispatch = vi.spyOn(store, 'dispatch')
+	return store
+}
+
+// Known app bug (src/views/TimelineSinglePost.vue:66-70): resetting the
+// timeline in beforeMount fires the parentsTimeline watcher in the pre-flush
+// phase of the first render, before template refs exist, so it throws
+// "Cannot read properties of undefined (reading 'parentElement')". Vue Test
+// Utils rethrows every error reaching the app error handler during mount, so a
+// host component stops it earlier to keep the view's other behaviour testable.
+const Host = {
+	components: { TimelineSinglePost },
+	errorCaptured: () => false,
+	template: '<TimelineSinglePost />',
+}
+
+// every view registers an event bus listener, so unmount them after each test
+const mounted = []
+
+const mountView = () => {
+	const wrapper = mount(Host, {
+		attachTo: document.body,
+		global: {
+			plugins: [store],
+			mocks: { $route: { name: 'single-post', params: { account: 'bob', id: '123' } } },
+			stubs: { Composer: ComposerStub, TimelineList: TimelineListStub, TimelineEntry: TimelineEntryStub },
+		},
+	})
+	mounted.push(wrapper)
+	return wrapper
+}
+
+describe('TimelineSinglePost', () => {
+	beforeEach(() => {
+		// the view derives the account from the browser URL
+		window.history.replaceState({}, '', '/apps/social/@bob/123')
+		setState('item', fromServer)
+		makeStore()
+		fetchAccount.mockClear()
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+		mounted.splice(0).forEach((wrapper) => wrapper.unmount())
+	})
+
+	it('switches the store to the single post context of the routed post', () => {
+		store.commit('addToStatuses', status)
+		mountView()
+		expect(dispatch).toHaveBeenCalledWith('changeTimelineType', {
+			type: 'single-post',
+			params: { account: 'bob', id: '123', type: 'single-post', singlePost: '123' },
+		})
+		expect(store.state.timeline.type).toBe('single-post')
+		expect(store.state.timeline.params.singlePost).toBe('123')
+	})
+
+	it('prefers the already loaded post over the server-rendered copy', () => {
+		store.commit('addToStatuses', status)
+		const wrapper = mountView()
+		expect(wrapper.findComponent(TimelineEntryStub).props('item')).toEqual(status)
+		expect(store.getters.getSinglePost.content).toBe('<p>Hello</p>')
+	})
+
+	it('falls back to the post from the initial state when it is not in the store yet', () => {
+		const wrapper = mountView()
+		expect(store.getters.getSinglePost).toEqual(fromServer)
+		expect(wrapper.findComponent(TimelineEntryStub).props('item')).toEqual(fromServer)
+	})
+
+	it('renders the main post as a block with the ancestors above and the replies below', () => {
+		store.commit('addToStatuses', status)
+		const wrapper = mountView()
+		const entry = wrapper.findComponent(TimelineEntryStub)
+		expect(entry.props('type')).toBe('single-post')
+		expect(entry.props('element')).toBe('div')
+		expect(entry.classes()).toContain('main-post')
+
+		const lists = wrapper.findAllComponents(TimelineListStub)
+		expect(lists).toHaveLength(2)
+		expect(lists[0].props('showParents')).toBe(true)
+		expect(lists[0].props('reverseOrder')).toBe(true)
+		expect(lists[1].props('showParents')).toBe(false)
+		expect(lists[1].classes()).toContain('descendants')
+	})
+
+	it('loads the author taken from the URL', async () => {
+		mountView()
+		expect(dispatch).toHaveBeenCalledWith('fetchAccountInfo', 'bob')
+		expect(dispatch).not.toHaveBeenCalledWith('fetchPublicAccountInfo', expect.anything())
+		await flushPromises()
+		expect(fetchAccount).toHaveBeenCalledTimes(1)
+	})
+
+	it('uses the public author lookup on the public page', () => {
+		makeStore({ public: true })
+		mountView()
+		expect(dispatch).toHaveBeenCalledWith('fetchPublicAccountInfo', 'bob')
+		expect(dispatch).not.toHaveBeenCalledWith('fetchAccountInfo', expect.anything())
+	})
+
+	it('only shows the composer when a reply was requested', async () => {
+		const wrapper = mountView()
+		const composer = () => wrapper.find('.composer-stub').element.style.display
+		expect(composer()).toBe('none')
+		store.commit('setComposerDisplayStatus', true)
+		await nextTick()
+		expect(composer()).toBe('')
+	})
+
+	it('scrolls to the post being replied to and stops listening after unmount', async () => {
+		const scrollIntoView = vi.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(() => {})
+		const wrapper = mountView()
+
+		eventBus.emit('composer-reply', { id: 'reply-1' })
+		await nextTick()
+		expect(scrollIntoView).toHaveBeenCalledTimes(1)
+		expect(scrollIntoView.mock.instances[0]).toBe(wrapper.find('[data-social-status="reply-1"]').element)
+		expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' })
+
+		wrapper.unmount()
+		eventBus.emit('composer-reply', { id: 'reply-1' })
+		await nextTick()
+		expect(scrollIntoView).toHaveBeenCalledTimes(1)
+	})
+})

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,24 +1,27 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<phpunit bootstrap="bootstrap.php"
-		 verbose="true"
-		 convertDeprecationsToExceptions="true"
+<!--
+  - SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+		 bootstrap="bootstrap.php"
+		 colors="true"
+		 failOnWarning="true"
+		 failOnRisky="true"
+		 beStrictAboutOutputDuringTests="true"
 		 timeoutForSmallTests="900"
 		 timeoutForMediumTests="900"
 		 timeoutForLargeTests="900"
 		>
-	<testsuite name='Social App Tests'>
-		<directory suffix='Test.php'>.</directory>
-	</testsuite>
-	<!-- filters for code coverage -->
-	<filter>
-		<whitelist>
-			<directory suffix=".php">../appinfo</directory>
+	<testsuites>
+		<testsuite name="Social App Tests">
+			<directory suffix="Test.php">.</directory>
+		</testsuite>
+	</testsuites>
+	<coverage>
+		<include>
 			<directory suffix=".php">../lib</directory>
-		</whitelist>
-	</filter>
-	<logging>
-		<!-- and this is where your report will be written -->
-		<log type="coverage-clover" target="./clover.xml"/>
-	</logging>
+		</include>
+	</coverage>
 </phpunit>
-

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { fileURLToPath } from 'node:url'
+import vue from '@vitejs/plugin-vue'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+	plugins: [vue()],
+	resolve: {
+		alias: {
+			'@': fileURLToPath(new URL('./src', import.meta.url)),
+		},
+	},
+	test: {
+		environment: 'jsdom',
+		globals: true,
+		setupFiles: ['./tests/js/setup.js'],
+		include: ['src/**/*.{test,spec}.js', 'tests/js/**/*.{test,spec}.js'],
+		css: false,
+		// @nextcloud/vue ships ESM that imports its own CSS; let Vite process it
+		// instead of handing the .css files to Node.
+		server: {
+			deps: {
+				inline: [/@nextcloud\/vue/, /@nextcloud\/dialogs/],
+			},
+		},
+		coverage: {
+			provider: 'v8',
+			include: ['src/**/*.{js,vue}'],
+			exclude: ['src/**/*.test.js', 'src/main.js', 'src/dashboard.js', 'src/oauth.js', 'src/ostatus.js', 'src/profile.js'],
+			reportsDirectory: './coverage/js',
+		},
+	},
+})


### PR DESCRIPTION
* Resolves: #693, #1014 (relates to #922)
* Target version: master

### Summary

The test suite ran one dummy assertion and needed a booted Nextcloud server to do it; the Cypress E2E tests were removed in 5e01b7b2. Nothing verified the ActivityPub layer, the services, the controllers or any Vue component. This adds unit tests for both.

|  | Before | After |
|---|---|---|
| Backend | 1 dummy assertion, required a server + database | **1,462 tests / 4,754 assertions**, 127 files, runs standalone in **0.6 s** |
| Frontend | 12 tests on Jest, which had no Vue transform and could not mount a component | **508 tests** on Vitest, 47 files, **5.7 s** |

```bash
composer run test:unit    # PHPUnit
npm test                  # Vitest  (npm run test:coverage for a report)
```

No changes to `lib/` or `src/` — `git diff --stat -- lib src` is empty. php-cs-fixer reports 0 findings across the 133 files it checks, ESLint is clean.

### Backend

Tests mirror `lib/`, so `lib/Service/PostService.php` → `tests/Service/PostServiceTest.php`.

| Area | Files | Tests | Focus |
|---|--:|--:|---|
| `Service` | 30 | 504 | HTTP + LD signature round-trips with real RSA keys; the visibility → recipient matrix; what each action federates, and to which inbox |
| `Model` | 34 | 243 | import/export against Mastodon-shaped documents; actor documents; client entities |
| `Controller` | 10 | 239 | response shape and status per route; inbox signature gating; OAuth flows |
| `Interfaces` | 23 | 164 | every incoming activity handler — Follow→Accept, Undo dispatch, Note dedup, Like/Announce counters, Delete, Move |
| `Tools` | 12 | 162 | traits and helper models |
| `AP` | 1 | 66 | type mapping, recursion limit |
| WellKnown, Cron, Dashboard, Search, Notification, Listeners, Providers, AppInfo | 14 | 79 | WebFinger JRD, cron jobs, widgets, unified search, notifier, listeners |

It runs without a server or a database. OCP interfaces come from the existing `nextcloud/ocp` dev dependency, whose autoloader is registered inside `tests/bootstrap.php` rather than through composer's `autoload-dev` — the app's autoloader is loaded by the server at runtime, so a psr-4 entry for `OCP\` there would shadow the server's real interfaces with those stubs wherever dev dependencies are present, and a server class carrying `#[\Override]` against a method the stub lacks then fails to load. Collaborators are mocked. Code that reaches the container statically — `\OCP\Server::get()`, `\OC::$server` — finds the small PSR container in `tests/Helper/TestContainer.php`, which resolves registered doubles and throws a named error for anything unregistered, so a hidden dependency surfaces as a clear failure instead of a fatal.

Nothing touches the network. `CurlService` is exercised through a partial mock of `doRequest`; the JSON-LD contexts are served offline from `context/`.

**Two areas are skipped, each with the reason in the test.** `lib/Command/*` extends the server-internal `OC\Core\Command\Base`, and `composer.json` carries `"replace": {"symfony/console": "*"}`, so those classes cannot autoload standalone. `QueueController::asyncForRequest` ends in an unconditional `exit()`, which ends the test runner even in a separate process. Covering commands needs a server-booting bootstrap; that is worth adding as a *second* suite rather than reverting this one, since the standalone bootstrap is what makes 1,462 tests run in 0.6 s.

### Frontend

Jest is replaced by Vitest with `@vue/test-utils` and jsdom. `@nextcloud/vue` 9 is ESM-only and imports its own CSS, so it is inlined for Vite. `tests/js/setup.js` supplies what the app expects the server to have injected — `t`, `n`, `OC`, `OCA`, the router webroots, and an in-memory `localStorage`, because Node's experimental global shadows jsdom's and throws without a backing file.

Components 248 (22 files) · stores 99 — every mutation with before and after state, every action's URL, payload and error path · views 69 · `App`/router/utils 45 · services 24 · mixins 20 · directives 3.

The `lint` script now covers `tests/js` as well, and `.github/workflows/vitest.yml` runs the frontend suite on PRs, mirroring the organisation's `lint-eslint` template so branch protection can key on the `vitest` summary job. The three existing `phpunit-*` workflows already call `composer run test:unit`, so they now exercise the new suite as well.

### One caveat worth stating plainly

**A green suite here does not mean the app is correct.** Writing these tests surfaced a number of defects. Where a test would have had to encode a defect in order to pass, the case was left out rather than written to match the current behaviour — so the suite is deliberately green against code that has known bugs. Each of those omissions sits in the test file next to the code it belongs to: fix the bug, add the case back.

I will send the maintainers the full list separately, since a few of the findings are security-relevant and a public pull request is the wrong venue for them. The clearly benign ones:

<details>
<summary>Functional defects found while writing the tests</summary>

- `lib/Service/StreamService.php:183` — a leftover `echo json_encode($actor)` writes into the body of every response that reaches `detectType()`.
- `lib/Service/StreamService.php:176` — the unlisted branch calls `setType(Stream::TYPE_UNLISTED)`, overwriting the ActivityPub type rather than setting the timeline; `DetailsService` reads `getTimeline()`.
- `lib/AP.php` — `getInterfaceFromType()` has no `Tombstone` case, and `DeleteInterface` catches the resulting `ItemUnknownException`, so `Delete{object: Tombstone}` is dropped. It also has no cases for `Group`, `Organization` or `Application`, although the interfaces are injected.
- `lib/Service/AccountService.php:384,420` — `self::TIME_RETENTION` and `self::KEY_PAIR_LIFESPAN` are never defined, so `manageDeletedActors()` and `blindKeyRotation()` fail with an undefined-constant `Error`.
- `lib/Service/SearchService.php:86,110,131` — `!$type & self::SEARCH_X` parses as `(!$type) & X`, so the type guards never fire.
- `lib/Service/FediverseService.php:173` — `removeAddress()` stores `json_encode(array_diff(...))` without `array_values`, so removing any element but the last persists a JSON object and `isListed()` then fails on it.
- `lib/Service/ActorService.php:129` — `catch (Exception $e)` without `use Exception` resolves to `OCA\Social\Service\Exception`, so nothing is caught.
- `lib/Model/LinkedDataSignature.php` — `sign()` omits `nonce` from the signed header while `verify()` includes it, so a signature made with a nonce can never verify.
- `lib/Model/ActivityPub/Stream.php` — `spoiler_text` reads a field `import()` never fills from a remote `summary`, so incoming content warnings do not reach Mastodon clients; `created_at` is rendered in the server timezone with a literal `Z`.
- `lib/Tools/Traits/TArrayTools.php:107` — `getFloat()` returns `intval()`, truncating fractions (it backs `AttachmentMeta`'s aspect and duration).
- `lib/Tools/Model/Cache.php:149` — the `create` flag in `updateItem()` is inverted.
- `lib/Controller/MediaApiController.php` — `uploadMedia()` is a stub returning `id => 1`.
- `src/components/Composer/Composer.vue:47` — renders `<Tribute>`, a component that is never imported or registered, so the mention and hashtag autocomplete is dead markup.
- `src/components/ActorAvatar.vue:47` — reads `this.item.attributedTo` on a component whose prop is `actor`, so rendering a remote actor throws.
- `src/views/TimelineSinglePost.vue:66-70` — the `parentsTimeline` watcher runs during the first render's pre-flush, before the template ref exists, and throws on every single-post view.
- `src/components/MessageContent.js:225` — splits `acct` on the wrong side, so a Mastodon-style mention anchor never matches and is dropped to plain text; `:86` the mention regex carries `g` and is reused with `exec`, so `lastIndex` leaks between calls.
- `src/store/account.js:226` — `isFollowingUser` looks relationships up by actor URL while they are stored by numeric id, so it always returns false (used by `FollowButton`, `OStatus`, `Timeline`).
- `src/store/timeline.js:258,267` — `postUnlike` special-cases `state.type === 'liked'`, but the navigation links that view as `favourites`, so unliking never removes the post from it.
- `src/store/timeline.js:63` — `removeStatus` tests `timelineIndex` where it means `parentsTimelineIndex`, splicing index -1 and deleting the last ancestor.
- `src/views/ProfileFollowers.vue:132` — sends `max_id` while the store action reads `maxId`, so infinite scroll refetches the first page.
- `src/views/Dashboard.vue:83` — merges new notifications by `publishedTime`, which the API does not emit.
- `src/components/EmptyContent.vue:7`, `src/views/Profile.vue:15` — pass `:title` to `NcEmptyContent`, which takes `name` in `@nextcloud/vue` 9, so the title lands as an HTML attribute and never renders.
- `src/App.vue:180` with `src/store/settings.js:13` — `commit('setServerDataEntry', 'setup', false)` passes two payload arguments to a mutation that receives one.

`docs/Architecture.md` also lists bookmark and pin as implemented, but `ActionService` handles only favourite and reblog, and it describes the instance blocklists whose implementation in `FediverseService` is commented out.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
