### PR TITLE
docs: bring the documentation in line with the implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,77 @@
 # Nextcloud Social 🚀✨
 
-Nextcloud Social is an ActivityPub-enabled app that integrates your Nextcloud account with the Fediverse. It lets your Nextcloud instance act as a lightweight federated social server: create, edit and distribute posts; follow remote accounts; and interact with likes, boosts and replies.
+Nextcloud Social is an ActivityPub app that connects your Nextcloud account to the Fediverse. Your instance acts as a lightweight federated social server: each user gets a `Person` actor, can write and edit posts, follow accounts on other servers, and like, boost and reply to what they receive.
 
 ![Screenshot](img/screenshot.png)
 
-Short summary: This app implements ActivityPub and enables Fediverse functionality inside Nextcloud.
+It is a partial implementation of ActivityPub and of the Mastodon client API — enough for posting, following and reading timelines, but far from feature parity with Mastodon. See "Not implemented yet" below before deploying it as someone's only Fediverse client.
 
 ## 🔧 Features
 
-- 🧭 Timelines — browse public, local and home timelines
-- ✍️ Composer — create posts, replies and mentions
-- ✏️ Edit posts — edit local posts
-- 👍 / 🔁 / 💬 Post actions — like, boost (announce), reply
-- 🧾 Profiles — avatar, header/banner and metadata support
-- 🌐 Federation — send and receive ActivityPub activities (Create, Like, Announce)
-- 🔎 Discovery — webfinger and remote user discovery
-- ⚙️ Backend — persistence, queues and signature support for reliable delivery
+- 🧭 **Timelines** — Home, Local, Global (federated), Direct messages, Liked posts, Notifications, per-account and per-hashtag timelines.
+- ✍️ **Composer** — write posts and replies, pick a visibility (public, unlisted, followers-only, direct), insert emoji, and attach images. `@mentions` and `#hashtags` typed by hand are extracted from the text and turned into real recipients and tags.
+- ✏️ **Edit posts** — edit your own local posts inline; the change is saved and federated as an ActivityPub `Update` (`lib/Service/PostService.php`, `editPost()`).
+- 🗑️ **Delete posts** — delete your own posts.
+- 👍 🔁 💬 **Post actions** — like/unlike, boost/unboost (`Announce`) and reply.
+- 👥 **Following** — follow and unfollow local and remote accounts, and browse followers/following lists.
+- 🖼️ **Profiles** — avatar, uploadable banner/header image and a profile description (`note`). Editable structured profile fields are *not* supported (see below).
+- 🌐 **Federation** — signed HTTP delivery of `Create`, `Update`, `Delete`, `Like`, `Announce`, `Follow`, `Accept` and `Undo` activities, an outbound request queue and a stream queue for resolving incoming objects, both drained by background jobs and by `occ social:queue:process`.
+- 🔎 **Discovery & search** — WebFinger lookups, remote actor resolution and caching, and search over known accounts and hashtags.
+- 🛡️ **Instance access list** — an allow-list or deny-list of remote hosts, enforced on incoming activities and outgoing requests. Managed with `occ social:fediverse`; see [docs/OCC-Commands.md](docs/OCC-Commands.md) for the details and its limits.
+- 🔑 **Mastodon-compatible API** — a subset of the Mastodon client API plus OAuth 2 authorization, so some third-party clients can talk to the app. See [docs/API.md](docs/API.md) for exactly which routes exist.
+
+### 🚧 Not implemented yet
+
+These are absent from the code today, not merely rough edges:
+
+- **No blocking, muting or reporting.** The `Block` activity model exists but nothing creates or acts on it; `mute`/`unmute`, `bookmark`/`unbookmark` and `pin`/`unpin` are accepted by the status-action endpoint and then silently ignored (`lib/Service/ActionService.php`, `action()` has no `case` for them).
+- **No approvable follow requests.** `manuallyApprovesFollowers` is not implemented; every incoming `Follow` is confirmed straight away with an `Accept` (`lib/Interfaces/Object/FollowInterface.php`, `confirmFollowRequest()`). There is no request queue, no accept/reject endpoint, and `follow_requests_count` is hard-coded to `0` (`lib/Model/ActivityPub/Actor/Person.php`). Accounts cannot be locked.
+- **No profile metadata fields.** `fields` is always exported as an empty array (`lib/Model/ActivityPub/Actor/Person.php`), so the profile "Website" row never appears and there is nothing to edit.
+- **No polls, bookmarks or lists.** The Mastodon type definitions in `src/types/Mastodon.js` mention polls, but no poll, bookmark or list feature exists on either side.
+- **No `@`/`#` autocomplete in the composer.** The template wraps the input in a `<Tribute>` component (`src/components/Composer/Composer.vue:47`) that is never imported or registered, so the suggestion dropdown does not appear.
+- **Images only for attachments.** The file picker is `accept="image/*"` (`src/components/Composer/Composer.vue:10`) and the server only keeps `image/jpeg`, `image/gif` and `image/png` (`lib/Service/CacheDocumentService.php`, `filterMimeTypes()`). No video, audio or document attachments.
+- **No link previews** and no custom emoji: `/api/v1/custom_emojis` returns an empty list (`lib/Controller/ApiController.php`, `customEmojis()`).
+- **No status translation.** The `translate` action returns the post unchanged (`lib/Service/ActionService.php`).
+- **`lib/Controller/MediaApiController.php` is a stub.** Its `uploadMedia()` returns a hard-coded empty response and it is not wired to any route; real uploads go through `Api#mediaNew` (`POST /api/v1/media`) in `lib/Controller/ApiController.php`.
 
 ## 📦 Quickstart (install & develop)
 
 1. Clone this repository into your Nextcloud `apps/` directory.
-2. Follow the setup and dependency steps in [DEPLOYMENT.md](DEPLOYMENT.md).
-3. Rebuild frontend assets after UI changes:
+2. Install the dependencies and build the frontend:
 
 ```bash
 cd /var/www/nextcloud/apps/social
-./build-package.sh    # produces build/artifacts/social.tar.gz
+composer install     # PHP dependencies
+npm ci
+npm run build        # production bundle into js/
 ```
 
-4. Enable the app in Nextcloud and test using a local account.
+3. Enable the app in Nextcloud (`occ app:enable social`) and check the install with
+   `occ social:check:install`.
+4. While working on the UI, use `npm run dev` for a development build or
+   `npm run watch` to rebuild on change. The `Makefile` wraps the same scripts
+   (`make build-js`, `make build-js-production`, `make watch-js`, `make lint`).
+5. To produce a release archive, run `./build-package.sh`. It runs
+   `composer install --no-dev`, `npm run build`, copies the app without the dev
+   files and writes `build/artifacts/social.tar.gz`. `make appstore` builds the same
+   archive through the Makefile; despite the `sign_dir` name it only stages and tars,
+   it does not sign anything.
 
 ## 🖼️ Banner / Header upload — Troubleshooting
 
-Banner/header uploads are supported and stored on the server, and should be referenced from the local actor/account cache.
+Banner/header uploads work: the image is stored in the app's document cache, the
+local actor's cached `header` is updated, and the change is federated as an actor
+`Update` (`lib/Controller/LocalController.php`, `uploadBanner()`). A banner can also
+be set from a URL. Only JPEG, GIF and PNG survive the mime filter.
 
 If an uploaded banner does not appear immediately:
 
-- Reload the profile page (clear browser cache if necessary).
-- Verify the uploaded file exists in Nextcloud's file storage.
-- Check server logs for upload or permission errors.
-- Re-fetch the account data or sign out/sign in to refresh the local cache.
+- Reload the profile page (clear the browser cache if necessary).
+- Check the server log for `[LocalController] uploadBanner failed` and for
+  `Failed to federate banner change`, which is only a warning and does not undo the
+  local upload.
+- Re-fetch the account data, or run `occ social:cache:refresh`, to refresh the cached
+  actor.
 
 ## ✅ Tests
 
@@ -63,12 +95,17 @@ reaches the container statically finds a `TestContainer` behind `\OC::$server`
 
 ## 🛠️ Contributing
 
-- Contributions welcome — open a pull request and run the build/tests locally before merging.
+- Contributions welcome — open a pull request and run the build and tests locally
+  first (`npm run lint`, `npm test`, `composer run test:unit`).
 - Reset local Social data for development with:
 
 ```bash
 occ social:reset
 ```
+
+  This prompts twice and then empties every Social table. `occ social:reset
+  --uninstall` additionally drops the tables, migrations, background jobs and app
+  config. See [docs/OCC-Commands.md](docs/OCC-Commands.md) for all commands.
 
 ## License
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,15 +10,16 @@
 	<summary>Nextcloud becomes part of the federated social networks</summary>
 	<description><![CDATA[Nextcloud Social connects your Nextcloud account to the Fediverse through the ActivityPub standard.
 
-Features:
-- 🧭 Timelines: browse the public, local, and home timelines
-- ✍️ Posts: create posts, replies, and mentions
-- ✏️ Edit posts: update local posts and federate them as ActivityPub `Update` activities
-- 👍 🔁 💬 Actions: like, boost, and reply
-- 🌐 Federation: send and receive ActivityPub activities
-- 👥 Following: discover and follow remote accounts
+What it does:
+- 🧭 Timelines: home, local, global (federated), direct messages, liked posts, notifications, hashtags
+- ✍️ Posts: write posts and replies with a visibility setting, mentions, hashtags and image attachments
+- ✏️ Edit and delete your own posts; edits are federated as ActivityPub Update activities
+- 👍 🔁 💬 Like, boost and reply
+- 👥 Follow and unfollow local and remote accounts; incoming follows are accepted automatically
+- 🔎 Find accounts and hashtags via WebFinger and search
+- 🌐 Federation: signed delivery of ActivityPub activities, with a delivery queue processed by cron
 
-This release restores the core social features and improves interoperability with the Fediverse.]]></description>
+This is a partial implementation of ActivityPub and of the Mastodon client API. It does not offer blocking, muting or reporting, approvable follow requests, polls, bookmarks, lists, or video and audio attachments.]]></description>
 	<version>0.10.1</version>
 	<licence>agpl</licence>
 	<author mail="benedikt.schaechner@web.de" homepage="https://benedikt.xn--schchner-2za.de">Benedikt Schächner</author>

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "nextcloud/social",
 	"description": "Social app",
 	"license": "AGPL-3.0-or-later",
-	"version": "0.10.0",
+	"version": "0.10.1",
 	"minimum-stability": "stable",
 	"authors": [
 		{

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,278 +1,298 @@
 # Nextcloud Social API Reference
 
+> This document is written by hand but mechanically checked: `tests/DocumentationTest.php` asserts that the set of routes documented here matches `appinfo/routes.php` (78 route entries). Every route below appears in a table row with its URL exactly as written in `appinfo/routes.php`. Paths that are *not* routes of this app (the `.well-known` discovery documents handled by the Nextcloud WellKnown API) are deliberately written without code spans so that check stays exact.
+
 ## Overview
 
-The Social app provides three categories of APIs:
+The Social app exposes four groups of endpoints, all registered in `appinfo/routes.php`:
 
-- **Mastodon-compatible REST API** under `/api/v1/` — designed to be compatible with the Mastodon client API specification
-- **Custom Local API** under `/api/v1/` and `/local/v1/` — app-specific endpoints for the Vue frontend
-- **ActivityPub Federation API** under `/users/`, `/@{username}/`, and `/inbox` — W3C ActivityPub protocol endpoints
+- **Mastodon-compatible REST API** (`ApiController`, `OAuthController`) — a partial implementation of the Mastodon client API. Several endpoints are stubs; each is marked below.
+- **Custom Local API** (`LocalController`, `ConfigController`) — the endpoints the app's own Vue frontend calls. They are not Mastodon-compatible and their response envelope differs (see Error Responses).
+- **ActivityPub Federation API** (`ActivityPubController`, `SocialPubController`) — server-to-server ActivityPub, plus the HTML profile/post pages served on the same URLs.
+- **Frontend, document, OStatus and queue endpoints** (`NavigationController`, `OStatusController`, `QueueController`) — HTML pages and internal plumbing.
 
-Base URL: `/apps/social` (e.g. `https://cloud.example/apps/social/api/v1/statuses`)
+All URLs are relative to the app's route base, i.e. index.php/apps/social + the URL from the route table (for example, index.php/apps/social/api/v1/statuses).
 
 ---
 
 ## Authentication
 
-The API supports two authentication methods:
+Two mechanisms exist, and which one applies depends on the controller:
 
-1. **OAuth Bearer Token** — obtained via the OAuth flow (see OAuth section below). Include as `Authorization: Bearer <token>` header.
-2. **Session-based** — uses the Nextcloud session cookie when the user is logged in to the web UI.
+1. **OAuth Bearer token** — only `ApiController` reads it. Its constructor parses the `Authorization` header, accepts a `bearer` auth type, and resolves the token through `ClientService::getFromToken()`. If no bearer token is present it falls back to the logged-in Nextcloud session user.
+2. **Nextcloud session** — `LocalController`, `ConfigController`, `NavigationController`, `OAuthController` (authorize/authorizing) and `OStatusController` use the session `userId` only. They do **not** honour bearer tokens, so the Custom Local API is effectively usable only from the app's own frontend (or with a Nextcloud session cookie / app password + `OCS-APIRequest`).
 
-Public endpoints (ActivityPub, media serving) do not require authentication.
+Access control is declared with **PHPDoc annotations, not PHP attributes** — the controllers contain no `#[PublicPage]`, `#[NoCSRFRequired]` or `#[NoAdminRequired]` attributes at all, only `@PublicPage`, `@NoCSRFRequired`, `@NoAdminRequired` docblocks. No endpoint uses `@BruteForceProtection`. The "Auth" column in the tables below records these annotations:
+
+- `public` — `@PublicPage`: reachable without a Nextcloud login (an endpoint may still fail later if it needs a viewer).
+- `user` — `@NoAdminRequired`: any logged-in user.
+- `admin` — no annotation at all: Nextcloud requires an admin session.
+- `no-csrf` — `@NoCSRFRequired`: no CSRF token needed, which matters for non-browser clients.
+
+Note that many `ApiController` endpoints are annotated `@PublicPage` but call `initViewer(true)` internally, which throws when there is neither a session nor a valid bearer token; those return HTTP 401 with `{"error": "the access_token was revoked"}`.
 
 ---
 
 ## Mastodon-compatible API
 
-### Instance
+### Instance and app metadata
 
-| Method | Route | Description |
-|--------|-------|-------------|
-| GET | `/api/v1/instance/` | Returns local instance metadata (title, version, usage stats, registration) |
-| GET | `/api/v1/apps/verify_credentials` | Returns connected app name and website |
-| GET | `/api/v1/custom_emojis` | Returns custom emoji list (currently empty, not implemented) |
+| Method | Route | Auth | Parameters | Description |
+|--------|-------|------|------------|-------------|
+| GET | `/api/v1/instance/` | public, no-csrf | — | Local instance metadata from `InstanceService::getLocal()` (title, version, usage, registrations). Returned as-is, not wrapped. |
+| GET | `/api/v1/apps/verify_credentials` | public, no-csrf | — | `{"name", "website"}` of the client behind the bearer token; falls back to `{"name": "Nextcloud Social", "website": "https://github.com/nextcloud/social/"}` when no client is identified. |
+| GET | `/api/v1/custom_emojis` | public, no-csrf | — | **Not implemented.** Always returns an empty array `[]` with HTTP 200. |
+| GET | `/api/saved_searches/list.json` | public, no-csrf | — | **Not implemented.** Initialises the viewer, then always returns `[]`. |
+| GET | `/.well-known/nodeinfo/2.0` | public, no-csrf | — | NodeInfo 2.0 document: `version`, `software.name` (instance title), `software.version`, `protocols: ["activitypub"]`, `rootUrl`, `usage`, `openRegistrations`. Falls back to name `Nextcloud Social` and the installed app version if no local instance row exists. |
 
 ### Accounts
 
-| Method | Route | Parameters | Description |
-|--------|-------|------------|-------------|
-| GET | `/api/v1/accounts/verify_credentials` | — | Returns the authenticated user's account |
-| GET | `/api/v1/accounts/relationships` | `id[]` (account IDs) | Returns relationship info (following, followed_by, etc.) |
-| GET | `/api/v1/accounts/{account}/statuses` | `limit`, `max_id`, `min_id`, `since_id` | Returns statuses by a specific account |
-| GET | `/api/v1/accounts/{account}/following` | `limit`, `max_id`, `min_id` | Returns who an account is following |
-| GET | `/api/v1/accounts/{account}/followers` | `limit`, `max_id`, `min_id` | Returns an account's followers |
+| Method | Route | Auth | Parameters | Description |
+|--------|-------|------|------------|-------------|
+| GET | `/api/v1/accounts/verify_credentials` | public, no-csrf | — | The viewer's `Person` actor serialised in local format. 401 `{"error": ...}` when unauthenticated. |
+| GET | `/api/v1/accounts/relationships` | public, no-csrf | `id` (array, required) | Relationship entries from `FollowService::getRelationships()`. Sent as `id[]=…` on the wire. |
+| GET | `/api/v1/accounts/{account}/statuses` | public, no-csrf | `limit` (20), `max_id` (0), `min_id` (0), `since_id` (0) | Statuses of `{account}`; syncs the remote timeline first. `{account}` accepts slashes (`requirements: .+`). |
+| GET | `/api/v1/accounts/{account}/followers` | public, no-csrf | `limit` (20), `max_id` (0), `min_id` (0), `since` (0) | Followers of `{account}`. For a remote domain the actor's `followers` collection is fetched over HTTP and up to `limit` actors are returned; otherwise the local cache is probed. Note the fourth parameter is `since`, not `since_id`. |
+| GET | `/api/v1/accounts/{account}/following` | public, no-csrf | `limit` (20), `max_id` (0), `min_id` (0), `since` (0) | Same as above for the `following` collection. |
 
 ### Statuses
 
-| Method | Route | Parameters | Description |
-|--------|-------|------------|-------------|
-| POST | `/api/v1/statuses` | `status`, `visibility`, `media_ids[]`, `in_reply_to_id`, `spoiler_text`, `sensitive` | Create a new post |
-| GET | `/api/v1/statuses/{nid}` | — | Get a single status by NID |
-| PUT | `/api/v1/statuses/{nid}` | `status`, `spoiler_text`, `sensitive` | Edit an existing post |
-| GET | `/api/v1/statuses/{nid}/context` | — | Get conversation context (ancestors and descendants) |
-| POST | `/api/v1/statuses/{nid}/{act}` | `act`: `favourite`, `unfavourite`, `boost`, `unboost` | Perform an action on a status |
+| Method | Route | Auth | Parameters | Description |
+|--------|-------|------|------------|-------------|
+| POST | `/api/v1/statuses` | public, no-csrf | Body (JSON or form-encoded): `status`, `visibility`, `media_ids` (array), `in_reply_to_id`, `spoiler_text`, `sensitive`, `content_type` | Creates a post. The body is read from `php://input` and parsed by `Content-Type`. Only `status`, `visibility`, `media_ids` and `in_reply_to_id` affect the created post — `spoiler_text`, `sensitive` and `content_type` are parsed but ignored here. `visibility` maps to the stream type (`public`, `unlisted`, `followers`, `direct`). Returns the new status; errors return HTTP 400 `{"error": "..."}`. |
+| GET | `/api/v1/statuses/{nid}` | public, no-csrf | — | One status by numeric id, local export format. |
+| PUT | `/api/v1/statuses/{nid}` | public, no-csrf | Body: `status`, `spoiler_text`, `sensitive` | Edits an own post via `PostService::editPost()`. An empty `spoiler_text` is sent as `null`. Errors return HTTP 400 `{"error": "..."}`. |
+| GET | `/api/v1/statuses/{nid}/context` | public, no-csrf | — | Ancestors/descendants of the status. |
+| POST | `/api/v1/statuses/{nid}/{act}` | public, no-csrf | `act` (path) | Performs an action on a status — see the action table below. |
 
-### Timelines
+`{act}` is validated against `ActionService::$availableStatusAction`. Accepted values are `translate`, `favourite`, `unfavourite`, `reblog`, `unreblog`, `bookmark`, `unbookmark`, `mute`, `unmute`, `pin`, `unpin`; anything else throws `InvalidActionException`. Only five of them do anything:
 
-| Method | Route | Parameters | Description |
-|--------|-------|------------|-------------|
-| GET | `/api/v1/timelines/{timeline}/` | `local`, `limit` (20), `max_id`, `min_id`, `since_id` | Get a timeline. `timeline` values: `home`, `account`, `public`, `direct`, `favourites` |
-| GET | `/api/v1/timelines/tag/{hashtag}` | `limit` (20), `max_id`, `min_id`, `since_id`, `local`, `only_media` | Get posts with a specific hashtag |
-| GET | `/api/v1/favourites/` | `limit` (20), `max_id`, `min_id`, `since_id` | Get liked/favourited posts |
+| `act` value | Effect |
+|-------------|--------|
+| `favourite`, `unfavourite` | Creates/deletes a Like (`LikeService`). |
+| `reblog`, `unreblog` | Creates/deletes an Announce (`BoostService`). The Mastodon-ish names `boost` and `unboost` are **not** accepted. |
+| `translate` | Returns the status unchanged (translation is a TODO). |
+| `bookmark`, `unbookmark`, `mute`, `unmute`, `pin`, `unpin` | Accepted by the validator but **not implemented** — no branch in the switch, so the request succeeds and returns the unchanged status without doing anything. |
 
-### Notifications
+The response is always the status itself in local format (for the no-op actions, the unmodified status).
 
-| Method | Route | Parameters | Description |
-|--------|-------|------------|-------------|
-| GET | `/api/v1/notifications` | `limit` (20), `max_id`, `min_id`, `since_id`, `types[]`, `exclude_types[]`, `accountId` | Get notifications for the viewer |
+### Timelines and notifications
+
+| Method | Route | Auth | Parameters | Description |
+|--------|-------|------|------------|-------------|
+| GET | `/api/v1/timelines/{timeline}/` | public, no-csrf | `local` (false), `limit` (20), `max_id` (0), `min_id` (0), `since_id` (0) | `{timeline}` must be one of `home`, `account`, `public`, `direct`, `favourites` (case-insensitive); anything else raises `UnknownProbeException` → 401 `{"error": "unknown timeline"}`. |
+| GET | `/api/v1/timelines/tag/{hashtag}` | public, no-csrf | `limit` (20), `max_id` (0), `min_id` (0), `since_id` (0), `local` (false), `only_media` (false) | Posts carrying `{hashtag}`. |
+| GET | `/api/v1/favourites/` | public, no-csrf | `limit` (20), `max_id` (0), `min_id` (0), `since_id` (0) | The viewer's favourited posts. |
+| GET | `/api/v1/notifications` | public, no-csrf | `limit` (20), `max_id` (0), `min_id` (0), `since_id` (0), `types` (array), `exclude_types` (array), `accountId` (string) | Notification stream for the viewer. |
+
+All four return a bare JSON array of statuses (no envelope, no `Link` header).
 
 ### Media
 
-| Method | Route | Parameters | Description |
-|--------|-------|------------|-------------|
-| POST | `/api/v1/media` | `file` (multipart upload) | Upload a media attachment |
-| GET | `/api/v1/media/{nid}` | `preview` (optional) | Get media metadata by NID (stub, not fully implemented) |
-| GET | `/media/{uuid}` | — | Serve a media file by UUID (supports optional `.ext` suffix) |
+| Method | Route | Auth | Parameters | Description |
+|--------|-------|------|------------|-------------|
+| POST | `/api/v1/media` | public, no-csrf | `file` (multipart, read from `$_FILES['file']`) | Uploads an attachment, caches it and returns the `MediaAttachment`. No mime-type or size restriction is applied. Failure returns HTTP 400 `{"error": "..."}`. |
+| GET | `/api/v1/media/{nid}` | public, no-csrf | `nid` (path), `preview` (default `''`) | **Stub.** The body ignores both parameters and returns an empty array `[]` with HTTP 200. |
+| GET | `/media/{uuid}` | public, no-csrf | `uuid` (path, may carry a `.ext` suffix) | Streams a cached document by UUID. The `Content-Type` is derived naively from the extension as `image/<ext>` (empty when there is no suffix). 404 when unknown. |
 
-### Search
+`MediaApiController::uploadMedia()` also exists and is a stub returning `{"id": 1, "url": "", "preview_url": "", "remote_url": null, "description": ""}`, and its `IMAGE_MIME_TYPES` allowlist is never used. **It has no route** — no entry in `appinfo/routes.php` maps to `MediaApi#…`, so it is unreachable dead code. `POST /api/v1/media` is served by `ApiController::mediaNew()`.
 
-| Method | Route | Parameters | Description |
-|--------|-------|------------|-------------|
-| GET | `/api/v1/search` | `search` (query string) | Unified search across accounts, hashtags, and post content |
-| GET | `/api/v1/global/accounts/search` | `search` | Search cached accounts by name/identifier |
-| GET | `/api/v1/global/tags/search` | `search` | Search hashtags |
+### Search (Mastodon-adjacent, app-specific shapes)
+
+| Method | Route | Auth | Parameters | Description |
+|--------|-------|------|------------|-------------|
+| GET | `/api/v1/search` | user, no-csrf | `search` (required) | `{"result": {"accounts": [...], "hashtags": [...], "content": [...]}, "status": 1}`. Not the shape of the Mastodon v2 search endpoint. |
+| GET | `/api/v1/global/accounts/search` | user | `search` (required) | `{"result": {"accounts": [...], "exact": <actor or null>}, "status": 1}`. A leading `@` is stripped; an empty query returns empty lists. |
+| GET | `/api/v1/global/tags/search` | user | `search` (required) | `{"result": {"tags": [...], "exact": <tag or null>}, "status": 1}`. A leading `#` is stripped. |
 
 ### Pagination
 
-Endpoints that return lists support cursor-based pagination via these query parameters:
-
-- `limit` — maximum number of items to return (default: 20)
-- `max_id` — return items older than this ID
-- `min_id` — return items newer than this ID
-- `since_id` — return items created after this ID
-- `since` — return items published after this Unix timestamp
+`ApiController` list endpoints accept the cursor parameters shown per route above (`limit`, `max_id`, `min_id`, and either `since_id` or `since`), all integers defaulting to `0` except `limit` (20). `LocalController` stream endpoints use a different pair: `since` (a numeric cursor, default `0`) and `limit` (default **5**, not 20).
 
 ---
 
 ## Custom Local API
 
+These endpoints exist to serve the app's own Vue frontend. They are session-authenticated only, mostly wrap their payload in the `{"result": …, "status": 1}` envelope, and are not part of any Mastodon client contract.
+
 ### Streams
 
-| Method | Route | Parameters | Description |
-|--------|-------|------------|-------------|
-| GET | `/api/v1/stream/home` | `since`, `limit` | Home timeline (posts from followed accounts) |
-| GET | `/api/v1/stream/notifications` | `since`, `limit` | User notifications |
-| GET | `/api/v1/stream/timeline` | `since`, `limit` | Local timeline (all local public posts) |
-| GET | `/api/v1/stream/federated` | `since`, `limit` | Global/federated timeline |
-| GET | `/api/v1/stream/direct` | `since`, `limit` | Direct messages |
-| GET | `/api/v1/stream/liked` | `since`, `limit` | Liked posts |
-| GET | `/api/v1/stream/tag/{hashtag}/` | `since`, `limit` | Posts by hashtag |
-| GET | `/api/v1/account/{username}/stream` | `since`, `limit` | Posts by a specific account |
+All eight take `since` (int, 0) and `limit` (int, 5) and return `{"result": [statuses], "status": 1}`.
+
+| Method | Route | Auth | Description |
+|--------|-------|------|-------------|
+| GET | `/api/v1/stream/home` | user, no-csrf | Posts from accounts the viewer follows. |
+| GET | `/api/v1/stream/notifications` | user, no-csrf | Notification stream. |
+| GET | `/api/v1/stream/timeline` | user, no-csrf | Local timeline. |
+| GET | `/api/v1/stream/federated` | user | Global/federated timeline. |
+| GET | `/api/v1/stream/direct` | user, no-csrf | Direct messages. |
+| GET | `/api/v1/stream/liked` | user | Posts the viewer liked. |
+| GET | `/api/v1/stream/tag/{hashtag}/` | user | Local posts for `{hashtag}`. |
+| GET | `/api/v1/account/{username}/stream` | user, public | Posts of `{username}` (remote timeline synced first). `{username}` accepts slashes (`requirements: .+`). |
 
 ### Posts
 
-| Method | Route | Parameters | Description |
-|--------|-------|------------|-------------|
-| GET | `/local/v1/post` | `id` (ActivityPub ID) | Get a single post by its ActivityPub ID |
-| GET | `/local/v1/post/replies` | `id`, `since`, `limit` | Get replies to a post |
-| POST | `/api/v1/post` | `content`, `to[]`, `type`, `replyTo`, `attachments`, `hashtags[]` | Create a new post |
-| DELETE | `/api/v1/post` | `id` | Delete own post |
-| POST | `/api/v1/post/like` | `postId` | Like a post |
-| DELETE | `/api/v1/post/like` | `postId` | Unlike a post |
+| Method | Route | Auth | Parameters | Description |
+|--------|-------|------|------------|-------------|
+| GET | `/local/v1/post` | user, public, no-csrf | `id` (required, ActivityPub id) | One post, returned **unwrapped** (`directSuccess()`). |
+| GET | `/local/v1/post/replies` | user, no-csrf | `id` (required), `since` (0), `limit` (5) | Replies to a post, wrapped in `result`. |
+| POST | `/api/v1/post` | user | `content` (`''`), `to` (array), `type` (default `public`), `replyTo` (`''`), `attachments` (mixed, default `[]`), `hashtags` (array) | Creates a post. Returns `{"result": {"post": <object>, "token": "<request token>"}, "status": 1}`. |
+| DELETE | `/api/v1/post` | user | `id` (required) | Deletes an own post; `{"result": [], "status": 1}`. Rejects posts not attributed to the caller. |
+| POST | `/api/v1/post/like` | user | `postId` (required) | Likes a post; `{"result": {"like": <activity>, "token": "…"}, "status": 1}`. |
+| DELETE | `/api/v1/post/like` | user | `postId` (required) | Removes the like; same shape. |
 
-### Current User
+`LocalController::postBoost()`, `postUnboost()`, `uploadAttachement()` and `documentsCache()` exist in the controller but have **no routes**; boosting from a client goes through `POST /api/v1/statuses/{nid}/{act}` with `reblog`. `uploadAttachement()` unconditionally throws `BadMethodCallException('uploadAttachment is not implemented yet')`.
 
-| Method | Route | Description |
-|--------|-------|-------------|
-| GET | `/api/v1/current/info` | Get current user's actor info with complete details |
-| GET | `/api/v1/current/followers` | Get current user's followers |
-| GET | `/api/v1/current/following` | Get who the current user follows |
-| PUT | `/api/v1/current/follow` | Follow an account (`?account=`) |
-| DELETE | `/api/v1/current/follow` | Unfollow an account (`?account=`) |
+### Current user
 
-### Account Info
+| Method | Route | Auth | Parameters | Description |
+|--------|-------|------|------------|-------------|
+| GET | `/api/v1/current/info` | user | — | `{"result": {"account": <Person>}, "status": 1}`; refreshes the local actor cache first. |
+| GET | `/api/v1/current/followers` | user | — | `{"result": [actors], "status": 1}`. |
+| GET | `/api/v1/current/following` | user | — | `{"result": [actors], "status": 1}`. |
+| PUT | `/api/v1/current/follow` | user | `account` (required) | Follows an account; `{"result": [], "status": 1}`. |
+| DELETE | `/api/v1/current/follow` | user | `account` (required) | Unfollows an account; `{"result": [], "status": 1}`. |
 
-| Method | Route | Parameters | Description |
-|--------|-------|------------|-------------|
-| GET | `/api/v1/account/{username}/info` | — | Get info for a local account (with cache fallback) |
-| GET | `/api/v1/global/account/info` | `account` (e.g. `@user@domain`) | Get info for any local or remote account |
-| GET | `/api/v1/global/actor/info` | `id` (ActivityPub actor ID) | Get actor info by raw ActivityPub ID |
-| GET | `/api/v1/global/actor/avatar` | `id` | Serve an actor's avatar image |
-| GET | `/api/v1/global/actor/header` | `id` | Redirect to an actor's banner/header image |
+### Account info
+
+| Method | Route | Auth | Parameters | Description |
+|--------|-------|------|------------|-------------|
+| GET | `/api/v1/account/{username}/info` | user, public | — | Local account with complete details, returned **unwrapped** as a `Person`; rebuilds the actor cache if it is missing. |
+| GET | `/api/v1/global/account/info` | user, public | `account` (required, e.g. `user` or `user@domain`) | Local or remote account, returned **unwrapped**. A leading `@` is stripped; local actors are created/cached on demand, remote ones get follower/following/post counts fetched. |
+| GET | `/api/v1/global/actor/info` | user, public | `id` (required, ActivityPub actor id) | `{"result": {"actor": <Person>}, "status": 1}`. |
+| GET | `/api/v1/global/actor/avatar` | user, public, no-csrf | `id` (required) | Streams the cached avatar with a 24 h cache header; 404 (envelope shape) when the actor has no icon. |
+| GET | `/api/v1/global/actor/header` | user, public, no-csrf | `id` (required) | HTTP **redirect** to the actor's header URL, 24 h cache; 404 when unset. |
+
+Two more methods, `LocalController::accountFollowers()` and `accountFollowing()`, have no routes — the followers/following lists of an arbitrary account are only reachable through the Mastodon-compatible `/api/v1/accounts/{account}/followers` and `/api/v1/accounts/{account}/following`.
 
 ### Banner
 
-| Method | Route | Parameters | Description |
-|--------|-------|------------|-------------|
-| POST | `/api/v1/banner` | `file` (multipart) | Upload a profile banner image |
-| POST | `/api/v1/banner/url` | `url` | Download and set a profile banner from a URL |
+| Method | Route | Auth | Parameters | Description |
+|--------|-------|------|------------|-------------|
+| POST | `/api/v1/banner` | user, no-csrf | `file` (multipart, `$_FILES['file']`) | Stores the upload as the current user's header image, updates the actor cache and federates an Update. Returns `{"result": {"url", "id"}, "status": 1}`. |
+| POST | `/api/v1/banner/url` | user, no-csrf | `url` (string, default `''`, required in practice) | Downloads the image at the given `url` with cURL (follows up to 5 redirects, 30 s timeout, user agent `Nextcloud-Social/0.10`) and stores it as the current user's header image. Same response shape. An empty `url`, or a non-2xx response, fails. |
 
-### Config
+### Config and system
 
-| Method | Route | Parameters | Description |
-|--------|-------|------------|-------------|
-| POST | `/api/v1/config/cloudAddress` | `cloudAddress` | Set the cloud base URL in app config |
-
-### System
-
-| Method | Route | Description |
-|--------|-------|-------------|
-| GET | `/local/` | Get app version and setup status |
-| GET | `/test/{account}/` | Run a WebFinger test against an account (debug only, requires `social.tests` system config) |
+| Method | Route | Auth | Parameters | Description |
+|--------|-------|------|------------|-------------|
+| POST | `/api/v1/config/cloudAddress` | admin | `cloudAddress` (required) | Sets the app's cloud base URL. Returns a bare `[]`. |
+| GET | `/local/` | public, no-csrf | — | `{"result": {"version": "<installed_version>", "setup": <bool>}, "status": 1}`. |
+| GET | `/test/{account}/` | public, no-csrf | `account` (path) | WebFinger self-test. Only active when the `social.tests` system value is set — otherwise it returns exactly the same payload as `/local/`. On failure it returns the error envelope with HTTP **200** and a `result` key holding the test data. |
 
 ---
 
 ## OAuth
 
-The Social app implements a Mastodon-compatible OAuth flow.
+A partial, Mastodon-shaped OAuth 2 flow (`OAuthController`, `ClientService`).
 
-| Method | Route | Parameters | Description |
-|--------|-------|------------|-------------|
-| POST | `/api/v1/apps` | `client_name`, `redirect_uris`, `website`, `scopes` | Register a new OAuth client app |
-| GET | `/oauth/authorize` | `client_id`, `redirect_uri`, `response_type`, `scope` | Show OAuth authorization page |
-| POST | `/oauth/authorize` | `client_id`, `redirect_uri`, `response_type`, `scope` | Confirm OAuth authorization |
-| POST | `/oauth/token` | `client_id`, `client_secret`, `redirect_uri`, `grant_type`, `code` | Exchange authorization code for bearer token |
+| Method | Route | Auth | Parameters | Description |
+|--------|-------|------|------------|-------------|
+| POST | `/api/v1/apps` | public, no-csrf | `client_name` (`''`), `redirect_uris` (string or array, `''`), `website` (`''`), `scopes` (`'read'`) | Registers a client. Returns `{"id", "name", "website", "scopes", "client_id", "client_secret"}`. A non-array `redirect_uris` is wrapped into a one-element array (handling a real array from the request is a TODO). |
+| GET | `/oauth/authorize` | user, no-csrf | `client_id`, `redirect_uri`, `response_type`, `scope` (`'read'`) | Renders the `oauth2` consent template. `response_type` must be `code`, else `ClientNotFoundException`. |
+| POST | `/oauth/authorize` | user | `client_id`, `redirect_uri`, `response_type`, `scope` (`'read'`) | Confirms authorization. Unless `redirect_uri` is `urn:ietf:wg:oauth:2.0:oob` it emits a `Location: <redirect_uri>?code=<code>` header and exits; for the out-of-band URI it returns `{"code": "<code>"}`. Errors: HTTP 400 `{"error": "..."}`. |
+| POST | `/oauth/token` | public, user, no-csrf | `client_id`, `client_secret`, `redirect_uri`, `grant_type`, `scope` (`'read'`), `code` (`''`) | Exchanges the code for a token: `{"access_token", "token_type": "Bearer", "scope", "created_at"}`. Errors are HTTP 400/401 `{"error": "..."}`. |
 
-**Grant types:** `authorization_code`, `client_credentials`
+**Grant types:** only `authorization_code` works. `client_credentials` is accepted by the `grant_type` check but its branch is an empty TODO, so no token is generated and the request fails with HTTP 400 `{"error": "issue generating access_token"}`. Any other value returns HTTP 400 `{"error": "invalid value for grant_type"}`.
 
-**Default scope:** `read`
+**Scopes:** there is no fixed scope vocabulary. `SocialClient::getScopesFromString()` simply splits the string on spaces, and `ClientService::confirmData()` only checks that requested scopes are a subset of the ones stored at registration. The default everywhere is `read`. Scopes are not enforced per endpoint.
+
+**Token lifetime:** `ClientService::TIME_TOKEN_TTL` is 30672000 s (~1 year), refresh window `TIME_TOKEN_REFRESH` 300 s.
 
 ---
 
 ## ActivityPub Federation
 
-The app implements the W3C ActivityPub protocol (Server-to-Server). All endpoints return `application/activity+json` content type for ActivityPub clients, and fall back to HTML for browsers.
+`ActivityPubController` decides per request, via `checkSourceActivityStreams()`, whether the caller is a Fediverse server: it splits the `Accept` header on commas, trims each entry at the first `;`, and returns true if any entry equals `application/ld+json` or `application/activity+json`. Anything else (a browser) is treated as HTML.
 
-### Actor
+JSON-LD responses are emitted through `activityPubSuccess()`, i.e. `Content-Type: application/ld+json; profile="https://www.w3.org/ns/activitystreams"`. The controller also registers `activity+json` and `ld+json; …` responders for format-based negotiation.
 
-| Method | Route | Description |
-|--------|-------|-------------|
-| GET | `/users/{username}` | Get ActivityPub Actor object for a local user |
-| GET | `/@{username}/` | Alias for actor endpoint |
+| Method | Route | Auth | Content negotiation | Description |
+|--------|-------|------|--------------------|-------------|
+| GET | `/users/{username}` | public, no-csrf | JSON-LD for AP `Accept`, else HTML | Actor object (with W3C security context). Unknown actor → error envelope with HTTP 404. Without an AP `Accept` header it delegates to `SocialPubController::actor()`, which renders the public Vue page (`PublicTemplateResponse`, HTTP 404 if the actor is uncached). |
+| GET | `/@{username}/` | public, no-csrf | same as above | Alias that calls `actor()`. |
+| POST | `/@{username}/inbox` | public, no-csrf | JSON | Per-user inbox. Verifies the HTTP signature, checks the Fediverse allow/blocklist, requires the local actor to exist, imports the activity, then async-processes the stream cache queue. Returns `{"result": [], "status": 1}`; a gone signature also returns success. |
+| GET | `/@{username}/inbox` | public, no-csrf | JSON-LD | Empty `OrderedCollection` (`totalItems: 0`) for the actor's inbox; bare `[]` with HTTP 404 if the actor is unknown. |
+| POST | `/inbox` | public, no-csrf | JSON | Shared inbox, same processing without the per-actor check. |
+| GET | `/@{username}/outbox` | public, no-csrf | always JSON-LD | Outbox collection. The HTML fallback is commented out in the source, so browsers get JSON-LD too. |
+| POST | `/@{username}/outbox` | public, no-csrf | always JSON-LD | Same route handler as the GET (`ActivityPub#outbox`); posting an activity is **not** implemented — the method only returns the outbox collection. |
+| GET | `/@{username}/followers` | public, no-csrf | JSON-LD for AP `Accept`, else HTML | Followers collection, or the public Vue page. |
+| GET | `/@{username}/following` | public, no-csrf | JSON-LD for AP `Accept`, else HTML | Following collection, or the public Vue page. |
+| GET | `/@{username}/{token}` | public, no-csrf | JSON-LD for AP `Accept`, else HTML | Single post. `{token}` values `outbox`, `followers` and `following` (case-insensitive) are re-routed to those handlers first. For AP callers the `Stream` is returned as JSON-LD (HTTP 404 error envelope with a `stream` key when missing); for browsers the Vue page is rendered with the post pre-loaded into initial state. |
 
-### Inbox
+### Discovery documents (not app routes)
 
-| Method | Route | Description |
-|--------|-------|-------------|
-| POST | `/@{username}/inbox` | Receive ActivityPub activities for a specific user |
-| GET | `/@{username}/inbox` | Get an empty OrderedCollection (inbox is not enumerable) |
-| POST | `/inbox` | Shared inbox — receives activities for all local actors |
+WebFinger, NodeInfo discovery and host-meta are served by `lib/WellKnown/WebfingerHandler.php`, registered through `registerWellKnownHandler()` in `lib/AppInfo/Application.php` — they are Nextcloud-level paths (.well-known/webfinger, .well-known/nodeinfo, .well-known/host-meta), not entries in this app's route table. Only the NodeInfo 2.0 *document* itself is an app route (see `/.well-known/nodeinfo/2.0` above).
 
-### Outbox
+The handler first checks `FediverseService::jailed()` and passes the previous response through when the instance is not allowed to federate. For `webfinger` with a `resource` query parameter (`acct:` prefix stripped; the raw request URI is parsed as a fallback):
 
-| Method | Route | Description |
-|--------|-------|-------------|
-| GET | `/@{username}/outbox` | Get the user's outbox as an OrderedCollection |
-| POST | `/@{username}/outbox` | Create a new activity in the outbox |
+- The app's own subject gets an extra link added to the existing response, carrying `app`, `name` and `version` properties.
+- For a local actor it returns a JRD document whose `subject` is the requested resource, with aliases for the actor URL and the Nextcloud profile page, a `self` link of type `application/activity+json` pointing at the `/@{username}/` route, an `http://webfinger.net/rel/profile-page` link (`text/html`) to the Nextcloud profile page, and an `http://ostatus.org/schema/1.0/subscribe` link with a `template` of `<social url>ostatus/follow/?uri={uri}`.
+- Unknown or non-local subjects produce an empty JRD with HTTP 404 (or hand back to the previous handler when the actor lookup fails outright).
 
-### Followers / Following
-
-| Method | Route | Description |
-|--------|-------|-------------|
-| GET | `/@{username}/followers` | Get the followers collection |
-| GET | `/@{username}/following` | Get the following collection |
-
-### Posts
-
-| Method | Route | Description |
-|--------|-------|-------------|
-| GET | `/@{username}/{token}` | Get a single post as ActivityPub JSON-LD |
-
-### Discovery
-
-| Route | Description |
-|-------|-------------|
-| `/.well-known/webfinger` | WebFinger endpoint for `acct:user@domain` lookups (returns `self` link to Actor) |
-| `/.well-known/nodeinfo/2.0` | NodeInfo 2.0 document |
+The `nodeinfo` service returns a single link with rel `http://nodeinfo.diaspora.software/ns/schema/2.0` pointing at the app's `/.well-known/nodeinfo/2.0` route; `host-meta` returns XRD (`application/xrd+xml`) with an `lrdd` template pointing at the instance's WebFinger URL.
 
 ---
 
 ## Legacy OStatus
 
-| Method | Route | Description |
-|--------|-------|-------------|
-| GET | `/ostatus/follow/` | Renders follow page via OStatus (`?uri=`) |
-| GET | `/api/v1/ostatus/followRemote/{local}` | Render guest follow page for remote account |
-| GET | `/api/v1/ostatus/link/{local}/{account}` | Perform WebFinger and get OStatus subscribe link |
+| Method | Route | Auth | Parameters | Description |
+|--------|-------|------|------------|-------------|
+| GET | `/ostatus/follow/` | user, no-csrf | `uri` (required) | Resolves `uri` as an account, then as an actor id, and renders the Vue app with `account` and `currentUser` in initial state. Requires a logged-in user; failures return the error envelope. |
+| GET | `/api/v1/ostatus/followRemote/{local}` | public, user, no-csrf | — | Renders the Vue app with the **guest** layout, providing `local` and `account` in initial state, so a remote visitor can follow the local account `{local}`. |
+| GET | `/api/v1/ostatus/link/{local}/{account}` | public, user, no-csrf | — | WebFingers `{account}`, extracts its `http://ostatus.org/schema/1.0/subscribe` link template, substitutes `{uri}` with `{local}`'s account, and returns `{"result": {"url": "<subscribe url>"}, "status": 1}`. |
 
 ---
 
-## Frontend / Document Serving
+## Frontend / Document serving
 
-| Method | Route | Description |
-|--------|-------|-------------|
-| GET | `/` | Main SPA entry point (renders the Vue app) |
-| GET | `/timeline/{path}` | SPA timeline route |
-| GET | `/document/get` | Get a cached document by ID (requires auth) |
-| GET | `/document/public` | Get a public cached document by ID (no auth) |
-| GET | `/document/get/resized` | Get a resized/preview of a cached document (requires auth) |
-| GET | `/document/public/resized` | Get a public resized/preview document (no auth) |
+These serve HTML or files for the app's own UI; they are not client API endpoints.
+
+| Method | Route | Auth | Parameters | Description |
+|--------|-------|------|------------|-------------|
+| GET | `/` | user, no-csrf | `cloudAddress` (read from the request during first-run setup, admins only) | Renders the Vue app (`main` template) and provides `serverData` (`public`, `firstrun`, `setup`, `isAdmin`, `cliUrl`, `cloudAddress`, plus `checks` for admins). Creates the user's actor on first visit and tries to auto-configure the cloud address. |
+| GET | `/timeline/{path}` | user, no-csrf | `path` (default `''`, `requirements: .+`) | Same page; `path` is accepted and then ignored — the method just calls `navigate()`. |
+| GET | `/document/get` | user, no-csrf | `id` (required) | Streams a cached document with its stored mime type. Errors: error envelope, HTTP 500. |
+| GET | `/document/public` | public, no-csrf | `id` (required) | Same for documents marked public. |
+| GET | `/document/get/resized` | user, no-csrf | `id` (required) | Streams the resized/preview variant. |
+| GET | `/document/public/resized` | public, no-csrf | `id` (required) | Same for public documents. |
 
 ---
 
 ## Async Queue
 
-| Method | Route | Description |
-|--------|-------|-------------|
-| POST | `/async/request/{token}` | Process queued ActivityPub federation requests for a given token |
+| Method | Route | Auth | Parameters | Description |
+|--------|-------|------|------------|-------------|
+| POST | `/async/request/{token}` | public, no-csrf | `token` (path) | Internal endpoint the app calls against itself to deliver queued federation requests for `{token}`. It closes the connection (`async()`) and then processes each standby request with the async timeout. It writes **no response body** — the method ends in `exit()`. |
 
 ---
 
 ## Error Responses
 
-The API returns standard HTTP status codes:
+There is no single error format; three shapes exist.
 
-| Status | Meaning |
-|--------|---------|
-| 200 | Success |
-| 201 | Created |
-| 204 | No Content (deletion success) |
-| 400 | Bad Request |
-| 401 | Unauthorized |
-| 403 | Forbidden |
-| 404 | Not Found |
-| 405 | Method Not Allowed |
-| 500 | Internal Server Error |
+**1. `TNCDataResponse` envelope** (`LocalController`, `ConfigController`, `ActivityPubController`, `OStatusController`, `NavigationController` — everything using the trait):
 
-Error bodies are JSON: `{"message": "...", "code": ...}`
+```json
+{"result": {}, "status": 1}
+```
+
+on success (`success()`; `more` keys are merged in at the top level), and
+
+```json
+{"status": -1, "exception": "OCA\\Social\\Exceptions\\AccountDoesNotExistException", "message": "User not logged in"}
+```
+
+on failure (`fail()`). The HTTP status is whatever the caller passed — the default is **500**, callers also use 404, and `Config#remote` deliberately returns the failure envelope with HTTP 200. Failures are logged as warnings unless the caller disables it. Two related helpers bypass the envelope: `directSuccess()` returns the object as-is with HTTP 200, and `activityPubSuccess()` does the same while setting `Content-Type: application/ld+json; profile="https://www.w3.org/ns/activitystreams"`.
+
+**2. `ApiController` errors** — a bare object, never the envelope:
+
+```json
+{"error": "the access_token was revoked"}
+```
+
+with HTTP **401** from its private `error()` helper (used by most getters, including for the "unknown timeline" case), or HTTP **400** with the same shape from `statusNew()`, `statusUpdate()`, `mediaNew()` and `mediaGet()`. `mediaOpen()` uses HTTP 404 for a missing document.
+
+**3. `OAuthController` errors** — `{"error": "..."}` with HTTP 400 (bad grant type, missing code, token generation failure) or HTTP 401 (`unknown client_id`, other exceptions).
+
+Successful Mastodon-compatible responses are **not** wrapped: `ApiController` returns the object or array directly with HTTP 200. HTTP status codes in use across the app are 200, 302 (actor header redirect), 400, 401, 404 and 500; no endpoint returns 201 or 204.

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -7,8 +7,11 @@ Nextcloud Social is a federated social networking app built on the W3C ActivityP
 **App ID:** `social`  
 **Namespace:** `OCA\Social`  
 **License:** AGPL-3.0-or-later  
-**Minimum NC version:** 28  
-**Maximum NC version:** 34  
+**App version:** 0.10.1  
+**Supported Nextcloud versions:** 28 – 35  
+**Supported PHP versions:** 8.1 – 8.5  
+
+All of the above come from `appinfo/info.xml`.
 
 ---
 
@@ -16,204 +19,295 @@ Nextcloud Social is a federated social networking app built on the W3C ActivityP
 
 ```
 social/
-├── appinfo/                    # App metadata, routes, navigation, commands
+├── appinfo/
+│   ├── info.xml                # App metadata, dependencies, cron jobs, occ commands
+│   └── routes.php              # All HTTP routes
 ├── lib/
-│   ├── AP.php                  # ActivityPub type registry (factory)
+│   ├── AP.php                  # ActivityPub type registry (factory + interface lookup)
 │   ├── AppInfo/
 │   │   └── Application.php     # Bootstrap, integration registration
-│   ├── Command/                # 15 occ CLI commands
-│   ├── Controller/             # 10 API/UI controllers
+│   ├── Command/                # occ CLI commands (+ ExtendedBase, a shared abstract base)
+│   ├── Controller/             # HTTP entry points (ActivityPub, Mastodon-ish API, local API, OAuth, OStatus, navigation, queue, config)
 │   ├── Cron/                   # Background jobs (Cache, Queue)
 │   ├── Dashboard/              # Nextcloud Dashboard widgets
-│   ├── Db/                     # 34 database repository classes
+│   ├── Db/                     # Query-builder based repositories (`*Request` + `*RequestBuilder` pairs)
 │   ├── Exceptions/             # Custom exceptions
-│   ├── Interfaces/             # ActivityPub typed interfaces
-│   ├── Listeners/              # Event listeners (profile, user updates)
-│   ├── Migration/              # Database schema migrations
+│   ├── Interfaces/             # Per-ActivityPub-type handlers (Activity/, Actor/, Object/, Internal/)
+│   ├── Listeners/              # Event listeners (ProfileSectionListener, UserAccountListener)
+│   ├── Migration/              # Database schema migrations + repair steps
 │   ├── Model/                  # ActivityPub model objects + support models
-│   ├── Notification/           # Nextcloud notification integration
+│   ├── Notification/           # Nextcloud notification integration (Notifier)
 │   ├── Providers/              # Contacts menu integration
 │   ├── Search/                 # Unified search integration
-│   ├── Service/                # 31 business logic services
-│   ├── WellKnown/              # WebFinger handler
-│   └── bootstrap.php           # Autoloader
-├── src/                        # Vue 3 frontend (SPA)
-│   ├── main.js                 # Entry point
-│   ├── App.vue                 # Root component
-│   ├── router.js               # 8 routes
-│   ├── store/                  # 5 Vuex modules
-│   ├── views/                  # 9 view components
-│   ├── components/             # 17+ UI components
-│   ├── services/               # JS services
-│   ├── mixins/                 # Vue mixins
-│   └── types/                  # JS type definitions
-├── templates/                  # PHP templates (main SPA, OAuth)
-├── l10n/                       # Translations (97 locales)
+│   ├── Service/                # Business logic services
+│   ├── Tools/                  # Vendored helper layer (query builder base, HTML sanitizer, traits, exceptions)
+│   ├── Traits/                 # TDetails
+│   └── WellKnown/              # WebFinger / NodeInfo / host-meta handler and responses
+├── src/                        # Vue 3 frontend
+│   ├── main.js                 # Main SPA entry
+│   ├── dashboard.js            # Dashboard widget entry
+│   ├── oauth.js                # OAuth authorization page entry
+│   ├── ostatus.js              # OStatus entry (built, but no server route loads it — see below)
+│   ├── profile.js              # Profile-page custom element entry
+│   ├── App.vue                 # Root component of the main SPA
+│   ├── router.js               # Vue Router configuration
+│   ├── store/                  # Vuex store (index.js + timeline, account, settings, errors)
+│   ├── views/                  # Route- and entry-level components
+│   ├── components/             # UI components (`.vue`, plus MessageContent.js)
+│   ├── services/               # eventBus, logger, notifications
+│   ├── mixins/                 # accountMixins, currentUserMixin, popoverMenu, serverData
+│   ├── directives/             # focusOnCreate
+│   ├── utils/                  # sanitizeHtml (+ its unit test)
+│   └── types/                  # JSDoc type definitions (ActivityPub, Mastodon)
+├── templates/                  # PHP templates: main.php (SPA), oauth2.php
+├── l10n/                       # Translations
 └── docs/                       # Documentation
 ```
+
+There is no `lib/bootstrap.php`; Composer's autoloader is pulled in by `lib/AppInfo/Application.php`.
 
 ---
 
 ## Database Schema
 
-The app uses 11 database tables, all prefixed with `social_`:
+Fourteen tables are created by `lib/Migration/Version1000Date20221118000001.php`, all prefixed with `social_`:
 
 | Table | Purpose |
 |-------|---------|
-| `social_actor` | Local user actors (tied to NC accounts, holds RSA key pairs) |
-| `social_cache_actor` | Cached remote federated actors (inbox/outbox URLs, public keys) |
-| `social_cache_doc` | Cached remote media attachments |
+| `social_action` | Like/Announce actions as ActivityPub objects (actor → object, with type) |
+| `social_actor` | Local user actors (tied to NC accounts, holds the RSA key pair) |
+| `social_cache_actor` | Cached remote federated actors (inbox/outbox URLs, public keys, counts) |
+| `social_cache_doc` | Cached remote and local media attachments |
 | `social_client` | OAuth 2.0 client registrations |
-| `social_follow` | Follow relationships (actor → object) |
-| `social_hashtag` | Hashtag trend data (counts per time window) |
+| `social_follow` | Follow relationships (actor → object, with accepted flag) |
+| `social_hashtag` | Hashtag trend data (a JSON `trend` blob per hashtag) |
 | `social_instance` | Known federated instances (version, metadata) |
 | `social_req_queue` | Outbound ActivityPub delivery queue |
 | `social_stream` | Core content table: posts, notes, activities |
-| `social_stream_act` | Per-user stream action state (liked, boosted) |
+| `social_stream_act` | Per-viewer stream flags (`liked`, `boosted`, `replied`, `values`) |
 | `social_stream_dest` | Stream visibility targets (who sees what) |
 | `social_stream_queue` | Inbound stream processing queue |
 | `social_stream_tag` | Stream-to-hashtag mapping |
+
+`Version1000Date20260611000001` only drops the abandoned `social_3_*` tables from an earlier prototype.
+
+Note that `CoreRequestBuilder::TABLE_NOTIFICATION` (`social_notif`) is declared but no migration creates that table and no repository queries it; it is a leftover constant. In-app notifications are stored in `social_stream` as `SocialAppNotification` items.
 
 ---
 
 ## Key Services
 
-The business logic is organized into 31 service classes in `lib/Service/`:
+The business logic lives in `lib/Service/`.
 
 ### Account & Identity
 
-- **AccountService** — Creates/deletes local ActivityPub actors with RSA key pairs, manages "blind key rotation", caches local actor data (avatar, display name, follower/following/post counts)
-- **ActorService** — Syncs local actor avatar/header images from Nextcloud user settings
-- **CacheActorService** — Central actor cache/resolver. Looks up actors by ID or `user@host` format. Fetches remote actors via WebFinger on cache-miss. Probes followers/following/outbox counts
+- **AccountService** — Creates local actors (generating an RSA key pair via `SignatureService`) and marks them deleted, refreshes the local actor cache (avatar, display name, follower/following/post counts), performs "blind key rotation", and reaps actors past their deletion retention
+- **ActorService** — Saves/updates cached `Person` rows and resolves an actor's cached header image
+- **CacheActorService** — Central actor cache/resolver. Looks up actors by ActivityPub id or `user@host`, fetches unknown remote actors over WebFinger + HTTP on a cache miss, and probes their followers/following/outbox counts
 
 ### Content & Timelines
 
-- **StreamService** — Core stream/timeline engine. Assigns ActivityPub IDs, manages recipients (public/unlisted/followers/direct), handles reply chains, detects stream types, fetches timelines (home, local, global, tag, account, liked, direct)
-- **PostService** — Handles post creation and editing (text, attachments, reply-to, mentions, hashtags). Calls ActivityService to federate
-- **FollowService** — Manages follow/unfollow flows with ActivityPub Federation
-- **LikeService** — Creates/deletes Like/Favourite activities
-- **BoostService** — Creates/deletes Announce (boost/reblog) activities
-- **ActionService** — Dispatcher for status actions (favourite, unfavourite, boost, unboost, bookmark, pin)
-- **HashtagService** — Computes hashtag trends over 1h/12h/1d/3d/10d windows
+- **StreamService** — Core stream/timeline engine. Assigns ActivityPub ids, expands recipients (public/unlisted/followers/direct), resolves reply chains, detects stream types, deletes local items, and reads the timelines (home, local, global/federated, tag, account, liked, direct, notifications)
+- **PostService** — Creates posts (text, attachments, reply-to, mentions, hashtags) and edits existing local posts, delegating federation to `ActivityService`
+- **FollowService** — Follow/unfollow flows, follower/following collections, and relationship lookups
+- **LikeService** — Creates and undoes Like activities
+- **BoostService** — Creates and undoes Announce (boost/reblog) activities
+- **ActionService** — Dispatcher for the Mastodon-style status actions. It validates the action against a list that includes `translate`, `favourite`, `unfavourite`, `reblog`, `unreblog`, `bookmark`, `unbookmark`, `mute`, `unmute`, `pin` and `unpin`, but the switch statement only implements favourite/unfavourite and reblog/unreblog. Bookmark, mute and pin are accepted and then silently do nothing, and `translate` returns the status unchanged
+- **HashtagService** — Recomputes hashtag trends over 1h/12h/1d/3d/10d windows and searches hashtags
+- **StreamActionService** — Writes the per-viewer flags in `social_stream_act`
+- **SearchService** — Backing searches for accounts, hashtags and URIs; `searchStreamContent()` exists but no caller uses it
 
 ### Federation
 
-- **ActivityService** — Creates, signs, and dispatches ActivityPub activities (Create, Update, Delete, Follow, Like, Announce, Undo). Signs outgoing requests with HTTP Signatures
-- **ImportService** — Parses incoming ActivityPub JSON into typed model objects and dispatches to interface handlers
-- **SignatureService** — RSA key generation, HTTP Signature signing/verification, LD-signature (RsaSignature2017) for JSON-LD objects
-- **RequestQueueService** — Manages outbound delivery queue with priority levels and exponential backoff
-- **CurlService** — Low-level HTTP client for ActivityPub requests and WebFinger lookups
-- **FediverseService** — Federation access control (blacklist/whitelist per instance domain)
-- **InstanceService** — Manages known instances metadata
+- **ActivityService** — Wraps items in Create/Update/Delete activities, LD-signs them, resolves target inboxes, and drives the delivery queue. `request()` sends the single highest-priority entry synchronously and kicks off an async request for the rest
+- **ImportService** — Parses incoming ActivityPub JSON into typed model objects (`AP::getItemFromData()`) and dispatches to the matching handler in `lib/Interfaces/`
+- **SignatureService** — RSA-2048 key generation, HTTP Signature signing and verification (checking `date` freshness, `content-length` and `digest` before the signature itself), and RsaSignature2017 Linked Data signatures
+- **RequestQueueService** — Manages `social_req_queue`: creates entries, hands out the priority entry, and re-offers standby entries after a `floor(tries^4 / 3)` second backoff
+- **StreamQueueService** — Manages `social_stream_queue`, the inbound side. Its only implemented queue type is `Cache`: for each Note a received stream references (a reply parent, a boosted post), it fetches that Note, caches its author, stores it, and embeds it in the referencing stream's cache. Anything that is not a Note, or whose id does not match the URL it was fetched from, is rejected
+- **CurlService** — HTTP client for ActivityPub fetches, WebFinger and host-meta lookups, and the async self-call that drains a delivery token
+- **FediverseService** — Instance-level access control; see [Security](#security)
+- **InstanceService** — Builds and returns the local instance's NodeInfo-style metadata
 
 ### Media
 
-- **DocumentService** — Manages cached document/media files
-- **CacheDocumentService** — Downloads and caches remote media with blurhash generation
+- **DocumentService** — Owns the cached document lifecycle: caching a remote document by id, serving originals and resized copies out of app storage, and caching the local actor's avatar and header
+- **CacheDocumentService** — Writes uploads, remote downloads and temp files into app storage, filters MIME types against an allow-list, and reads content back out
+- **BlurService** — Generates a blurhash string from a GD image
 
 ### System
 
-- **ConfigService** — App configuration (cloud URL, social URL, download limits)
-- **CheckService** — Installation health checks (WebFinger, URL configuration)
-- **DetailsService** — Computes stream visibility (who sees a post)
+- **ConfigService** — App/user configuration and the derived URLs (cloud URL, social URL, social address, max download size, self-signed toggle), plus ActivityPub id generation
+- **CheckService** — Installation checks (is `/.well-known/webfinger` reachable) and repair of invalid follow and note rows
+- **ClientService** — OAuth 2.0 client registration, authorization and token issuing
+- **DetailsService** — Computes a `StreamDetails` object describing which local viewers a stream reaches
+- **MiscService** — Logging helper and the running Nextcloud major version
+- **TestService** — Backs the WebFinger probe of `occ social:check:install`
+- **PushService** — `onNewStream()` returns immediately; the Nextcloud push integration it once wrapped is entirely commented out. Calling it has no effect
+- **UpdateService** — Builds admin notifications about the app's state, but nothing in `lib/` calls it; it is currently dead code
 
 ---
 
 ## ActivityPub Federation
 
-The app is a full ActivityPub **Server** that both produces and consumes ActivityPub protocol messages.
+The app is an ActivityPub **Server** that both produces and consumes ActivityPub messages.
 
 ### Actor Identity
 
-Each Nextcloud user gets a Person actor:
-- **ID:** `https://cloud.tld/apps/social/@username`
-- **Keys:** RSA 2048-bit key pair (generated per-actor)
-- **Endpoints:** Inbox, shared inbox, outbox, followers, following
+Each Nextcloud user that has been given a Social account gets a Person actor:
+
+- **ID:** the configured social URL plus `@username`, e.g. `https://cloud.tld/apps/social/@username`
+- **Keys:** RSA 2048-bit key pair, generated per actor by `SignatureService::generateKeys()`
+- **Endpoints:** `/@{user}/inbox`, the shared `/inbox`, `/@{user}/outbox`, `/@{user}/followers`, `/@{user}/following`
 
 ### Outgoing Flow
 
-1. User action (post, like, follow, boost) → Service creates an Activity wrapper
-2. `SignatureService::signObject()` adds Linked Data Signature
-3. `ActivityService::request()` determines target inboxes based on recipients
-4. `RequestQueueService` creates queue entries with priority levels
-5. High-priority requests are sent synchronously; others are queued
-6. `Cron\Queue` processes remaining entries with retry and backoff
-7. `CurlService` makes signed HTTP POST requests to remote inboxes
+1. A user action (post, edit, delete, follow, unfollow, like, boost) has a service build the activity
+2. `SignatureService::signObject()` adds a Linked Data Signature — for Create, Update, Delete, Like, Announce and their Undos. Follow and Accept are **not** LD-signed; they travel with the HTTP signature only
+3. `ActivityService::request()` expands the activity's instance paths into concrete target inboxes
+4. `RequestQueueService::generateRequestQueue()` writes one `social_req_queue` row per target
+5. At most one row is delivered inline: `RequestQueueService::getPriorityRequest()` hands back the first row only when its priority is `TOP`, or `HIGH`/`MEDIUM` under narrow conditions, and otherwise throws `NoHighPriorityRequestException` so nothing is sent synchronously. If rows remain on standby, `CurlService::asyncWithToken()` fires a request at the app's own `/async/request/{token}` route to drain them
+6. `Cron\Queue` (12-minute interval) retries whatever is still on standby, with the backoff above
+7. Every delivery is an HTTP POST signed by `SignatureService::signRequest()`
 
-**Supported outgoing activities:** Create, Update, Delete, Follow, Accept, Reject, Like, Announce, Undo, Add, Remove, Move, Block
+**Activities the app emits:** Create, Update, Delete, Follow, Accept, Like, Announce, Undo.
+
+The app never emits Reject, Add, Remove, Move or Block. It can parse all of them — `AP::getItemFromType()` constructs each one for an incoming document — but no service ever builds one to send.
 
 ### Incoming Flow
 
-1. Remote instance POSTs to `/@{username}/inbox` or `/inbox`
-2. HTTP Signature is verified (digest, date, content-length headers)
-3. LD-signature on JSON body is verified
-4. ImportService parses JSON into typed ActivityPub objects
-5. Appropriate interface handler processes the activity
-6. Content is stored in `social_stream`, federated to local recipients
+1. A remote instance POSTs to `/@{username}/inbox` or the shared `/inbox`
+2. `SignatureService::checkRequest()` checks the `date` header for freshness, that `content-length` matches the body, that `digest` matches the body, and then the HTTP signature. It returns the verified origin host, or an empty string if the signature does not verify
+3. `FediverseService::authorized()` is called with that origin. An empty origin is rejected, so a request with an unverifiable signature is refused here
+4. `ImportService::importFromJson()` parses the body into a typed object
+5. If the body carries a valid Linked Data Signature the origin is taken from it, otherwise the HTTP-signature origin is used
+6. `ImportService::parseIncomingRequest()` looks the handler up with `AP::getInterfaceForItem()` and calls `processIncomingRequest()`. Every exception from the handler is logged and swallowed
+7. The controller answers 200 and then drains the inbound stream queue for that request token
 
-**Supported incoming activities:** Create, Update, Delete, Follow, Accept, Reject, Like, Announce, Undo, Move, Block
+**Incoming activities that are actually acted on:**
+
+| Activity | Effect |
+|----------|--------|
+| `Create` (Note) | Post is stored in `social_stream`, notification generated |
+| `Update` (Note) | Stored post is updated |
+| `Update` (Person) | Cached remote actor is refreshed |
+| `Delete` (Note, Person) | Item is deleted; also handled when only an object id is given |
+| `Follow` | Saved and auto-accepted — an `Accept` is queued straight back |
+| `Accept` (Follow) | Local follow row marked accepted |
+| `Reject` (Follow) | Local follow row deleted |
+| `Undo` (Follow, Like, Announce) | The wrapped relation or action is deleted |
+| `Like` | Stored as an action, notification generated |
+| `Announce` | Stored as a boost, notification generated |
+| `Move` | Actions, follows, streams and cached documents are repointed to the target actor |
+
+**Incoming activities that are accepted but do nothing:** `Add`, `Remove` and `Block` are dispatched to a handler that forwards to the wrapped object's `activity()` method, and no object handler recognises those activity types. `BlockInterface` in particular means Block is a no-op — the app has no blocking implementation.
+
+**Object types that are dropped:** `AP::getItemFromType()` can build `Tombstone`, `Group`, `Organization`, `Application`, `OrderedCollection` and `Stream`, but `AP::getInterfaceFromType()` has no case for any of them. An incoming activity whose top-level type is one of these raises `ItemUnknownException`, which the inbox controller catches and ignores, so the message is silently discarded. In practice this means only Person and Service actors federate; Group, Organization and Application actors, and Tombstone deletions, are not processed.
 
 ### Discovery
 
-- **WebFinger:** `/.well-known/webfinger?resource=acct:user@domain` returns `self` link to actor profile
-- **NodeInfo:** `/.well-known/nodeinfo/2.0` returns server metadata
+`WellKnown/WebfingerHandler` is registered as a Nextcloud well-known handler and serves three services at the server root:
+
+- **WebFinger:** `/.well-known/webfinger?resource=acct:user@domain` — returns the `self` link to the actor
+- **NodeInfo:** `/.well-known/nodeinfo` — returns the discovery document pointing at the app's own `/apps/social/.well-known/nodeinfo/2.0` route (`OAuthController::nodeinfo2()`), which carries the actual server metadata
+- **host-meta:** `/.well-known/host-meta`
+
+All three return the previous handler's response untouched when `FediverseService::jailed()` says the instance is in allow-list mode with an empty list.
 
 ---
 
 ## Frontend Architecture
 
-The user interface is a **Vue 3 Single Page Application (SPA)** using:
+The user interface is a **Vue 3** front end using Vue Router, Vuex, `@nextcloud/vue` components, `@nextcloud/axios`, DOMPurify (via `src/utils/sanitizeHtml.js`), linkifyjs, and twemoji.
 
-- **Vue Router** — 8 named routes for timelines, profiles, posts
-- **Vuex** — 5 store modules (timeline, account, settings, serverData, errors)
-- **Nextcloud Vue Components** — NcButton, NcAppNavigation, NcAppNavigationItem, NcActions, etc.
-- **Axios** — HTTP client for API calls
-- **Tribute.js** — @mention autocomplete in the composer
-- **Custom components** — Composer, TimelinePost, TimelineEntry, ProfileInfo, MediaAttachment, Emoji picker, Visibility selector
+### Entry bundles
 
-The frontend is divided into separate entry bundles:
-- `social-main.js` — Main SPA (timeline, profile, search)
-- `social-dashboard.js` — Dashboard widgets
-- `social-oauth.js` — OAuth authorization page
-- `social-ostatus.js` — OStatus follow page
-- `social-profilePage.js` — Public profile embedding
+`webpack.common.js` defines five entries; the Nextcloud webpack preset prefixes the output with the app id, so they land in `js/` as:
 
-### Views
+| Bundle | Source | Loaded by |
+|--------|--------|-----------|
+| `social-social.js` | `src/main.js` | `templates/main.php` — the main SPA |
+| `social-dashboard.js` | `src/dashboard.js` | `SocialWidget::load()` |
+| `social-oauth.js` | `src/oauth.js` | `templates/oauth2.php` |
+| `social-profilePage.js` | `src/profile.js` | `ProfileSectionListener` |
+| `social-ostatus.js` | `src/ostatus.js` | nothing — no `addScript()` call references it |
 
-| View | Route | Purpose |
-|------|-------|---------|
-| Timeline | `/timeline/:type` | Timeline (home, local, global, direct, notifications, liked, hashtag) |
-| TimelineSinglePost | `/@{user}/{id}` | Single post with reply context |
-| Profile | `/@{user}` | User profile with posts tab |
-| Profile | `/@{user}/followers` | User profile with followers tab |
-| Profile | `/@{user}/following` | User profile with following tab |
-| Dashboard | (widget) | Dashboard notification widget |
-| OAuth2Authorize | `/oauth/authorize` | OAuth app authorization |
+The OStatus bundle and `src/views/OStatus.vue` are therefore dead code today: `OStatusController::subscribe()` and `followRemote()` both render the `main` template, so remote-follow lands in the main SPA on its `/ostatus/follow` route.
+
+### Store
+
+`src/store/index.js` registers four Vuex modules: `timeline`, `account`, `settings` and `errors`. Server-side state is not a store module — it is passed through Nextcloud's initial state as `serverData` and read by the `serverData` mixin.
+
+### Routes and views
+
+`src/router.js` declares one redirect, six named routes and one unnamed route:
+
+| Path | Route name | View |
+|------|-----------|------|
+| `/` | — (redirects to `timeline`) | — |
+| `/timeline/:type?` | `timeline` | Timeline |
+| `/timeline/:type?/tags/:tag` | `tags` | Timeline |
+| `/@:account` | `profile` | Profile + ProfileTimeline |
+| `/@:account/followers` | `profile.followers` | Profile + ProfileFollowers |
+| `/@:account/following` | `profile.following` | Profile + ProfileFollowers |
+| `/@:account/:id` | `single-post` | TimelineSinglePost |
+| `/ostatus/follow` | — | Profile + ProfileTimeline |
+
+`profile.followers` and `profile.following` render the same `ProfileFollowers` component; it decides what to load from the route.
+
+Views outside the router: `Dashboard.vue` (mounted by the dashboard entry), `OAuth2Authorize.vue` (mounted by the OAuth entry on `#social-oauth2`), `ProfilePageIntegration.vue` (registered by the profile entry as the `social-profile-section` custom element), and `OStatus.vue` (unreachable, per the table above).
+
+### Components
+
+`src/components/` holds the timeline and profile UI: `TimelineList`, `TimelineEntry`, `TimelinePost`, `TimelineAvatar`, `ActorAvatar`, `ProfileInfo`, `FollowButton`, `UserEntry`, `Navigation`, `Search`, `MediaAttachment`, `PostAttachment`, `Emoji`, `EmptyContent`, the `Composer/` group (`Composer`, `PreviewGrid`, `PreviewGridItem`, `SubmitStatusButton`), the `Visibility/` group (`VisibilitySelect`, `VisibilityIcon`), and `MessageContent.js`, a render-function component that parses a post body and rebuilds it as Vue nodes (turning mentions and hashtags into `router-link`s and emoji into `Emoji` components).
+
+`Composer.vue` still wraps its input in a `<Tribute>` element and carries a full `tributeOptions` config for `@` account and `#` hashtag completion, but no `Tribute` component is imported or registered anywhere in `src/` and the `tributejs` dependency is never imported. The element therefore does not resolve and neither autocomplete works. The emoji picker is a separate `NcEmojiPicker` and is unaffected.
 
 ---
 
 ## Integration Points
 
-| Integration | Class | Description |
-|-------------|-------|-------------|
-| Dashboard | `SocialWidget` | Shows recent social notifications |
-| Dashboard | `SocialTimelineWidget` | Shows home timeline posts (5-minute refresh) |
-| Unified Search | `UnifiedSearchProvider` | Searches accounts, hashtags, URIs |
-| Notifications | `Notifier` | Prepares Social notifications for NC notification system |
-| Contacts Menu | `ContactsMenuProvider` | "Follow on Social" button in contacts menu |
-| Profile Page | `ProfileSectionListener` | Injects Social data into user profile |
-| WebFinger | `WebfingerHandler` | ActivityPub discovery endpoint |
-| User Events | `UserAccountListener` | Syncs NC display name changes to Social actor |
-| Background Jobs | `Cron\Cache` | Periodic cache refresh and hashtag trends |
-| Background Jobs | `Cron\Queue` | Processes outbound federation queue |
+| Integration | Class | Registered in | Description |
+|-------------|-------|---------------|-------------|
+| Dashboard | `SocialWidget` | `Application::register()` | Recent Social notifications; loads `social-dashboard` |
+| Dashboard | `SocialTimelineWidget` | `Application::register()` | Home timeline as an API widget, 300-second reload interval |
+| Unified Search | `UnifiedSearchProvider` | `Application::register()` | Searches URIs, accounts and hashtags. Post-content search is present in `SearchService` but commented out at the call site |
+| Notifications | `Notifier` | `Application::register()` | Prepares Social notifications for the NC notification system |
+| Profile Page | `ProfileSectionListener` | `Application::register()` (on `BeforeTemplateRenderedEvent`) | Adds the `social-profilePage` script to the user profile page |
+| User Events | `UserAccountListener` | `Application::register()` (on `UserUpdatedEvent`) | Re-caches the local actor when the NC account changes |
+| WebFinger / NodeInfo / host-meta | `WebfingerHandler` | `Application::register()` | ActivityPub discovery at the server root |
+| Contacts Menu | `ContactsMenuProvider` | `appinfo/info.xml` | "Follow %s on Social" entry linking to the actor page |
+| Background Jobs | `Cron\Cache` | `appinfo/info.xml` | 12-minute interval: reaps deleted actors, refreshes local and remote actor caches, caches documents, recomputes hashtag trends, syncs remote timelines |
+| Background Jobs | `Cron\Queue` | `appinfo/info.xml` | 12-minute interval: drains the outbound request queue and the inbound stream queue |
+| Repair step | `Migration\RenameDocumentLocalCopy` | `appinfo/info.xml` | Post-migration repair of cached document paths |
+
+Fourteen occ commands are registered in `appinfo/info.xml`. `lib/Command/` holds a fifteenth file, `ExtendedBase.php`, which is the abstract base the others extend and is not itself a command. See `docs/OCC-Commands.md`.
 
 ---
 
 ## Security
 
-- **HTTP Signatures** — All outbound ActivityPub requests are signed with the sending actor's RSA private key
-- **LD-Signatures** — JSON-LD activity objects are signed with RsaSignature2017
-- **Signature Verification** — Incoming requests are verified before processing
-- **Federation Access Control** — Instance-level blacklist/whitelist
-- **Configuration** — Cloud base URL is fixed at setup and cannot be changed without resetting
-- **Self-signed certificates** — Configurable support for development environments
+**What is enforced**
+
+- **HTTP Signatures on outbound requests** — every queued delivery is signed with the sending actor's RSA private key over `(request-target)`, `content-length`, `date`, `host` and `digest`
+- **HTTP Signature verification on inbound requests** — `SignatureService::checkRequest()` rejects a stale `date`, a `content-length` that disagrees with the body, and a `digest` that does not match the body. If the signature itself fails to verify it returns an empty origin, and `FediverseService::authorized('')` then throws `UnauthorizedFediverseException`, so the request is refused
+- **Linked Data Signatures** — outgoing Create, Update, Delete, Like, Announce and Undo carry an RsaSignature2017 signature; incoming ones are verified by `SignatureService::checkObject()`, which also retries against a refreshed public key. Follow and Accept are not LD-signed
+- **Instance access control** — `FediverseService::authorized()` is checked on both inbox routes and on every outgoing `CurlService` request. It reads one app config value, `access_type`, which is either `all_but` (the default: everything is allowed unless the host is in the list) or `none_but` (only listed hosts, plus the local host, are allowed), together with a single host list in `access_list`. `occ social:fediverse` manages both
+- **HTML sanitisation** — remote HTML reaches local timelines, so `ACore` runs `lib/Tools/HtmlSanitizer.php` over every `AS_CONTENT` field it imports, and strips tags from string, username and account fields. The frontend sanitises again with DOMPurify in `src/utils/sanitizeHtml.js`
+- **Self-signed certificates** — TLS peer verification is skipped only when the `allow_self_signed` app config value is `1`
+
+**Known gaps — these are real and deliberate to record**
+
+- **Actor private keys are stored unencrypted.** `social_actor.private_key` holds the PEM as written by `openssl_pkey_export()`. `ICrypto` is not used anywhere in the app, so anyone with database read access can impersonate any local actor across the Fediverse
+- **The federation endpoints are unauthenticated.** `ActivityPubController::actor()`, `actorAlias()`, `outbox()`, `followers()`, `following()` and `displayPost()` are all annotated `@PublicPage` with `@NoCSRFRequired`, and there is no signed-fetch (authorized-fetch) requirement. Any anonymous caller can read a local actor's profile, outbox, follower and following collections and individual posts
+- **There is no blocking.** `BlockInterface` accepts an incoming Block and forwards it to a handler that ignores it, and the app never sends one. Per-actor blocks and mutes do not exist; the `mute`/`unmute` status actions are accepted by the API and discarded
+- **The older dual blacklist/whitelist implementation in `FediverseService` is commented out**, along with `PushService`. What remains is the single-list `access_type`/`access_list` mechanism described above
+- **`FediverseService::getKnownAddresses()` returns an empty array** unconditionally
+- **The base URL is set once.** `ConfigService::setCloudUrl()` will overwrite it, but stored actor and stream ids embed the old URL, so changing it in practice requires `occ social:reset`
+
+---
+
+## Keeping this document in sync
+
+This file, `docs/API.md` and `docs/OCC-Commands.md` describe the current implementation. They must be updated in the same change as the code they describe.
+
+`tests/DocumentationTest.php` mechanically enforces the parts that can be checked — the registered occ commands, the HTTP routes, and the supported Nextcloud and PHP version ranges. Everything else is on the author of the change.

--- a/docs/OCC-Commands.md
+++ b/docs/OCC-Commands.md
@@ -2,13 +2,18 @@
 
 All commands are invoked via `php occ <command>` from the Nextcloud root directory.
 
+This page documents the fourteen commands the app registers in `appinfo/info.xml`.
+Every command extends Nextcloud's `OC\Core\Command\Base`, so the generic
+`--output plain|json|json_pretty` option exists on all of them, but only
+`social:timeline` reads it (see below).
+
 ---
 
 ## Account Management
 
 ### `social:account:create`
 
-Create a new social account for a Nextcloud user.
+Create the Social actor for an existing Nextcloud user.
 
 ```
 php occ social:account:create [--handle HANDLE] <userId>
@@ -18,15 +23,18 @@ php occ social:account:create [--handle HANDLE] <userId>
 |----------|----------|-------------|
 | `userId` | Yes | Nextcloud username of the account |
 
-| Option | Description |
-|--------|-------------|
-| `--handle` | Social handle (defaults to the `userId` if omitted) |
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--handle` | required | Social handle. If omitted, the `userId` is used as the handle. |
+
+Fails with `Unknown user` if no such Nextcloud user exists. On success the command
+prints nothing.
 
 ---
 
 ### `social:account:delete`
 
-Delete a local social account.
+Delete a local Social account.
 
 ```
 php occ social:account:delete <account>
@@ -34,13 +42,15 @@ php occ social:account:delete <account>
 
 | Argument | Required | Description |
 |----------|----------|-------------|
-| `account` | Yes | Social local account identifier |
+| `account` | Yes | Local Social account (the handle / preferred username) |
+
+Prints nothing on success.
 
 ---
 
 ### `social:account:following`
 
-Follow or unfollow a remote or local account.
+Follow or unfollow an account on behalf of a local user.
 
 ```
 php occ social:account:following [--local] [--unfollow] <userId> <account>
@@ -49,12 +59,16 @@ php occ social:account:following [--local] [--unfollow] <userId> <account>
 | Argument | Required | Description |
 |----------|----------|-------------|
 | `userId` | Yes | Nextcloud user performing the action |
-| `account` | Yes | Target account handle/address to follow |
+| `account` | Yes | Account to follow (e.g. `user@example.org`) |
 
-| Option | Description |
-|--------|-------------|
-| `--local` | Indicates the target account is local |
-| `--unfollow` | Unfollow instead of follow |
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--local` | none | Resolve `account` as a **local** account first, and use its canonical account name |
+| `--unfollow` | none | Send an `Undo`/unfollow instead of a follow |
+
+Prints progress lines (`Following account...`, the resolved local actor id and nid,
+then the result). This is the only command that returns exit code `1` on a handled
+failure; the rest let the exception surface.
 
 ---
 
@@ -62,7 +76,7 @@ php occ social:account:following [--local] [--unfollow] <userId> <account>
 
 ### `social:note:create`
 
-Create a new note (post) from a given user.
+Create a note (post) as a given user and federate it.
 
 ```
 php occ social:note:create [-r|--replyTo REPLYTO] [-t|--to TO] [-y|--type TYPE] [-g|--hashtag HASHTAG] <user_id> <content>
@@ -73,18 +87,25 @@ php occ social:note:create [-r|--replyTo REPLYTO] [-t|--to TO] [-y|--type TYPE] 
 | `user_id` | Yes | Nextcloud user ID of the author |
 | `content` | Yes | Content of the post |
 
-| Option | Description |
-|--------|-------------|
-| `-r`, `--replyTo` | In-reply-to an existing thread ID |
-| `-t`, `--to` | Mention specific people |
-| `-y`, `--type` | Visibility type: `public` (default), `followers`, `unlisted`, `direct` |
-| `-g`, `--hashtag` | Hashtag (without the leading `#`) |
+| Option | Value | Description |
+|--------|-------|-------------|
+| `-r`, `--replyTo` | optional | Id of the post this one replies to |
+| `-t`, `--to` | optional | A single mentioned account |
+| `-y`, `--type` | optional | Visibility: `unlisted`, `followers` or `direct`. Anything else — including omitting the option — results in a **public** post; the value is not validated (`StreamService::setRecipient()`, `lib/Service/StreamService.php:115`). |
+| `-g`, `--hashtag` | optional | A single hashtag, without the leading `#` |
+
+`--to` and `--hashtag` each accept only one value. In addition,
+`PostService::fixRecipientAndHashtags()` (`lib/Service/PostService.php:86`) scans the
+content for `@mentions` and `#hashtags` and adds those too.
+
+Prints the resulting activity as pretty JSON followed by `token: <request token>`
+(written with `echo`, so `--output json` does not change it).
 
 ---
 
 ### `social:note:boost`
 
-Boost or unboost a note.
+Boost (`Announce`) a note, or undo a boost.
 
 ```
 php occ social:note:boost [--unboost] <user_id> <note_id>
@@ -92,18 +113,20 @@ php occ social:note:boost [--unboost] <user_id> <note_id>
 
 | Argument | Required | Description |
 |----------|----------|-------------|
-| `user_id` | Yes | Nextcloud user ID (who is boosting) |
-| `note_id` | Yes | Note ID to boost |
+| `user_id` | Yes | Nextcloud user ID boosting the note |
+| `note_id` | Yes | Id of the note |
 
-| Option | Description |
-|--------|-------------|
-| `--unboost` | Unboost instead of boost |
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--unboost` | none | Undo the boost instead of creating one |
+
+Prints the activity as pretty JSON plus `token: <request token>`.
 
 ---
 
 ### `social:note:like`
 
-Like or unlike a note.
+Like a note, or undo a like.
 
 ```
 php occ social:note:like [--unlike] <user_id> <note_id>
@@ -111,12 +134,14 @@ php occ social:note:like [--unlike] <user_id> <note_id>
 
 | Argument | Required | Description |
 |----------|----------|-------------|
-| `user_id` | Yes | Nextcloud user ID (who is liking) |
-| `note_id` | Yes | Note ID to like |
+| `user_id` | Yes | Nextcloud user ID liking the note |
+| `note_id` | Yes | Id of the note |
 
-| Option | Description |
-|--------|-------------|
-| `--unlike` | Unlike instead of like |
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--unlike` | none | Undo the like instead of creating one |
+
+Prints the activity as pretty JSON plus `token: <request token>`.
 
 ---
 
@@ -124,7 +149,7 @@ php occ social:note:like [--unlike] <user_id> <note_id>
 
 ### `social:timeline`
 
-Get a timeline (stream of posts) for a given viewer.
+Print a timeline as seen by a given local viewer.
 
 ```
 php occ social:timeline [--local] [--min_id MIN] [--max_id MAX] [--since SINCE] [--limit N] [--account ACCOUNT] [--crop N] <userId> <timeline>
@@ -132,26 +157,44 @@ php occ social:timeline [--local] [--min_id MIN] [--max_id MAX] [--since SINCE] 
 
 | Argument | Required | Description |
 |----------|----------|-------------|
-| `userId` | Yes | Nextcloud user whose timeline to view |
-| `timeline` | Yes | Timeline name: `home`, `public`, `direct`, `notifications`, `liked`, `account`; or `#hashtag` |
+| `userId` | Yes | Nextcloud user whose view is used. Fails with `Unknown user` if unknown. |
+| `timeline` | Yes | See the table of supported values below |
 
-| Option | Description |
-|--------|-------------|
-| `--local` | Local-only mode |
-| `--min_id` | Minimum ID for pagination (default: 0) |
-| `--max_id` | Maximum ID for pagination (default: 0) |
-| `--since` | Since Unix timestamp (default: 0) |
-| `--limit` | Number of items to return (default: 5) |
-| `--account` | Filter by specific account |
-| `--crop` | Character limit to crop content (default: 0 = no crop) |
+| Option | Value | Default | Description |
+|--------|-------|---------|-------------|
+| `--local` | none | off | Restrict to local content |
+| `--min_id` | required | `0` | Pagination bound |
+| `--max_id` | required | `0` | Pagination bound |
+| `--since` | required | `0` | Unix timestamp bound |
+| `--limit` | required | `5` | Number of items |
+| `--account` | required | `''` | A **local** account, resolved with `CacheActorService::getFromLocalAccount()`; used as the account filter |
+| `--crop` | required | `0` | Truncate the printed content to N characters (`0` = no cropping) |
 
-Supports JSON output via `--output json`.
+Supported `timeline` values (`StreamRequest::getTimeline()`,
+`lib/Db/StreamRequest.php:410`):
+
+| Value | Meaning |
+|-------|---------|
+| `home` | Own posts plus posts of followed accounts |
+| `public` | Public timeline |
+| `direct` | Direct messages |
+| `account` | Posts of one account (combine with `--account`) |
+| `favourites` | Liked posts |
+| `notifications` | Notifications (rendered in the notification format) |
+| `#<tag>` | A leading `#` selects the hashtag timeline for `<tag>` |
+
+`ProbeOptions` also defines `followers` and `following`, but `getTimeline()` has no
+case for them and silently returns an empty list (`lib/Db/StreamRequest.php:434`).
+Any other value behaves the same way.
+
+Output is a table (`Nid`, `Id`, `Source`, `Type`, `Author`, `Content`).
+`--output json` switches this command to a JSON dump of the streams.
 
 ---
 
 ### `social:details`
 
-Get details about a specific stream item (who can see it, on which timelines).
+Print who can see one stream item and which timelines it lands on.
 
 ```
 php occ social:details [--json] <streamId>
@@ -159,11 +202,18 @@ php occ social:details [--json] <streamId>
 
 | Argument | Required | Description |
 |----------|----------|-------------|
-| `streamId` | Yes | ID of the stream item |
+| `streamId` | Yes | Id of the stream item. Fails with `Unknown item` if it does not exist. |
 
-| Option | Description |
-|--------|-------------|
-| `--json` | Return output in JSON format |
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--json` | none | Dump the details object as pretty JSON |
+
+Without `--json` it prints the item id, author and type, then `Affected Timelines`
+with the `Home` viewers, the `Direct` viewers, and the `Public` / `Federated` flags.
+This command uses its own `--json` flag; the inherited `--output` option is ignored.
+
+Note the command name is `social:details`, not `social:stream:details`, even though
+the class is `OCA\Social\Command\StreamDetails`.
 
 ---
 
@@ -171,27 +221,34 @@ php occ social:details [--json] <streamId>
 
 ### `social:queue:process`
 
-Process the request queue and stream queue (handles pending outbound federation and inbound stream processing).
+Process both queues once: the outbound request queue (federation delivery) and the
+stream queue (caching of not-yet-resolved incoming objects).
 
 ```
 php occ social:queue:process
 ```
 
-No arguments or options.
+No arguments or options. Prints how many items are in each queue, how many are
+processable right now, and a `.` per processed item.
 
 ---
 
 ### `social:queue:status`
 
-Get status of a specific request queue item by its token.
+Dump the request-queue rows belonging to one request token.
 
 ```
 php occ social:queue:status [-t|--token TOKEN]
 ```
 
-| Option | Description |
-|--------|-------------|
-| `-t`, `--token` | Token of the request (mandatory) |
+| Option | Value | Description |
+|--------|-------|-------------|
+| `-t`, `--token` | optional | Token of the request |
+
+The option is declared optional but the command throws
+`As of today, --token is mandatory` when it is missing
+(`lib/Command/QueueStatus.php:70`). There is no way to list the whole queue with
+this command. Each matching row is printed as one line of JSON.
 
 ---
 
@@ -199,15 +256,22 @@ php occ social:queue:status [-t|--token TOKEN]
 
 ### `social:cache:refresh`
 
-Update cached data: local accounts, remote actors, documents, and hashtags.
+Run the cache maintenance steps once, printing a counter per step.
 
 ```
 php occ social:cache:refresh [-f|--force]
 ```
 
-| Option | Description |
-|--------|-------------|
-| `-f`, `--force` | Enforce update of cached remote accounts |
+| Option | Value | Description |
+|--------|-------|-------------|
+| `-f`, `--force` | none | Refresh cached remote actors even if they are not due |
+
+Steps and their output lines: local accounts deleted, local accounts regenerated,
+remote accounts created, remote accounts updated, remote accounts details updated,
+documents cached, hashtags updated.
+
+Key-pair rotation is **not** part of this command; the `blindKeyRotation()` call is
+commented out (`lib/Command/CacheRefresh.php:51`).
 
 ---
 
@@ -215,28 +279,58 @@ php occ social:cache:refresh [-f|--force]
 
 ### `social:fediverse`
 
-Manage federation access control — allow or deny access to specific Fediverse instances.
+Inspect and change the Fediverse access list.
 
 ```
-php occ social:fediverse [-t|--type TYPE] [action] [address]
+php occ social:fediverse [-t|--type TYPE] [<action>] [<address>]
 ```
 
-| Argument | Description |
-|----------|-------------|
-| `action` | Action to perform: `add`, `remove`, `list`, `test`, `reset` (empty to list addresses) |
-| `address` | Instance address/host to act upon |
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `action` | No | `''` | One of `list`, `add`, `remove`, `test`, `reset`, or empty |
+| `address` | No | `''` | Address / host the action applies to |
 
-| Option | Description |
-|--------|-------------|
-| `-t`, `--type` | Change the access type (blacklist/whitelist) |
+| Option | Value | Description |
+|--------|-------|-------------|
+| `-t`, `--type` | required | Set the access type. Only `all_but` (deny-list, the default) and `none_but` (allow-list) are accepted; anything else throws `invalid type` (`lib/Service/ConfigService.php:61`). |
 
-**Actions:**
-- _(empty)_ — list allowed/blocked addresses
-- `list` — list both known and listed addresses
-- `add <address>` — add an address to the list
-- `remove <address>` — remove an address from the list
-- `test <address>` — test if an address is authorized
-- `reset` — clear the entire list
+Passing `--type` **sets the type and exits** — the `action` argument is not executed
+in the same invocation (`lib/Command/Fediverse.php:53`). Without `--type`, the
+command first prints the current access type and then runs the action:
+
+| Action | Effect |
+|--------|--------|
+| _(empty)_ | Print the access list under `- List:` |
+| `list` | Print `- Known address:` followed by the access list |
+| `add <address>` | Add the address to the list |
+| `remove <address>` | Remove the address from the list |
+| `test <address>` | Print `Authorized` or `Unauthorized` for that address |
+| `reset` | Empty the list |
+
+An unknown action throws `specify action: add, remove, list, reset`.
+
+**What is actually enforced.** There is a single list (`access_list`) whose meaning
+depends on `access_type`: with `all_but` every address that is *not* listed is
+allowed; with `none_but` only listed addresses and the local host are allowed.
+`FediverseService::authorized()` is enforced on incoming activities
+(`lib/Controller/ActivityPubController.php:183` and `:226`) and on every outgoing
+HTTP request (`lib/Service/CurlService.php:259`), so the list does take effect for
+inbox delivery and for fetching remote data.
+
+**Known limitations:**
+
+- `list` always prints an empty `Known address:` section, because
+  `FediverseService::getKnownAddresses()` returns an empty array
+  (`lib/Service/FediverseService.php:121`).
+- The older two-list implementation (`blockAddress()`, `allowAddress()`,
+  `isBlocked()`, `isAllowed()`, and the separate blacklist/whitelist config keys) is
+  commented out (`lib/Service/FediverseService.php:178-255`). Only the single
+  `access_list` above exists; there is no separate block list.
+- Webfinger lookups are not filtered per address; `WebfingerHandler` only calls
+  `jailed()`, which refuses service when the instance is in `none_but` mode with an
+  empty list (`lib/WellKnown/WebfingerHandler.php:63`).
+- Matching is exact string comparison against the host
+  (`FediverseService::isListed()`); there is no wildcard or subdomain handling.
 
 ---
 
@@ -244,52 +338,66 @@ php occ social:fediverse [-t|--type TYPE] [action] [address]
 
 ### `social:check:install`
 
-Check the integrity of the installation and optionally regenerate the index.
+Check the integrity of the installation, or regenerate the stream index.
 
 ```
 php occ social:check:install [--index]
 ```
 
-| Option | Description |
-|--------|-------------|
-| `--index` | Regenerate the stream index (requires confirmation) |
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--index` | none | Regenerate the stream index instead of running the checks |
 
 Without `--index`:
-- Checks installation status
-- Removes invalid followers and notes
-- Prints current configuration as JSON
 
-With `--index`:
-- Confirmation prompt ("Do you confirm this operation?")
-- Empties `stream_dest` and `stream_tags` tables
-- Regenerates the index for all streams with a progress bar
+- runs `CheckService::checkInstallationStatus()`,
+- prints how many invalid followers and invalid notes were removed,
+- prints the current app configuration as pretty JSON.
+
+With `--index` the checks are skipped entirely. The command warns that the operation
+takes a while, asks `Do you confirm this operation? (y/N)`, and on confirmation
+empties `stream_dest` and `stream_tags` and rebuilds both for every stream, with a
+progress bar. Answering anything but `y` exits without changes.
+
+A `--push` option for testing Nextcloud Push integration is present in the source but
+commented out (`lib/Command/CheckInstall.php:66-70`), so it is not available.
 
 ---
 
 ### `social:reset`
 
-Reset ALL Social app data (destructive). Optionally perform a full uninstall.
+Delete all Social data, or uninstall the app's database footprint.
 
 ```
 php occ social:reset [--uninstall]
 ```
 
-| Option | Description |
-|--------|-------------|
-| `--uninstall` | Full removal: drops all social tables, removes migrations, background jobs, and config |
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--uninstall` | none | Full removal instead of a data flush |
 
-Requires **double confirmation** before executing.
+The command always asks **two** confirmations before doing anything:
+
+1. `Do you confirm this operation? (y/N)`
+2. `Operation is destructive. Are you sure about this? (y/N)`
+
+Answering anything but `y` to either question aborts with exit code `0`.
 
 Without `--uninstall`:
-- Empties all social data tables
-- Re-runs installation checks
-- Optionally allows changing the cloud base URL
+
+- empties every Social table (`CoreRequestBuilder::emptyAll()`),
+- re-runs `checkInstallationStatus(true)`,
+- offers to change the cloud base address, pre-filled with the current one; entering
+  the same value leaves it unchanged.
 
 With `--uninstall`:
-- Drops all `social_*` database tables
-- Removes migration entries from the migrations table
-- Removes background jobs (Cron)
-- Removes app configuration
+
+- drops the Social tables,
+- removes the app's rows from the migrations table,
+- removes the app's background jobs,
+- unsets the app configuration.
+
+The app files themselves are not removed, and the app is not disabled.
 
 ---
 
@@ -297,16 +405,17 @@ With `--uninstall`:
 
 | Code | Meaning |
 |------|---------|
-| 0 | Success |
-| 1 | General error / failure |
+| 0 | Success, and also an aborted confirmation prompt or a caught error in `social:reset` |
+| 1 | `social:account:following` handled failure, or an uncaught exception in any command |
 
 ---
 
 ## Background Jobs
 
-In addition to CLI commands, the app registers two background jobs that run automatically via Nextcloud's cron system:
+The app also registers two `TimedJob`s, both with an interval of 12 minutes, run by
+Nextcloud's cron:
 
-| Job | Class | Interval | Description |
-|-----|-------|----------|-------------|
-| Cache maintenance | `OCA\Social\Cron\Cache` | Periodic | Refreshes actor cache, updates hashtag trends, performs key rotation, cleans deleted actors |
-| Queue processing | `OCA\Social\Cron\Queue` | Periodic | Processes outbound ActivityPub delivery queue (sends pending activities to remote inboxes) |
+| Job | Class | Description |
+|-----|-------|-------------|
+| Cache maintenance | `OCA\Social\Cron\Cache` | Same steps as `social:cache:refresh` (deleted actors, local actor cache, remote actors and their details, documents, hashtags), and additionally syncs the timelines of cached remote actors. No key rotation is performed. |
+| Queue processing | `OCA\Social\Cron\Queue` | Processes the outbound request queue **and** the stream queue, like `social:queue:process`. |

--- a/tests/DocumentationTest.php
+++ b/tests/DocumentationTest.php
@@ -1,0 +1,357 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Keeps `docs/` mechanically in sync with the code.
+ *
+ * Everything here is parsed out of the source files with regular expressions;
+ * nothing is instantiated, because the classes involved (commands, in
+ * particular) extend server-internal base classes that are not autoloadable in
+ * the standalone test suite.
+ *
+ * Only contracts that a reader of the docs would act on are asserted: occ
+ * command names, HTTP route URLs, supported version ranges and the app
+ * version. Counts of internal classes are deliberately not asserted.
+ */
+class DocumentationTest extends TestCase {
+	/** Endpoints the app serves outside `appinfo/routes.php`, so the doc may name them. */
+	private const NON_ROUTE_ENDPOINTS = [
+		// Registered as an IHandler in lib/WellKnown/WebfingerHandler.php, not as a route.
+		'/.well-known/webfinger',
+	];
+
+	public function testInfoXmlRegistersEveryCommandClass(): void {
+		$onDisk = $this->commandClassesOnDisk();
+		$registered = $this->registeredCommandClasses();
+
+		$this->assertSame(
+			[],
+			array_values(array_diff($onDisk, $registered)),
+			'These command classes exist in lib/Command/ but are not registered:'
+			. ' add a <command> entry for each in appinfo/info.xml.'
+		);
+		$this->assertSame(
+			[],
+			array_values(array_diff($registered, $onDisk)),
+			'These <command> entries in appinfo/info.xml have no class in lib/Command/:'
+			. ' remove them from appinfo/info.xml or add the missing class.'
+		);
+	}
+
+	public function testEveryRegisteredCommandIsDocumented(): void {
+		$registered = $this->registeredCommandNames();
+		$documented = $this->documentedCommandNames();
+
+		$this->assertSame(
+			[],
+			array_values(array_diff($registered, $documented)),
+			'These occ commands are registered but undocumented:'
+			. ' document them in docs/OCC-Commands.md.'
+		);
+		$this->assertSame(
+			[],
+			array_values(array_diff($documented, $registered)),
+			'These occ commands are documented in docs/OCC-Commands.md but not registered:'
+			. ' remove them from docs/OCC-Commands.md, or register them in appinfo/info.xml.'
+		);
+	}
+
+	public function testEveryRouteIsDocumented(): void {
+		$routes = $this->routeUrls();
+		$documented = $this->documentedPaths();
+
+		$this->assertSame(
+			[],
+			array_values(array_diff($routes, $documented)),
+			'These routes from appinfo/routes.php are undocumented:'
+			. ' document these routes in docs/API.md (keep the {placeholder} names verbatim).'
+		);
+	}
+
+	public function testDocumentedPathsAreRealRoutes(): void {
+		$routes = $this->routeUrls();
+		$documented = $this->documentedPaths();
+
+		$this->assertSame(
+			[],
+			array_values(array_diff($documented, $routes)),
+			'These paths in docs/API.md are not routes:'
+			. ' remove them from docs/API.md, or fix the path (a wrong {placeholder} name'
+			. ' counts as a wrong path) so it matches a url in appinfo/routes.php.'
+		);
+	}
+
+	public function testSupportedNextcloudVersionsAreDocumented(): void {
+		$doc = $this->read('docs/Architecture.md');
+
+		$this->assertSame(
+			$this->dependencyVersion('nextcloud', 'min'),
+			$this->documentedVersion($doc, 'nextcloud', 'min'),
+			'docs/Architecture.md states the wrong minimum Nextcloud version:'
+			. ' state the <nextcloud min-version> from appinfo/info.xml.'
+		);
+		$this->assertSame(
+			$this->dependencyVersion('nextcloud', 'max'),
+			$this->documentedVersion($doc, 'nextcloud', 'max'),
+			'docs/Architecture.md states the wrong maximum Nextcloud version:'
+			. ' state the <nextcloud max-version> from appinfo/info.xml.'
+		);
+	}
+
+	public function testSupportedPhpVersionsAreDocumented(): void {
+		$doc = $this->read('docs/Architecture.md');
+
+		$this->assertSame(
+			$this->dependencyVersion('php', 'min'),
+			$this->documentedVersion($doc, 'php', 'min'),
+			'docs/Architecture.md states the wrong minimum PHP version:'
+			. ' state the <php min-version> from appinfo/info.xml.'
+		);
+		$this->assertSame(
+			$this->dependencyVersion('php', 'max'),
+			$this->documentedVersion($doc, 'php', 'max'),
+			'docs/Architecture.md states the wrong maximum PHP version:'
+			. ' state the <php max-version> from appinfo/info.xml.'
+		);
+	}
+
+	public function testAppVersionMatchesComposerVersion(): void {
+		$composer = json_decode($this->read('composer.json'), true, 512, JSON_THROW_ON_ERROR);
+		if (!isset($composer['version'])) {
+			$this->addToAssertionCount(1);
+
+			return;
+		}
+
+		$this->assertSame(
+			$this->appVersion(),
+			(string)$composer['version'],
+			'The version in composer.json disagrees with <version> in appinfo/info.xml:'
+			. ' bump "version" in composer.json to the appinfo/info.xml version'
+			. ' (appinfo/info.xml is the release version of the app).'
+		);
+	}
+
+	private function read(string $relativePath): string {
+		$path = __DIR__ . '/../' . $relativePath;
+		$content = file_get_contents($path);
+		$this->assertIsString($content, $relativePath . ' is missing or unreadable.');
+
+		return $content;
+	}
+
+	/** Fully qualified command classes listed as `<command>` in appinfo/info.xml, sorted. */
+	private function registeredCommandClasses(): array {
+		preg_match_all(
+			'/<command>\s*([^<\s]+)\s*<\/command>/',
+			$this->read('appinfo/info.xml'),
+			$matches
+		);
+
+		return $this->normalise($matches[1]);
+	}
+
+	/**
+	 * Fully qualified command classes found in lib/Command/, sorted.
+	 *
+	 * Files that register no command name (the shared ExtendedBase) are not
+	 * commands and are skipped.
+	 */
+	private function commandClassesOnDisk(): array {
+		$classes = [];
+		foreach ($this->commandFiles() as $file => $code) {
+			if ($this->commandNameOf($code) === null) {
+				continue;
+			}
+
+			$classes[] = 'OCA\\Social\\Command\\' . basename($file, '.php');
+		}
+
+		return $this->normalise($classes);
+	}
+
+	/** Command names passed to setName() in lib/Command/, sorted. */
+	private function registeredCommandNames(): array {
+		$names = [];
+		foreach ($this->commandFiles() as $code) {
+			$name = $this->commandNameOf($code);
+			if ($name !== null) {
+				$names[] = $name;
+			}
+		}
+
+		return $this->normalise($names);
+	}
+
+	/**
+	 * Command names that have their own section in docs/OCC-Commands.md, sorted.
+	 *
+	 * A heading is what documents a command; a name in prose may well be a
+	 * counter-example ("the command is `social:details`, not `social:stream:details`").
+	 */
+	private function documentedCommandNames(): array {
+		preg_match_all(
+			'/^#{2,4}[^\S\n]+`(social:[a-z0-9:_-]+)`/m',
+			$this->read('docs/OCC-Commands.md'),
+			$matches
+		);
+
+		return $this->normalise($matches[1]);
+	}
+
+	/** @return array<string, string> file path => file contents */
+	private function commandFiles(): array {
+		$files = glob(__DIR__ . '/../lib/Command/*.php');
+		$this->assertNotEmpty($files, 'No command classes found in lib/Command/.');
+
+		$contents = [];
+		foreach ($files as $file) {
+			$contents[$file] = (string)file_get_contents($file);
+		}
+
+		return $contents;
+	}
+
+	private function commandNameOf(string $code): ?string {
+		if (preg_match('/setName\(\s*[\'"]([^\'"]+)[\'"]\s*\)/', $code, $match) !== 1) {
+			return null;
+		}
+
+		return $match[1];
+	}
+
+	/** Route urls declared in appinfo/routes.php, normalised and sorted. */
+	private function routeUrls(): array {
+		$definition = require __DIR__ . '/../appinfo/routes.php';
+		$this->assertArrayHasKey('routes', $definition, 'appinfo/routes.php declares no routes.');
+
+		$urls = [];
+		foreach ($definition['routes'] as $route) {
+			$this->assertArrayHasKey('url', $route, 'A route in appinfo/routes.php has no url.');
+			$urls[] = $this->normalisePath((string)$route['url']);
+		}
+
+		return $this->normalise($urls);
+	}
+
+	/**
+	 * Paths documented in docs/API.md, normalised and sorted.
+	 *
+	 * Only code spans inside the endpoint tables count: paths in prose are
+	 * illustrations (a base URL, a `/api/v1/` prefix, a full https:// example)
+	 * rather than claims about a route.
+	 */
+	private function documentedPaths(): array {
+		$paths = [];
+		foreach (explode("\n", $this->read('docs/API.md')) as $line) {
+			if (!str_starts_with(trim($line), '|')) {
+				continue;
+			}
+
+			preg_match_all('/`(\/[^`]*)`/', $line, $matches);
+			foreach ($matches[1] as $path) {
+				if (in_array($path, self::NON_ROUTE_ENDPOINTS, true)) {
+					continue;
+				}
+
+				$paths[] = $this->normalisePath($path);
+			}
+		}
+
+		return $this->normalise($paths);
+	}
+
+	/** Drops a trailing slash, so `/local/` and `/local` compare equal; keeps the root. */
+	private function normalisePath(string $path): string {
+		$trimmed = rtrim(trim($path), '/');
+
+		return $trimmed === '' ? '/' : $trimmed;
+	}
+
+	private function appVersion(): string {
+		$found = preg_match(
+			'/<version>\s*([^<\s]+)\s*<\/version>/',
+			$this->read('appinfo/info.xml'),
+			$match
+		);
+		$this->assertSame(1, $found, 'appinfo/info.xml declares no <version>.');
+
+		return $match[1];
+	}
+
+	/**
+	 * A `min-version`/`max-version` from the `<dependencies>` of appinfo/info.xml.
+	 *
+	 * @param string $subject `nextcloud` or `php`
+	 * @param string $bound `min` or `max`
+	 */
+	private function dependencyVersion(string $subject, string $bound): string {
+		$found = preg_match(
+			'/<' . $subject . '\b[^>]*\b' . $bound . '-version="([^"]+)"/',
+			$this->read('appinfo/info.xml'),
+			$match
+		);
+		$this->assertSame(
+			1,
+			$found,
+			'appinfo/info.xml declares no ' . $subject . ' ' . $bound . '-version.'
+		);
+
+		return $match[1];
+	}
+
+	/**
+	 * The version a doc states for one bound of one dependency.
+	 *
+	 * Accepts the labelled forms ("Minimum NC version: 28", "PHP max version: 8.5")
+	 * in either word order, and a range ("Nextcloud: 28 - 35").
+	 *
+	 * @param string $subject `nextcloud` or `php`
+	 * @param string $bound `min` or `max`
+	 */
+	private function documentedVersion(string $doc, string $subject, string $bound): string {
+		$name = $subject === 'nextcloud' ? '(?:nextcloud|nc)' : 'php';
+		$limit = $bound === 'min' ? '(?:minimum|min)\.?' : '(?:maximum|max)\.?';
+		$version = '`?([0-9]+(?:\.[0-9]+)*)`?';
+		$gap = '[\s*_:]+';
+
+		$patterns = [
+			'/' . $limit . $gap . $name . $gap . '(?:version[s]?' . $gap . ')?' . $version . '/i',
+			'/' . $name . $gap . $limit . $gap . '(?:version[s]?' . $gap . ')?' . $version . '/i',
+		];
+		foreach ($patterns as $pattern) {
+			if (preg_match($pattern, $doc, $match) === 1) {
+				return $match[1];
+			}
+		}
+
+		$range = '/' . $name . $gap . '(?:version[s]?' . $gap . ')?' . $version
+			. '\s*(?:-|--|–|—|\.\.\.?|to)\s*' . $version . '/i';
+		if (preg_match($range, $doc, $match) === 1) {
+			return $bound === 'min' ? $match[1] : $match[2];
+		}
+
+		return 'not stated';
+	}
+
+	/**
+	 * @param string[] $values
+	 * @return string[]
+	 */
+	private function normalise(array $values): array {
+		$unique = array_unique($values);
+		sort($unique);
+
+		return array_values($unique);
+	}
+}


### PR DESCRIPTION
* Resolves: # <!-- no issue -->
* Target version: master

> **Stacked on #2027.** The base of this PR is `tests/unit-suite`, so the diff shows only the documentation change. `tests/DocumentationTest.php` needs the test harness from that PR to run. Once #2027 is merged this can be retargeted to `master`.

### Summary

The documentation described features the code does not have. That is worse than having none, because a reader cannot tell which parts to trust. Every claim in `docs/`, `README.md` and the app-store description has been checked against the code and corrected, qualified or removed — and the parts that can be checked mechanically are now enforced by a test.

No changes to `lib/` or `src/`: `git diff --stat -- lib src` is empty. The one code change is `composer.json`'s version, which had been left at `0.10.0` while `appinfo/info.xml` said `0.10.1`.

### What was wrong

| Claim | Reality |
|---|---|
| Nextcloud 28–34 | `appinfo/info.xml` says 28–35; the PHP range (8.1–8.5) and app version were missing entirely |
| `POST /api/v1/statuses/{nid}/{act}` takes `boost`/`unboost` | `ActionService` accepts neither. It takes `favourite`, `unfavourite`, `reblog`, `unreblog`. `bookmark`, `mute` and `pin` pass its allow-list but have no branch, so the endpoint answers **200 with an unchanged status** |
| Errors are `{"message", "code"}`, with 201 and 204 responses | Responses come from `TNCDataResponse`; nothing returns 201 or 204; `ApiController::error()` answers 401 |
| Local stream endpoints default to `limit=20` | They default to 5 (the Mastodon-compatible ones use 20) |
| Emits Reject, Add, Remove, Move, Block | All five can be parsed; none is ever built to send. Add, Remove and Block are accepted inbound and do nothing, and an activity whose object is a `Tombstone`, `Group`, `Organization` or `Application` is dropped, because `AP::getInterfaceFromType()` has no case for those types |
| Instance blacklist and whitelist | One `access_type` and one `access_list`. The dual-list helpers are commented out and `getKnownAddresses()` returns `[]` |
| `social:timeline` accepts `liked` | Never existed |
| `social:queue:status -t` is optional | The code throws `As of today, --token is mandatory` |
| `social:cache:refresh` rotates keys | `blindKeyRotation()` is commented out |
| Profile "metadata support" | `Person::exportAsLocal()` writes `fields => []` unconditionally |
| A `DEPLOYMENT.md` to follow | Does not exist |
| "5 Vuex modules", "11 database tables", "15 occ commands", "31 services" | 4, 14, 14 — counts removed throughout, see below |

The security section previously listed controls that are not in force. It now records what `authorized()` and `getAccessType()` actually enforce, and adds two facts a self-hoster should know: actor private keys are stored unencrypted, and the actor, outbox, followers, following and post endpoints are public with no signed-fetch requirement.

`README.md` gains a **"Not implemented yet"** section, because for a prospective user the gaps matter more than the feature list: no blocking, muting or reporting; no approvable follow requests (every `Follow` is auto-accepted and `follow_requests_count` is hard-coded to 0); no polls, bookmarks or lists; images only for attachments; and no working mention autocomplete (`Composer.vue` renders a `<Tribute>` component that is never registered).

Counts of internal classes are gone from `docs/Architecture.md`. They were wrong, and they go stale on almost every commit; naming the classes and describing their roles carries the same information without rotting.

### Keeping it in sync

`tests/DocumentationTest.php` asserts, in both directions:

- the `<command>` entries in `appinfo/info.xml` match the command classes on disk;
- every registered command name is documented in `docs/OCC-Commands.md`, and nothing else is;
- every route in `appinfo/routes.php` appears in `docs/API.md`, and no documented path is a non-route (a wrong `{placeholder}` name fails here too);
- the Nextcloud and PHP version ranges in `docs/Architecture.md` match `appinfo/info.xml`;
- `appinfo/info.xml` and `composer.json` agree on the version.

The failure messages name the file to edit and the action to take. It deliberately does not assert counts of services, controllers or database classes — that is the kind of check that produces noise rather than signal.

It earned its keep while this PR was being written: it caught the version mismatch above, an undocumented route (`/api/saved_searches/list.json`), and a missing PHP version range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
