### PR TITLE
fix: guard Move with alsoKnownAs and encrypt actor private keys at rest

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -45,6 +45,7 @@ This is a partial implementation of ActivityPub and of the Mastodon client API. 
 	<repair-steps>
 		<post-migration>
 			<step>OCA\Social\Migration\RenameDocumentLocalCopy</step>
+			<step>OCA\Social\Migration\EncryptPrivateKeys</step>
 		</post-migration>
 	</repair-steps>
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -197,7 +197,7 @@ The app never emits Reject, Add, Remove, Move or Block. It can parse all of them
 | `Undo` (Follow, Like, Announce) | The wrapped relation or action is deleted |
 | `Like` | Stored as an action, notification generated |
 | `Announce` | Stored as a boost, notification generated |
-| `Move` | Actions, follows, streams and cached documents are repointed to the target actor |
+| `Move` | Actions, follows, streams and cached documents are repointed to the target actor — but only after the target actor (refreshed from its server) lists the moving actor in its `alsoKnownAs`; a Move whose target does not acknowledge the actor is refused |
 
 **Incoming activities that are accepted but do nothing:** `Add`, `Remove` and `Block` are dispatched to a handler that forwards to the wrapped object's `activity()` method, and no object handler recognises those activity types. `BlockInterface` in particular means Block is a no-op — the app has no blocking implementation.
 
@@ -301,7 +301,7 @@ Fourteen occ commands are registered in `appinfo/info.xml`. `lib/Command/` holds
 
 **Known gaps — these are real and deliberate to record**
 
-- **Actor private keys are stored unencrypted.** `social_actor.private_key` holds the PEM as written by `openssl_pkey_export()`. `ICrypto` is not used anywhere in the app, so anyone with database read access can impersonate any local actor across the Fediverse
+- **Actor private keys are encrypted at rest.** `social_actor.private_key` holds the PEM encrypted with the instance secret (`ICrypto`, via `PrivateKeyCipher`), so a database dump alone is not enough to impersonate a local actor — it also takes the `secret` from `config.php`. Rows written before encryption existed (recognisable by their `-----BEGIN` prefix) are still readable and are rewritten once by the `EncryptPrivateKeys` repair step on upgrade
 - **The federation endpoints are unauthenticated.** `ActivityPubController::actor()`, `actorAlias()`, `outbox()`, `followers()`, `following()` and `displayPost()` are all annotated `@PublicPage` with `@NoCSRFRequired`, and there is no signed-fetch (authorized-fetch) requirement. Any anonymous caller can read a local actor's profile, outbox, follower and following collections and individual posts
 - **There is no blocking.** `BlockInterface` accepts an incoming Block and forwards it to a handler that ignores it, and the app never sends one. Per-actor blocks and mutes do not exist; the `mute`/`unmute` status actions are accepted by the API and discarded
 - **The older dual blacklist/whitelist implementation in `FediverseService` is commented out**, along with `PushService`. What remains is the single-list `access_type`/`access_list` mechanism described above

--- a/lib/Db/ActorsRequest.php
+++ b/lib/Db/ActorsRequest.php
@@ -36,7 +36,7 @@ class ActorsRequest extends ActorsRequestBuilder {
 				'preferred_username', $qb->createNamedParameter($actor->getPreferredUsername())
 			)
 			->setValue('public_key', $qb->createNamedParameter($actor->getPublicKey()))
-			->setValue('private_key', $qb->createNamedParameter($actor->getPrivateKey()))
+			->setValue('private_key', $qb->createNamedParameter($this->keyCipher->seal($actor->getPrivateKey())))
 			->setValue(
 				'creation',
 				$qb->createNamedParameter(new DateTime('now'), IQueryBuilder::PARAM_DATE)
@@ -58,7 +58,7 @@ class ActorsRequest extends ActorsRequestBuilder {
 	public function refreshKeys(Person $actor): void {
 		$qb = $this->getActorsUpdateSql();
 		$qb->set('public_key', $qb->createNamedParameter($actor->getPublicKey()))
-			->set('private_key', $qb->createNamedParameter($actor->getPrivateKey()));
+			->set('private_key', $qb->createNamedParameter($this->keyCipher->seal($actor->getPrivateKey())));
 
 		try {
 			$qb->set(

--- a/lib/Db/ActorsRequestBuilder.php
+++ b/lib/Db/ActorsRequestBuilder.php
@@ -11,10 +11,31 @@ namespace OCA\Social\Db;
 
 use OCA\Social\Exceptions\SocialAppConfigException;
 use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Security\PrivateKeyCipher;
+use OCA\Social\Service\ConfigService;
+use OCA\Social\Service\MiscService;
 use OCA\Social\Tools\Traits\TArrayTools;
+use OCP\IDBConnection;
+use OCP\IURLGenerator;
+use Psr\Log\LoggerInterface;
 
 class ActorsRequestBuilder extends CoreRequestBuilder {
 	use TArrayTools;
+
+	protected PrivateKeyCipher $keyCipher;
+
+	public function __construct(
+		IDBConnection $connection,
+		LoggerInterface $logger,
+		IURLGenerator $urlGenerator,
+		ConfigService $configService,
+		MiscService $miscService,
+		PrivateKeyCipher $keyCipher,
+	) {
+		parent::__construct($connection, $logger, $urlGenerator, $configService, $miscService);
+
+		$this->keyCipher = $keyCipher;
+	}
 
 
 	/**
@@ -89,6 +110,7 @@ class ActorsRequestBuilder extends CoreRequestBuilder {
 
 		$actor = new Person();
 		$actor->importFromDatabase($data);
+		$actor->setPrivateKey($this->keyCipher->open($actor->getPrivateKey()));
 		$actor->setId($root . '@' . $actor->getPreferredUsername());
 		$actor->setType('Person');
 		$actor->setInbox($actor->getId() . '/inbox')

--- a/lib/Interfaces/Activity/MoveInterface.php
+++ b/lib/Interfaces/Activity/MoveInterface.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\Social\Interfaces\Activity;
 
 use OCA\Social\Db\ActionsRequest;
+use OCA\Social\Db\CacheActorsRequest;
 use OCA\Social\Db\CacheDocumentsRequest;
 use OCA\Social\Db\FollowsRequest;
 use OCA\Social\Db\StreamDestRequest;
@@ -24,6 +25,7 @@ use OCA\Social\Service\CacheActorService;
 
 class MoveInterface extends AbstractActivityPubInterface implements IActivityPubInterface {
 	private ActionsRequest $actionsRequest;
+	private CacheActorsRequest $cacheActorsRequest;
 	private CacheDocumentsRequest $cacheDocumentsRequest;
 	private FollowsRequest $followsRequest;
 	private StreamRequest $streamRequest;
@@ -32,6 +34,7 @@ class MoveInterface extends AbstractActivityPubInterface implements IActivityPub
 
 	public function __construct(
 		ActionsRequest $actionsRequest,
+		CacheActorsRequest $cacheActorsRequest,
 		CacheDocumentsRequest $cacheDocumentsRequest,
 		FollowsRequest $followsRequest,
 		StreamRequest $streamRequest,
@@ -39,6 +42,7 @@ class MoveInterface extends AbstractActivityPubInterface implements IActivityPub
 		CacheActorService $cacheActorService,
 	) {
 		$this->actionsRequest = $actionsRequest;
+		$this->cacheActorsRequest = $cacheActorsRequest;
 		$this->cacheDocumentsRequest = $cacheDocumentsRequest;
 		$this->streamRequest = $streamRequest;
 		$this->streamDestRequest = $streamDestRequest;
@@ -56,12 +60,26 @@ class MoveInterface extends AbstractActivityPubInterface implements IActivityPub
 		$item->checkOrigin($item->getActorId());
 
 		try {
-			$old = $this->cacheActorService->getFromAccount($item->getActorId(), false);
+			// cache only: an actor this instance has never seen has nothing to move
+			$old = $this->cacheActorsRequest->getFromId($item->getActorId());
 		} catch (CacheActorDoesNotExistException $e) {
 			return;
 		}
 
-		$new = $this->cacheActorService->getFromAccount($item->getTarget());
+		// Refresh the target so the alsoKnownAs list is the one its server
+		// publishes right now, not a stale cached copy.
+		$new = $this->cacheActorService->getFromId($item->getTarget(), true);
+
+		// The signature only proves the Move comes from the old account's
+		// server. Without the back-reference, anyone could re-point another
+		// actor's followers and posts at an account they control.
+		if (!in_array($old->getId(), $new->getAlsoKnownAs(), true)) {
+			throw new InvalidOriginException(
+				'MoveInterface - target ' . $new->getId()
+				. ' does not list ' . $old->getId() . ' in alsoKnownAs'
+			);
+		}
+
 		$this->moveAccount($old, $new);
 	}
 

--- a/lib/Migration/EncryptPrivateKeys.php
+++ b/lib/Migration/EncryptPrivateKeys.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Migration;
+
+use OCA\Social\Db\CoreRequestBuilder;
+use OCA\Social\Security\PrivateKeyCipher;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+/**
+ * Rewrites the actor private keys stored as bare PEM into their encrypted
+ * form. New keys are written encrypted from the start; this step only exists
+ * for rows created before that. Runs on every upgrade and is a no-op once no
+ * plaintext key is left, so it needs no marker.
+ */
+class EncryptPrivateKeys implements IRepairStep {
+	private IDBConnection $connection;
+	private PrivateKeyCipher $keyCipher;
+
+	public function __construct(IDBConnection $connection, PrivateKeyCipher $keyCipher) {
+		$this->connection = $connection;
+		$this->keyCipher = $keyCipher;
+	}
+
+	public function getName(): string {
+		return 'Encrypt the stored Social actor private keys';
+	}
+
+	public function run(IOutput $output): void {
+		$select = $this->connection->getQueryBuilder();
+		$select->select('id', 'private_key')
+			->from(CoreRequestBuilder::TABLE_ACTORS)
+			->where($select->expr()->like(
+				'private_key',
+				$select->createNamedParameter(
+					$this->connection->escapeLikeParameter('-----BEGIN') . '%'
+				)
+			));
+
+		$plain = [];
+		$result = $select->executeQuery();
+		while ($row = $result->fetch()) {
+			$plain[] = $row;
+		}
+		$result->closeCursor();
+
+		if ($plain === []) {
+			return;
+		}
+
+		$output->startProgress(count($plain));
+		foreach ($plain as $row) {
+			$update = $this->connection->getQueryBuilder();
+			$update->update(CoreRequestBuilder::TABLE_ACTORS)
+				->set('private_key', $update->createNamedParameter(
+					$this->keyCipher->seal((string)$row['private_key'])
+				))
+				->where($update->expr()->eq('id', $update->createNamedParameter($row['id'])));
+			$update->executeStatement();
+			$output->advance();
+		}
+		$output->finishProgress();
+	}
+}

--- a/lib/Model/ActivityPub/Actor/Person.php
+++ b/lib/Model/ActivityPub/Actor/Person.php
@@ -69,6 +69,9 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 	private int $headerVersion = -1;
 	private string $viewerLink = '';
 
+	/** @var string[] */
+	private array $alsoKnownAs = [];
+
 	/**
 	 * Person constructor.
 	 *
@@ -610,6 +613,25 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 	}
 
 	/**
+	 * The actor ids this actor also answers to — a `Move` is only valid when
+	 * its target lists the moving actor here.
+	 *
+	 * @return string[]
+	 */
+	public function getAlsoKnownAs(): array {
+		return $this->alsoKnownAs;
+	}
+
+	/**
+	 * @param string[] $alsoKnownAs
+	 */
+	public function setAlsoKnownAs(array $alsoKnownAs): self {
+		$this->alsoKnownAs = array_values(array_filter($alsoKnownAs, 'is_string'));
+
+		return $this;
+	}
+
+	/**
 	 * @param array $data
 	 *
 	 * @throws ItemUnknownException
@@ -629,7 +651,8 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 			->setOutbox($this->validate(ACore::AS_URL, 'outbox', $data, ''))
 			->setFollowers($this->validate(ACore::AS_URL, 'followers', $data, ''))
 			->setFollowing($this->validate(ACore::AS_URL, 'following', $data, ''))
-			->setFeatured($this->validate(ACore::AS_URL, 'featured', $data, ''));
+			->setFeatured($this->validate(ACore::AS_URL, 'featured', $data, ''))
+			->setAlsoKnownAs($this->getArray('alsoKnownAs', $data, []));
 
 		/** @var Image $icon */
 		$icon = AP::$activityPub->getItemFromType(Image::TYPE);
@@ -700,6 +723,7 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 			if ($image !== '') {
 				$this->setHeader($image);
 			}
+			$this->setAlsoKnownAs($this->getArray('alsoKnownAs', $source, []));
 		}
 
 		$this->setPreferredUsername($this->validate(self::AS_USERNAME, 'preferred_username', $data, ''))
@@ -765,6 +789,10 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 				'publicKeyPem' => $this->getPublicKey()
 			]
 		];
+
+		if ($this->getAlsoKnownAs() !== []) {
+			$data['alsoKnownAs'] = $this->getAlsoKnownAs();
+		}
 
 		if ($this->hasIcon()) {
 			$icon = $this->getIcon();

--- a/lib/Security/PrivateKeyCipher.php
+++ b/lib/Security/PrivateKeyCipher.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Security;
+
+use Exception;
+use OCP\Security\ICrypto;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Encrypts actor private keys at rest with the instance secret (ICrypto), so a
+ * database dump alone is no longer enough to impersonate every local actor.
+ *
+ * Rows written before encryption existed hold the bare PEM; those are
+ * recognised by their '-----BEGIN' prefix and still readable, and the
+ * EncryptPrivateKeys repair step rewrites them once.
+ */
+class PrivateKeyCipher {
+	private const PEM_PREFIX = '-----BEGIN';
+
+	private ICrypto $crypto;
+	private LoggerInterface $logger;
+
+	public function __construct(ICrypto $crypto, LoggerInterface $logger) {
+		$this->crypto = $crypto;
+		$this->logger = $logger;
+	}
+
+	/**
+	 * The value to store for a private key.
+	 */
+	public function seal(string $privateKey): string {
+		if ($privateKey === '') {
+			return '';
+		}
+
+		return $this->crypto->encrypt($privateKey);
+	}
+
+	/**
+	 * The private key held in a stored value — sealed, legacy plaintext or empty.
+	 * An undecryptable value (the instance secret changed) yields '' so signing
+	 * fails visibly instead of sending garbage signatures.
+	 */
+	public function open(string $stored): string {
+		if ($stored === '' || $this->isPlain($stored)) {
+			return $stored;
+		}
+
+		try {
+			return $this->crypto->decrypt($stored);
+		} catch (Exception $e) {
+			$this->logger->error('Social: cannot decrypt an actor private key', ['exception' => $e]);
+
+			return '';
+		}
+	}
+
+	public function isPlain(string $stored): bool {
+		return str_starts_with($stored, self::PEM_PREFIX);
+	}
+}

--- a/tests/Interfaces/Activity/MoveInterfaceTest.php
+++ b/tests/Interfaces/Activity/MoveInterfaceTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\Social\Tests\Interfaces\Activity;
 
 use OCA\Social\Db\ActionsRequest;
+use OCA\Social\Db\CacheActorsRequest;
 use OCA\Social\Db\CacheDocumentsRequest;
 use OCA\Social\Db\FollowsRequest;
 use OCA\Social\Db\StreamDestRequest;
@@ -30,11 +31,14 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 require_once __DIR__ . '/../ActivityPubTestCase.php';
 
+// see also PersonTest for the alsoKnownAs import/export round-trip
 class MoveInterfaceTest extends ActivityPubTestCase {
 	private const CAROL = 'https://other.example/users/carol';
 
 	/** @var ActionsRequest&MockObject */
 	private $actionsRequest;
+	/** @var CacheActorsRequest&MockObject */
+	private $cacheActorsRequest;
 	/** @var CacheDocumentsRequest&MockObject */
 	private $cacheDocumentsRequest;
 	/** @var FollowsRequest&MockObject */
@@ -54,6 +58,7 @@ class MoveInterfaceTest extends ActivityPubTestCase {
 		parent::setUp();
 
 		$this->actionsRequest = $this->createMock(ActionsRequest::class);
+		$this->cacheActorsRequest = $this->createMock(CacheActorsRequest::class);
 		$this->cacheDocumentsRequest = $this->createMock(CacheDocumentsRequest::class);
 		$this->followsRequest = $this->createMock(FollowsRequest::class);
 		$this->streamRequest = $this->createMock(StreamRequest::class);
@@ -62,6 +67,7 @@ class MoveInterfaceTest extends ActivityPubTestCase {
 
 		$this->handler = new MoveInterface(
 			$this->actionsRequest,
+			$this->cacheActorsRequest,
 			$this->cacheDocumentsRequest,
 			$this->followsRequest,
 			$this->streamRequest,
@@ -71,6 +77,7 @@ class MoveInterfaceTest extends ActivityPubTestCase {
 
 		$this->old = $this->person(self::REMOTE_URL . '/users/bob');
 		$this->new = $this->person('https://new.example/users/bob');
+		$this->new->setAlsoKnownAs([$this->old->getId()]);
 	}
 
 	private function dest(string $streamId, string $type = 'recipient', string $subtype = 'to'): StreamDest {
@@ -186,10 +193,10 @@ class MoveInterfaceTest extends ActivityPubTestCase {
 	}
 
 	public function testIncomingMoveOfAKnownActorIsAppliedToItsTarget(): void {
-		$this->cacheActorService->method('getFromAccount')
-			->willReturnCallback(function (string $account) {
-				return $account === $this->old->getId() ? $this->old : $this->new;
-			});
+		$this->cacheActorsRequest->method('getFromId')
+			->with($this->old->getId())->willReturn($this->old);
+		$this->cacheActorService->method('getFromId')
+			->with($this->new->getId(), true)->willReturn($this->new);
 		$this->streamDestRequest->method('getRelatedToActor')->willReturn([]);
 
 		$this->followsRequest->expects($this->once())
@@ -199,9 +206,10 @@ class MoveInterfaceTest extends ActivityPubTestCase {
 	}
 
 	public function testIncomingMoveOfAnUnknownActorIsIgnored(): void {
-		$this->cacheActorService->method('getFromAccount')
+		$this->cacheActorsRequest->method('getFromId')
 			->willThrowException(new CacheActorDoesNotExistException());
 
+		$this->cacheActorService->expects($this->never())->method('getFromId');
 		$this->actionsRequest->expects($this->never())->method('moveAccount');
 		$this->followsRequest->expects($this->never())->method('moveAccountFollowers');
 
@@ -209,7 +217,7 @@ class MoveInterfaceTest extends ActivityPubTestCase {
 	}
 
 	public function testIncomingMoveNotComingFromTheActorsOriginIsRefused(): void {
-		$this->cacheActorService->expects($this->never())->method('getFromAccount');
+		$this->cacheActorsRequest->expects($this->never())->method('getFromId');
 		$this->followsRequest->expects($this->never())->method('moveAccountFollowers');
 
 		$this->expectException(InvalidOriginException::class);
@@ -221,10 +229,43 @@ class MoveInterfaceTest extends ActivityPubTestCase {
 		$move = $this->move();
 		$move->setObjectId(self::CAROL);
 
-		$this->cacheActorService->expects($this->never())->method('getFromAccount');
+		$this->cacheActorsRequest->expects($this->never())->method('getFromId');
 
 		$this->expectException(InvalidOriginException::class);
 
 		$this->handler->processIncomingRequest($move);
+	}
+
+	public function testIncomingMoveIsRefusedWhenTheTargetDoesNotAcknowledgeTheActor(): void {
+		$this->new->setAlsoKnownAs(['https://new.example/users/someoneelse']);
+		$this->cacheActorsRequest->method('getFromId')->willReturn($this->old);
+		$this->cacheActorService->method('getFromId')->willReturn($this->new);
+
+		$this->actionsRequest->expects($this->never())->method('moveAccount');
+		$this->followsRequest->expects($this->never())->method('moveAccountFollowers');
+		$this->streamRequest->expects($this->never())->method('updateAuthor');
+
+		$this->expectException(InvalidOriginException::class);
+
+		$this->handler->processIncomingRequest($this->move());
+	}
+
+	public function testIncomingMoveIsRefusedWhenTheTargetHasNoAlsoKnownAs(): void {
+		$this->new->setAlsoKnownAs([]);
+		$this->cacheActorsRequest->method('getFromId')->willReturn($this->old);
+		$this->cacheActorService->method('getFromId')->willReturn($this->new);
+
+		$this->expectException(InvalidOriginException::class);
+
+		$this->handler->processIncomingRequest($this->move());
+	}
+
+	public function testTheTargetIsRefreshedSoTheGuardSeesACurrentAlsoKnownAs(): void {
+		$this->cacheActorsRequest->method('getFromId')->willReturn($this->old);
+		$this->cacheActorService->expects($this->once())
+			->method('getFromId')->with($this->new->getId(), true)->willReturn($this->new);
+		$this->streamDestRequest->method('getRelatedToActor')->willReturn([]);
+
+		$this->handler->processIncomingRequest($this->move());
 	}
 }

--- a/tests/Model/ActivityPub/Actor/PersonTest.php
+++ b/tests/Model/ActivityPub/Actor/PersonTest.php
@@ -78,6 +78,37 @@ class PersonTest extends TestCase {
 		$this->assertSame('Person', (new Person())->getType());
 	}
 
+	public function testImportReadsAlsoKnownAs(): void {
+		$person = new Person();
+		$actor = $this->mastodonActor();
+		$actor['alsoKnownAs'] = ['https://old.example/users/alice', 42, ['nested']];
+
+		$person->import($actor);
+
+		$this->assertSame(['https://old.example/users/alice'], $person->getAlsoKnownAs(), 'non-strings are dropped');
+	}
+
+	public function testAlsoKnownAsSurvivesTheActorCache(): void {
+		$person = new Person();
+
+		$person->importFromDatabase([
+			'id' => 'https://mastodon.social/users/alice',
+			'source' => '{"alsoKnownAs":["https://old.example/users/alice"]}',
+		]);
+
+		$this->assertSame(['https://old.example/users/alice'], $person->getAlsoKnownAs());
+	}
+
+	public function testAlsoKnownAsIsExportedOnlyWhenSet(): void {
+		$person = new Person();
+		$person->setUrlSocial('https://cloud.example.org/apps/social/');
+
+		$this->assertArrayNotHasKey('alsoKnownAs', $person->exportAsActivityPub());
+
+		$person->setAlsoKnownAs(['https://old.example/users/alice']);
+		$this->assertSame(['https://old.example/users/alice'], $person->exportAsActivityPub()['alsoKnownAs']);
+	}
+
 	public function testImportReadsAMastodonActorDocument(): void {
 		$person = new Person();
 

--- a/tests/Security/PrivateKeyCipherTest.php
+++ b/tests/Security/PrivateKeyCipherTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Security;
+
+use Exception;
+use OCA\Social\Security\PrivateKeyCipher;
+use OCP\Security\ICrypto;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class PrivateKeyCipherTest extends TestCase {
+	private const PEM = "-----BEGIN PRIVATE KEY-----\nMIIEvT...\n-----END PRIVATE KEY-----\n";
+
+	/** @var ICrypto&MockObject */
+	private $crypto;
+	private PrivateKeyCipher $cipher;
+
+	protected function setUp(): void {
+		$this->crypto = $this->createMock(ICrypto::class);
+		$this->crypto->method('encrypt')->willReturnCallback(fn (string $m): string => 'sealed(' . $m . ')');
+		$this->crypto->method('decrypt')->willReturnCallback(function (string $c): string {
+			if (!preg_match('/^sealed\((.*)\)$/s', $c, $m)) {
+				throw new Exception('HMAC does not match');
+			}
+
+			return $m[1];
+		});
+
+		$this->cipher = new PrivateKeyCipher($this->crypto, new NullLogger());
+	}
+
+	public function testAKeyRoundTrips(): void {
+		$stored = $this->cipher->seal(self::PEM);
+
+		$this->assertSame('sealed(' . self::PEM . ')', $stored, 'the stored value goes through ICrypto');
+		$this->assertSame(self::PEM, $this->cipher->open($stored));
+	}
+
+	public function testAnEmptyKeyStaysEmpty(): void {
+		$this->assertSame('', $this->cipher->seal(''));
+		$this->assertSame('', $this->cipher->open(''));
+	}
+
+	public function testALegacyPlaintextKeyIsStillReadable(): void {
+		$this->crypto->expects($this->never())->method('decrypt');
+
+		$this->assertSame(self::PEM, $this->cipher->open(self::PEM));
+	}
+
+	public function testAnUndecryptableValueYieldsAnEmptyKey(): void {
+		$this->assertSame('', $this->cipher->open('not-something-we-sealed'));
+	}
+
+	public function testIsPlainRecognisesAPem(): void {
+		$this->assertTrue($this->cipher->isPlain(self::PEM));
+		$this->assertFalse($this->cipher->isPlain($this->cipher->seal(self::PEM)));
+		$this->assertFalse($this->cipher->isPlain(''));
+	}
+}


### PR DESCRIPTION
* Resolves: # <!-- security review follow-up: the two items deferred from the private batch -->
* Target version: master

### Summary

The two remaining items from the security review that #2030 deferred. Backend only; `docs/Architecture.md` updated in the same change.

**`Move` now requires the target's `alsoKnownAs` to acknowledge the moving actor.** The HTTP signature only proves a Move comes from the *moving* actor's server — nothing bound the *target*. The handler now refreshes the target actor from its server and refuses the Move unless its `alsoKnownAs` lists the moving actor (the same rule Mastodon enforces); otherwise re-pointing followers and re-attributing posts at an arbitrary account is one signed activity away. `Person` gains the `alsoKnownAs` field (imported from actor documents, preserved through the actor cache's `source`, exported for local actors).

The handler had also been unreachable since it was written: it resolved actor *URLs* through `getFromAccount()` (which expects `user@host`) and caught an exception type that call never throws. That lookup is fixed in the same commit, deliberately together with the guard — fixing the lookup alone would have armed the vulnerability.

**Actor private keys are now encrypted at rest.** `social_actor.private_key` held the bare PEM; one database read allowed impersonating every local actor to the whole Fediverse, permanently (there is no key rotation). Keys are now encrypted with the instance secret via `ICrypto` (new `PrivateKeyCipher`), raising that to database **plus** `config.php`. Both directions live at the single DB boundary (`ActorsRequest`/`ActorsRequestBuilder`), so no consumer changes. Legacy plaintext rows (recognised by the PEM prefix) stay readable and are rewritten once by the `EncryptPrivateKeys` repair step; an undecryptable value (changed secret) yields an empty key so signing fails visibly.

### Tests

`composer run test:unit` → **1540 tests / 5086 assertions**, php-cs-fixer clean. New: `PrivateKeyCipherTest`, the Move-guard cases in `MoveInterfaceTest`, and the `alsoKnownAs` round-trip in `PersonTest` — the guard tests fail against the previous handler.

### Notes for review

- The app version is **not** bumped here; the repair step runs at the next version bump (or `occ maintenance:repair`). If #2035 (0.11.0) merges first, that bump covers it — otherwise flag it and I'll add one.
- `refreshKeys()` also seals; it is currently dormant (key rotation has no scheduled caller).
- The DB write/read paths themselves are covered by review rather than unit tests (they need a live query builder); the cipher, the model round-trip and the guard are covered by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
