### PR TITLE
fix: fresh-instance timelines and version-independent SSRF classification

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@ What it does:
 - 🔎 Find accounts and hashtags via WebFinger and search
 - 🌐 Federation: signed delivery of ActivityPub activities, with a delivery queue processed by cron
 
-This is a partial implementation of ActivityPub and of the Mastodon client API. Blocking and muting are supported. It does not offer reporting, approvable follow requests, polls, bookmarks, lists, or video and audio attachments.]]></description>
+This is a partial implementation of ActivityPub and of the Mastodon client API. Blocking and muting are supported. It does not offer reporting, approvable follow requests, polls, lists, or video and audio attachments.]]></description>
 	<version>0.11.2</version>
 	<licence>agpl</licence>
 	<author mail="benedikt.schaechner@web.de" homepage="https://benedikt.xn--schchner-2za.de">Benedikt Schächner</author>

--- a/lib/Db/SocialCrossQueryBuilder.php
+++ b/lib/Db/SocialCrossQueryBuilder.php
@@ -17,6 +17,7 @@ use OCA\Social\Model\ActivityPub\Object\Document;
 use OCA\Social\Model\ActivityPub\Object\Image;
 use OCA\Social\Model\ActivityPub\Stream;
 use OCP\DB\QueryBuilder\ICompositeExpression;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 
 /**
  * Class SocialCrossQueryBuilder
@@ -39,6 +40,32 @@ class SocialCrossQueryBuilder extends SocialCoreQueryBuilder {
 		if ($aliasFollowing !== '') {
 			$this->from(CoreRequestBuilder::TABLE_FOLLOWS, $aliasFollowing);
 		}
+	}
+
+	/**
+	 * The viewer's accepted follows as a LEFT JOIN. A plain `FROM social_follow`
+	 * next to the stream table is a cartesian product: with an *empty* follow
+	 * table it collapses every row — so on a fresh instance even the public and
+	 * hashtag timelines came back empty until somebody followed someone. Bound
+	 * as a join, an OR-branch that does not use the follows (public, DM) is
+	 * unaffected by whether any exist.
+	 */
+	public function leftJoinFollowing(string $alias = 'f'): void {
+		if ($this->getType() !== QueryBuilder::SELECT || !$this->hasViewer()) {
+			return;
+		}
+
+		$expr = $this->expr();
+		$this->leftJoin(
+			$this->getDefaultSelectAlias(), CoreRequestBuilder::TABLE_FOLLOWS, $alias,
+			$expr->andX(
+				$expr->eq(
+					$alias . '.actor_id_prim',
+					$this->createNamedParameter($this->prim($this->getViewer()->getId()))
+				),
+				$expr->eq($alias . '.accepted', $this->createNamedParameter(1, IQueryBuilder::PARAM_INT))
+			)
+		);
 	}
 
 

--- a/lib/Db/SocialLimitsQueryBuilder.php
+++ b/lib/Db/SocialLimitsQueryBuilder.php
@@ -429,7 +429,8 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 			return;
 		}
 
-		$this->selectDestFollowing($aliasDest, $aliasFollowing);
+		$this->selectDestFollowing($aliasDest, '');
+		$this->leftJoinFollowing($aliasFollowing);
 		$expr = $this->expr();
 		$actor = $this->getViewer();
 

--- a/lib/Tools/RemoteAddress.php
+++ b/lib/Tools/RemoteAddress.php
@@ -31,6 +31,20 @@ final class RemoteAddress {
 			return false;
 		}
 
+		// An IPv6 address that only wraps an IPv4 one is classified by the
+		// address it wraps: IPv4-mapped (::ffff:a.b.c.d — PHP's range flags
+		// only learned these in later PHP versions, so never rely on them)
+		// and NAT64 (64:ff9b::/96, delivered to the embedded address by a
+		// translating network).
+		$packed = inet_pton($ip);
+		if ($packed !== false && strlen($packed) === 16) {
+			$hex = bin2hex($packed);
+			if (str_starts_with($hex, '00000000000000000000ffff')
+				|| str_starts_with($hex, '0064ff9b0000000000000000')) {
+				return self::isLocalIp(inet_ntop(substr($packed, 12)));
+			}
+		}
+
 		// A public address survives both flags; anything private or reserved
 		// (10/8, 172.16/12, 192.168/16, 127/8, 169.254/16, ::1, fc00::/7, fe80::/10,
 		// 0/8, 240/4, …) is filtered out and returns false here.
@@ -41,14 +55,6 @@ final class RemoteAddress {
 		// Multicast is not covered by the reserved-range flag; reject it too.
 		if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false) {
 			return (int)explode('.', $ip)[0] >= 224;
-		}
-
-		// NAT64 (64:ff9b::/96) embeds an IPv4 address that a translating
-		// network delivers to; classify by the embedded address.
-		$packed = inet_pton($ip);
-		if ($packed !== false && strlen($packed) === 16
-			&& str_starts_with(bin2hex($packed), '0064ff9b0000000000000000')) {
-			return self::isLocalIp(inet_ntop(substr($packed, 12)));
 		}
 
 		return str_starts_with(strtolower($ip), 'ff');


### PR DESCRIPTION
* Resolves: # <!-- follow-up to #2042: the two defects its full-matrix run caught -->
* Target version: master

### Summary

#2042's second CI run — fresh database, full PHP matrix — caught two more shipped defects that the devel validation (populated DB, PHP 8.5) could not show. This fixes both; the tests that caught them are already on master.

**Fresh-instance timelines were empty.** `limitToViewer()` added `social_follow` as a plain `FROM` — a cartesian product. With an *empty* follow table that collapses every row, so on a brand-new instance the public, hashtag and federated timelines returned nothing for anyone until the first follow existed; on populated instances it silently multiplied rows behind `filterDuplicate()`. The viewer's accepted follows are now a LEFT JOIN bound to the viewer, so the public/DM OR-branches no longer depend on the table having rows. (This is very plausibly the root cause of the long-standing "timeline is empty on new installs" class of reports.)

**The SSRF classifier had a PHP 8.1 bypass.** `RemoteAddress` relied on PHP's filter range-flags to catch IPv4-mapped IPv6 literals (`::ffff:127.0.0.1`); PHP 8.1 doesn't know them, so on 8.1 installs a mapped loopback literal classified as public. Mapped and NAT64 literals are now unmapped explicitly and classified by their embedded IPv4 address, independent of PHP version.

### Tests

No new tests needed — the ones that caught both are in master since #2042 (`TimelineSeedTest::testHashtagTimelineReturnsTaggedNotes` on an empty-follows DB; `RemoteAddressTest`'s v4-mapped cases on the PHP 8.1 leg). This PR makes them pass across the whole matrix. Unit 1650 / integration 43 green locally and on a live stable35 + MariaDB instance (populated-DB regression check for the join change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
