### PR TITLE
fix: webfinger without a resource parameter is a 400

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -264,6 +264,7 @@ The handler first checks `FediverseService::jailed()` and passes the previous re
 
 - The app's own subject gets an extra link added to the existing response, carrying `app`, `name` and `version` properties.
 - For a local actor it returns a JRD document whose `subject` is the requested resource, with aliases for the actor URL and the Nextcloud profile page, a `self` link of type `application/activity+json` pointing at the `/@{username}/` route, an `http://webfinger.net/rel/profile-page` link (`text/html`) to the Nextcloud profile page, and an `http://ostatus.org/schema/1.0/subscribe` link with a `template` of `<social url>ostatus/follow/?uri={uri}`.
+- A missing or empty `resource` parameter is an empty JRD with HTTP 400 (RFC 7033 makes the parameter mandatory).
 - Unknown or non-local subjects produce an empty JRD with HTTP 404 (or hand back to the previous handler when the actor lookup fails outright).
 
 The `nodeinfo` service returns a single link with rel `http://nodeinfo.diaspora.software/ns/schema/2.0` pointing at the app's `/.well-known/nodeinfo/2.0` route; `host-meta` returns XRD (`application/xrd+xml`) with an `lrdd` template pointing at the instance's WebFinger URL.

--- a/lib/WellKnown/WebfingerHandler.php
+++ b/lib/WellKnown/WebfingerHandler.php
@@ -97,6 +97,11 @@ class WebfingerHandler implements IHandler {
 	 */
 	public function handleWebfinger(IRequestContext $context, ?IResponse $previousResponse): ?IResponse {
 		$subject = $this->getSubjectFromRequest($context->getHttpRequest());
+		if ($subject === '') {
+			// RFC 7033, section 4.2: the resource parameter is required
+			return new JrdResponse('', Http::STATUS_BAD_REQUEST);
+		}
+
 		$subjectAcct = $subject;
 		if (str_starts_with($subject, 'acct:')) {
 			$subject = substr($subject, 5);
@@ -216,7 +221,7 @@ class WebfingerHandler implements IHandler {
 
 		// work around to extract resource:
 		// on some setup (i.e. tests) the data are not available from IRequest
-		parse_str(parse_url($request->getRequestUri(), PHP_URL_QUERY), $query);
+		parse_str((string)parse_url($request->getRequestUri(), PHP_URL_QUERY), $query);
 
 		return $query['resource'] ?? '';
 	}

--- a/tests/WellKnown/WebfingerHandlerTest.php
+++ b/tests/WellKnown/WebfingerHandlerTest.php
@@ -188,6 +188,27 @@ class WebfingerHandlerTest extends TestCase {
 		$this->assertSame('alice@cloud.example', $json['subject']);
 	}
 
+	public function testAMissingResourceParameterIsABadRequest(): void {
+		// RFC 7033, section 4.2: the resource parameter is required
+		$this->resource('');
+		$this->request->method('getRequestUri')->willReturn('/.well-known/webfinger');
+		$this->cacheActorService->expects($this->never())->method('getFromLocalAccount');
+
+		$response = $this->handler->handleWebfinger($this->context, null);
+
+		$this->assertInstanceOf(JrdResponse::class, $response);
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->toHttpResponse()->getStatus());
+	}
+
+	public function testAnEmptyRequestUriRaisesNoWarning(): void {
+		$this->resource('');
+		$this->request->method('getRequestUri')->willReturn('');
+
+		$response = $this->handler->handleWebfinger($this->context, null);
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->toHttpResponse()->getStatus());
+	}
+
 	public function testResourceIsReadFromTheRequestUriWhenParamsAreMissing(): void {
 		$this->resource('');
 		$this->request->method('getRequestUri')->willReturn('/.well-known/webfinger?resource=acct%3Aalice%40cloud.example&rel=self');


### PR DESCRIPTION
Fresh redo of the still-valid half of #1951 (the `getParam('resource')` fallback it also carried has since landed on master):

- A missing/empty `resource` on `.well-known/webfinger` now returns an empty JRD with **HTTP 400** — RFC 7033 §4.2 makes the parameter mandatory — instead of running an actor lookup on an empty string.
- The request-URI fallback no longer passes `null` to `parse_str()` when the URI has no query string (PHP 8.1+ deprecation).

Covered by two new unit tests (verified to fail without the fix); docs updated in the same change. Credit to @joshtrichards for the original patch (co-authored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)