### PR TITLE
fix: keep the Mastodon-compatible version string out of NodeInfo

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -39,7 +39,7 @@ Note that many `ApiController` endpoints are annotated `@PublicPage` but call `i
 
 | Method | Route | Auth | Parameters | Description |
 |--------|-------|------|------------|-------------|
-| GET | `/api/v1/instance/` | public, no-csrf | — | Local instance metadata from `InstanceService::getLocal()` (title, version, usage, registrations). Returned as-is, not wrapped. |
+| GET | `/api/v1/instance/` | public, no-csrf | — | Local instance metadata from `InstanceService::getLocal()` (title, version, usage, registrations). Returned as-is, not wrapped. The `version` field is Pleroma-style — `4.1.0 (compatible; Nextcloud Social <app version>)` — because clients gate features on it; NodeInfo keeps reporting the real app version. |
 | GET | `/api/v1/apps/verify_credentials` | public, no-csrf | — | `{"name", "website"}` of the client behind the bearer token; falls back to `{"name": "Nextcloud Social", "website": "https://github.com/nextcloud/social/"}` when no client is identified. |
 | GET | `/api/v1/custom_emojis` | public, no-csrf | — | **Not implemented.** Always returns an empty array `[]` with HTTP 200. |
 | GET | `/api/saved_searches/list.json` | public, no-csrf | — | **Not implemented.** Initialises the viewer, then always returns `[]`. |

--- a/lib/Model/Instance.php
+++ b/lib/Model/Instance.php
@@ -71,6 +71,16 @@ class Instance implements IQueryRow, JsonSerializable {
 	}
 
 	public function getVersion(): string {
+		return $this->version;
+	}
+
+	/**
+	 * The version advertised to Mastodon API clients, Pleroma-style: clients
+	 * gate features on the version, so a plain app version would make them
+	 * treat the API as ancient. Only the /api/v1/instance entity carries it —
+	 * NodeInfo keeps reporting the real app version.
+	 */
+	public function getCompatVersion(): string {
 		return '4.1.0 (compatible; Nextcloud Social ' . $this->version . ')';
 	}
 
@@ -267,7 +277,7 @@ class Instance implements IQueryRow, JsonSerializable {
 		$arr = [
 			'uri' => $this->getUri(),
 			'title' => $this->getTitle(),
-			'version' => $this->getVersion(),
+			'version' => $this->getCompatVersion(),
 			'short_description' => $this->getShortDescription(),
 			'description' => $this->getDescription(),
 			'email' => $this->getEmail(),

--- a/tests/Model/InstanceTest.php
+++ b/tests/Model/InstanceTest.php
@@ -71,7 +71,8 @@ class InstanceTest extends TestCase {
 		$this->assertSame([
 			'uri' => 'cloud.example.org',
 			'title' => 'Nextcloud Social',
-			'version' => '0.7.0',
+			// Pleroma-style: clients gate features on the advertised version
+			'version' => '4.1.0 (compatible; Nextcloud Social 0.7.0)',
 			'short_description' => 'short',
 			'description' => 'long',
 			'email' => 'admin@cloud.example.org',


### PR DESCRIPTION
Follow-up to #1616, which I merged with only the required DCO check and which turned the unit suite red: `Instance::getVersion()` returned the Pleroma-style string everywhere, leaking into NodeInfo's `software.version` and the `social_instance` writes, and breaking the pinned `InstanceTest`/`OAuthControllerTest` expectations.

- `getVersion()` is the raw app version again (NodeInfo, storage).
- New `getCompatVersion()` returns `4.1.0 (compatible; Nextcloud Social <version>)` and is used only in the `/api/v1/instance` entity, where clients gate features on it — the intent of #1616, scoped correctly.
- Entity expectation re-pinned; full unit suite green again (1717 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)