### PR TITLE
fix: escape post content before newline conversion, everywhere

### DIFF
--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -381,7 +381,7 @@ class ApiController extends Controller {
 			// Use the viewer that was already initialized
 			$actor = $this->accountService->getActorFromUserId($this->currentSession(), true);
 			$post = new Post($actor);
-			$post->setContent(nl2br($status->getStatus()));
+			$post->setContent($status->getStatus());
 			$post->setType($status->getVisibility());
 
 			if (!empty($status->getMediaIds())) {
@@ -452,7 +452,7 @@ class ApiController extends Controller {
 			$item = $this->postService->editPost(
 				$nid,
 				$actor,
-				nl2br($status->getStatus()),
+				$status->getStatus(),
 				$status->getSpoilerText() !== '' ? $status->getSpoilerText() : null,
 				$status->isSensitive()
 			);

--- a/lib/Service/PostService.php
+++ b/lib/Service/PostService.php
@@ -74,7 +74,7 @@ class PostService {
 		$this->streamService->assignItem($note, $actor, $post->getType());
 
 		$note->setAttributedTo($actor->getId());
-		$note->setContent(htmlentities($post->getContent(), ENT_QUOTES));
+		$note->setContent(nl2br(htmlentities($post->getContent(), ENT_QUOTES)));
 		$note->setAttachments($post->getMedias());
 		$note->setVisibility($post->getType());
 
@@ -101,7 +101,7 @@ class PostService {
 			throw new \Exception('Not authorized to edit this post');
 		}
 
-		$stream->setContent($content);
+		$stream->setContent(nl2br(htmlentities($content, ENT_QUOTES)));
 		if ($spoilerText !== null) {
 			$stream->setSpoilerText($spoilerText);
 		}

--- a/src/components/ProfileInfo.vue
+++ b/src/components/ProfileInfo.vue
@@ -241,7 +241,7 @@ export default {
 			}
 		},
 		followRemote() {
-			window.open(generateUrl('/apps/social/api/v1/ostatus/followRemote/' + encodeURI(this.localUid)), 'followRemote', 'width=433,height=600toolbar=no,menubar=no,scrollbars=yes,resizable=yes')
+			window.open(generateUrl('/apps/social/api/v1/ostatus/followRemote/' + encodeURI(this.localUid)), 'followRemote', 'width=433,height=600,toolbar=no,menubar=no,scrollbars=yes,resizable=yes')
 		},
 		async openFilePicker() {
 			if (this.$refs.bannerInput) {

--- a/tests/Controller/ApiControllerTest.php
+++ b/tests/Controller/ApiControllerTest.php
@@ -592,7 +592,7 @@ class ApiControllerTest extends TestCase {
 
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
 		$this->assertSame($item, $response->getData());
-		$this->assertSame("hello<br />\nworld", $created->getContent());
+		$this->assertSame("hello\nworld", $created->getContent(), 'the raw text; PostService escapes and converts newlines');
 		$this->assertSame('unlisted', $created->getType());
 		$this->assertSame('https://remote.example/notes/7', $created->getReplyTo());
 	}
@@ -634,7 +634,7 @@ class ApiControllerTest extends TestCase {
 		]);
 		$item = $this->createMock(Stream::class);
 		$this->postService->expects($this->once())->method('editPost')
-			->with(5, $this->isInstanceOf(Person::class), "edited<br />\ntext", 'cw', true)
+			->with(5, $this->isInstanceOf(Person::class), "edited\ntext", 'cw', true)
 			->willReturn($item);
 		$item->expects($this->once())->method('setExportFormat')->with(ACore::FORMAT_LOCAL);
 

--- a/tests/Service/PostServiceTest.php
+++ b/tests/Service/PostServiceTest.php
@@ -358,6 +358,19 @@ class PostServiceTest extends TestCase {
 	}
 
 
+	public function testCreatePostEscapesHtmlAndTurnsNewlinesIntoBreaks(): void {
+		$this->expectCreateActivity($note);
+
+		$this->service->createPost($this->post("line one\n<b>line two</b>"));
+
+		$this->assertSame(
+			"line one<br />\n&lt;b&gt;line two&lt;/b&gt;",
+			$note->getContent(),
+			'user text is escaped first, then newlines become <br />'
+		);
+	}
+
+
 	// editPost()
 
 	private function storedNote(string $attributedTo = self::ACTOR_ID): Note {
@@ -406,6 +419,21 @@ class PostServiceTest extends TestCase {
 		$this->assertSame(self::ACTOR_ID, $paths[0]->getUri());
 		$this->assertSame(InstancePath::TYPE_FOLLOWERS, $paths[0]->getType());
 		$this->assertSame(InstancePath::PRIORITY_LOW, $paths[0]->getPriority());
+	}
+
+	public function testEditPostEscapesHtmlAndTurnsNewlinesIntoBreaks(): void {
+		$stored = $this->storedNote();
+		$this->streamRequest->method('getStreamByNid')
+			->willReturnOnConsecutiveCalls($stored, $this->storedNote());
+		$this->activityService->method('updateActivity')->willReturn('token');
+
+		$this->service->editPost(7, $this->actor(), "line one\n<script>x()</script>");
+
+		$this->assertSame(
+			"line one<br />\n&lt;script&gt;x()&lt;/script&gt;",
+			$stored->getContent(),
+			'edited text goes through the same escaping as new posts'
+		);
 	}
 
 	public function testEditPostLeavesSpoilerAndSensitivityAloneWhenNotProvided(): void {


### PR DESCRIPTION
The follow-ups promised when closing #1148 and #1135, plus a real bug found while verifying:

- **API-posted statuses with newlines showed a literal `<br />`**: `ApiController` ran `nl2br()` *before* `PostService::createPost()` escaped the whole thing with `htmlentities()`. Reproduced over HTTP on devel (`line one&lt;br /&gt;`).
- **`editPost()` stored content without any escaping**, so an edit could store raw user HTML while a new post could not.
- Both fixed by moving content handling to one place: `PostService` escapes first, converts newlines after — identically for create and edit; the controller passes raw text. The app's own composer path gains newline support as a side effect (the live remainder of #1148).
- The missing comma in the `followRemote` `window.open()` feature string (salvaged from #1135, credit @mnd).

New unit tests pin the escape-then-convert order for create and edit (verified to fail without the fix); verified over HTTP on devel: `line one<br>\nline &lt;b&gt;two&lt;/b&gt;`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)