### PR TITLE
ci: reuse check back on ubuntu-latest

### DIFF
--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   reuse-compliance-check:
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
The `ubuntu-latest-low` runner label that came in with the #1980 template sync doesn't exist in this repository's runner pools — every `reuse.yml` run since that merge has been a startup failure with zero jobs. Back to `ubuntu-latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)