### PR TITLE
chore: apply nextcloud/coding-standard 1.5

### DIFF
--- a/lib/AP.php
+++ b/lib/AP.php
@@ -159,7 +159,6 @@ class AP {
 		}
 	}
 
-
 	public function getItemFromData(array $data, ?ACore $parent = null, int $level = 0): ACore {
 		if (++$level > self::REDUNDANCY_LIMIT) {
 			throw new RedundancyLimitException((string)$level);
@@ -335,64 +334,44 @@ class AP {
 		switch ($type) {
 			case Accept::TYPE:
 				return $this->acceptInterface;
-
 			case Add::TYPE:
 				return $this->addInterface;
-
 			case Announce::TYPE:
 				return $this->announceInterface;
-
 			case Block::TYPE:
 				return $this->blockInterface;
-
 			case Create::TYPE:
 				return $this->createInterface;
-
 			case Delete::TYPE:
 				return $this->deleteInterface;
-
 			case Document::TYPE:
 				return $this->documentInterface;
-
 			case Flag::TYPE:
 				return $this->flagInterface;
-
 			case Follow::TYPE:
 				return $this->followInterface;
-
 			case Image::TYPE:
 				return $this->imageInterface;
-
 			case Like::TYPE:
 				return $this->likeInterface;
-
 			case Move::TYPE:
 				return $this->moveInterface;
-
 			case Note::TYPE:
 				return $this->noteInterface;
-
 			case SocialAppNotification::TYPE:
 				return $this->notificationInterface;
-
 			case Person::TYPE:
 				return $this->personInterface;
-
 			case Reject::TYPE:
 				return $this->rejectInterface;
-
 			case Remove::TYPE:
 				return $this->removeInterface;
-
 			case Service::TYPE:
 				return $this->serviceInterface;
-
 			case Undo::TYPE:
 				return $this->undoInterface;
-
 			case Update::TYPE:
 				return $this->updateInterface;
-
 			default:
 				throw new ItemUnknownException();
 		}

--- a/lib/Command/CheckInstall.php
+++ b/lib/Command/CheckInstall.php
@@ -71,7 +71,6 @@ class CheckInstall extends Base {
 			->setDescription('Check the integrity of the installation');
 	}
 
-
 	/**
 	 * @throws Exception
 	 */
@@ -121,7 +120,6 @@ class CheckInstall extends Base {
 
 		return true;
 	}
-
 
 	/**
 	 * @param InputInterface $input

--- a/lib/Command/ExtendedBase.php
+++ b/lib/Command/ExtendedBase.php
@@ -35,7 +35,6 @@ class ExtendedBase extends Base {
 		$this->output->writeln('');
 	}
 
-
 	/**
 	 * @param Stream[] $streams
 	 */
@@ -90,7 +89,6 @@ class ExtendedBase extends Base {
 			);
 		}
 	}
-
 
 	/**
 	 * @param Stream $stream

--- a/lib/Command/Fediverse.php
+++ b/lib/Command/Fediverse.php
@@ -117,7 +117,6 @@ class Fediverse extends Base {
 		}
 	}
 
-
 	/**
 	 * @throws Exception
 	 */

--- a/lib/Command/NoteBoost.php
+++ b/lib/Command/NoteBoost.php
@@ -41,7 +41,6 @@ class NoteBoost extends Base {
 		$this->accountService = $accountService;
 	}
 
-
 	/**
 	 *
 	 */
@@ -53,7 +52,6 @@ class NoteBoost extends Base {
 			->addOption('unboost', '', InputOption::VALUE_NONE, 'Unboost')
 			->setDescription('Boost a note');
 	}
-
 
 	/**
 	 * @param InputInterface $input

--- a/lib/Command/NoteCreate.php
+++ b/lib/Command/NoteCreate.php
@@ -41,7 +41,6 @@ class NoteCreate extends Base {
 
 	private MiscService $miscService;
 
-
 	/**
 	 * NoteCreate constructor.
 	 *
@@ -65,7 +64,6 @@ class NoteCreate extends Base {
 		$this->configService = $configService;
 		$this->miscService = $miscService;
 	}
-
 
 	/**
 	 *
@@ -91,7 +89,6 @@ class NoteCreate extends Base {
 			->addArgument('content', InputArgument::REQUIRED, 'content of the post')
 			->setDescription('Create a new note');
 	}
-
 
 	/**
 	 * @param InputInterface $input

--- a/lib/Command/NoteLike.php
+++ b/lib/Command/NoteLike.php
@@ -34,7 +34,6 @@ class NoteLike extends Base {
 
 	private MiscService $miscService;
 
-
 	/**
 	 * NoteBoost constructor.
 	 *
@@ -55,7 +54,6 @@ class NoteLike extends Base {
 		$this->miscService = $miscService;
 	}
 
-
 	/**
 	 *
 	 */
@@ -67,7 +65,6 @@ class NoteLike extends Base {
 			->addOption('unlike', '', InputOption::VALUE_NONE, 'Unlike')
 			->setDescription('Like a note');
 	}
-
 
 	/**
 	 * @param InputInterface $input

--- a/lib/Command/QueueProcess.php
+++ b/lib/Command/QueueProcess.php
@@ -26,7 +26,6 @@ class QueueProcess extends Base {
 	private ConfigService $configService;
 	private MiscService $miscService;
 
-
 	/**
 	 * NoteCreate constructor.
 	 *
@@ -50,7 +49,6 @@ class QueueProcess extends Base {
 		$this->miscService = $miscService;
 	}
 
-
 	/**
 	 *
 	 */
@@ -59,7 +57,6 @@ class QueueProcess extends Base {
 		$this->setName('social:queue:process')
 			->setDescription('Process the request queue');
 	}
-
 
 	/**
 	 * @param InputInterface $input
@@ -74,7 +71,6 @@ class QueueProcess extends Base {
 
 		return 0;
 	}
-
 
 	/**
 	 * @param OutputInterface $output
@@ -105,7 +101,6 @@ class QueueProcess extends Base {
 
 		$output->writeLn('done');
 	}
-
 
 	private function processStreamQueue(OutputInterface $output) {
 		$total = 0;

--- a/lib/Command/QueueStatus.php
+++ b/lib/Command/QueueStatus.php
@@ -25,7 +25,6 @@ class QueueStatus extends Base {
 
 	private MiscService $miscService;
 
-
 	/**
 	 * NoteCreate constructor.
 	 *
@@ -43,7 +42,6 @@ class QueueStatus extends Base {
 		$this->miscService = $miscService;
 	}
 
-
 	/**
 	 *
 	 */
@@ -55,7 +53,6 @@ class QueueStatus extends Base {
 			)
 			->setDescription('Return status on the request queue');
 	}
-
 
 	/**
 	 * @param InputInterface $input

--- a/lib/Command/Reset.php
+++ b/lib/Command/Reset.php
@@ -30,7 +30,6 @@ class Reset extends Base {
 
 	private MiscService $miscService;
 
-
 	/**
 	 * CacheUpdate constructor.
 	 *
@@ -51,7 +50,6 @@ class Reset extends Base {
 		$this->miscService = $miscService;
 	}
 
-
 	/**
 	 *
 	 */
@@ -61,7 +59,6 @@ class Reset extends Base {
 			->addOption('uninstall', '', InputOption::VALUE_NONE, 'full removing of the app')
 			->setDescription('Reset ALL data related to the Social App');
 	}
-
 
 	/**
 	 * @param InputInterface $input
@@ -91,7 +88,6 @@ class Reset extends Base {
 			return 0;
 		}
 
-
 		if ($input->getOption('uninstall')) {
 			try {
 				$output->writeln('');
@@ -104,7 +100,6 @@ class Reset extends Base {
 
 			return 0;
 		}
-
 
 		$output->writeln('');
 		$output->write('flushing data... ');
@@ -140,7 +135,6 @@ class Reset extends Base {
 
 		return 0;
 	}
-
 
 	/**
 	 * @param OutputInterface $output

--- a/lib/Command/StreamDetails.php
+++ b/lib/Command/StreamDetails.php
@@ -33,7 +33,6 @@ class StreamDetails extends ExtendedBase {
 
 	private MiscService $miscService;
 
-
 	/**
 	 * StreamDetails constructor.
 	 *
@@ -51,7 +50,6 @@ class StreamDetails extends ExtendedBase {
 		$this->miscService = $miscService;
 	}
 
-
 	/**
 	 *
 	 */
@@ -62,7 +60,6 @@ class StreamDetails extends ExtendedBase {
 			->addOption('json', '', InputOption::VALUE_NONE, 'return JSON format')
 			->setDescription('Get details about a Stream item');
 	}
-
 
 	/**
 	 * @param InputInterface $input

--- a/lib/Command/Timeline.php
+++ b/lib/Command/Timeline.php
@@ -37,7 +37,6 @@ class Timeline extends ExtendedBase {
 
 	private ?int $count = null;
 
-
 	/**
 	 * Timeline constructor.
 	 *
@@ -62,7 +61,6 @@ class Timeline extends ExtendedBase {
 		$this->configService = $configService;
 	}
 
-
 	/**
 	 *
 	 */
@@ -80,7 +78,6 @@ class Timeline extends ExtendedBase {
 			->addOption('crop', '', InputOption::VALUE_REQUIRED, 'crop', 0)
 			->setDescription('Get stream by timeline and viewer');
 	}
-
 
 	/**
 	 * @param InputInterface $input

--- a/lib/Controller/ActivityPubController.php
+++ b/lib/Controller/ActivityPubController.php
@@ -100,7 +100,6 @@ class ActivityPubController extends Controller {
 		});
 	}
 
-
 	/**
 	 * returns information about an Actor, based on the username.
 	 *
@@ -133,7 +132,6 @@ class ActivityPubController extends Controller {
 		}
 	}
 
-
 	/**
 	 * Alias to the actor() method.
 	 *
@@ -152,7 +150,6 @@ class ActivityPubController extends Controller {
 	public function actorAlias(string $username): Response {
 		return $this->actor($username);
 	}
-
 
 	/**
 	 * Shared inbox — receives incoming ActivityPub activities from remote servers.
@@ -202,7 +199,6 @@ class ActivityPubController extends Controller {
 		}
 	}
 
-
 	/**
 	 * User-specific inbox — receives incoming ActivityPub activities for a specific user.
 	 *
@@ -246,7 +242,6 @@ class ActivityPubController extends Controller {
 		}
 	}
 
-
 	/**
 	 * Method is called when a remote ActivityPub server wants to GET in the INBOX of a USER
 	 * Checking that the user exists, and that the header is properly signed.
@@ -272,7 +267,6 @@ class ActivityPubController extends Controller {
 		}
 	}
 
-
 	/**
 	 * Outbox. does nothing.
 	 *
@@ -296,7 +290,6 @@ class ActivityPubController extends Controller {
 			return $this->fail($e);
 		}
 	}
-
 
 	/**
 	 * followers. does nothing.
@@ -324,7 +317,6 @@ class ActivityPubController extends Controller {
 		}
 	}
 
-
 	/**
 	 * following. does nothing.
 	 *
@@ -350,7 +342,6 @@ class ActivityPubController extends Controller {
 			return $this->fail($e);
 		}
 	}
-
 
 	/**
 	 * should return data about a post. do nothing.
@@ -413,7 +404,6 @@ class ActivityPubController extends Controller {
 		return new TemplateResponse(Application::APP_ID, 'main', []);
 	}
 
-
 	/**
 	 * @param string $username
 	 * @param string $token
@@ -464,7 +454,6 @@ class ActivityPubController extends Controller {
 
 		return false;
 	}
-
 
 	private function trimHeader(string $header) {
 		$header = trim($header);

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -135,7 +135,6 @@ class ApiController extends Controller {
 		}
 	}
 
-
 	/**
 	 * @NoCSRFRequired
 	 * @PublicPage
@@ -166,7 +165,6 @@ class ApiController extends Controller {
 		}
 	}
 
-
 	/**
 	 * @NoCSRFRequired
 	 * @PublicPage
@@ -182,7 +180,6 @@ class ApiController extends Controller {
 			return $this->error($e->getMessage());
 		}
 	}
-
 
 	/**
 	 * Minimal Mastodon-style profile update: only `locked` (manually approve
@@ -213,7 +210,6 @@ class ApiController extends Controller {
 		}
 	}
 
-
 	/**
 	 * The accounts waiting for the viewer's approval to follow them.
 	 *
@@ -235,7 +231,6 @@ class ApiController extends Controller {
 		}
 	}
 
-
 	/**
 	 * @NoCSRFRequired
 	 * @PublicPage
@@ -244,7 +239,6 @@ class ApiController extends Controller {
 		return $this->followRequestAction($id, true);
 	}
 
-
 	/**
 	 * @NoCSRFRequired
 	 * @PublicPage
@@ -252,7 +246,6 @@ class ApiController extends Controller {
 	public function followRequestReject(string $id): DataResponse {
 		return $this->followRequestAction($id, false);
 	}
-
 
 	private function followRequestAction(string $id, bool $authorize): DataResponse {
 		try {
@@ -274,7 +267,6 @@ class ApiController extends Controller {
 			return $this->error($e->getMessage());
 		}
 	}
-
 
 	/**
 	 * Files a moderation report about an account (and optionally some of its
@@ -319,7 +311,6 @@ class ApiController extends Controller {
 		}
 	}
 
-
 	/**
 	 * @NoCSRFRequired
 	 * @PublicPage
@@ -329,7 +320,6 @@ class ApiController extends Controller {
 	public function customEmojis(): DataResponse {
 		return new DataResponse([], Http::STATUS_OK);
 	}
-
 
 	/**
 	 * @NoCSRFRequired
@@ -347,7 +337,6 @@ class ApiController extends Controller {
 		}
 	}
 
-
 	/**
 	 * @NoCSRFRequired
 	 * @PublicPage
@@ -360,7 +349,6 @@ class ApiController extends Controller {
 
 		return new DataResponse($local, Http::STATUS_OK);
 	}
-
 
 	/**
 	 * @PublicPage
@@ -430,7 +418,6 @@ class ApiController extends Controller {
 		}
 	}
 
-
 	/**
 	 * @PublicPage
 	 * @NoCSRFRequired
@@ -467,7 +454,6 @@ class ApiController extends Controller {
 			return new DataResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
 		}
 	}
-
 
 	/**
 	 * @PublicPage
@@ -523,7 +509,6 @@ class ApiController extends Controller {
 		}
 	}
 
-
 	/**
 	 * Same upload as mediaNew — modern Mastodon clients POST /api/v2/media and
 	 * only fall back to v1 on a 404.
@@ -534,7 +519,6 @@ class ApiController extends Controller {
 	public function mediaNewV2(): DataResponse {
 		return $this->mediaNew();
 	}
-
 
 	/**
 	 * One of the viewer's own attachments, by the id mediaNew returned.
@@ -555,7 +539,6 @@ class ApiController extends Controller {
 			return new DataResponse(['error' => $e->getMessage()], Http::STATUS_UNAUTHORIZED);
 		}
 	}
-
 
 	/**
 	 * Updates the alt text of the viewer's own attachment.
@@ -585,7 +568,6 @@ class ApiController extends Controller {
 			return new DataResponse(['error' => $e->getMessage()], Http::STATUS_UNAUTHORIZED);
 		}
 	}
-
 
 	/**
 	 * @throws NotFoundException when the id is unknown or belongs to someone else
@@ -717,7 +699,6 @@ class ApiController extends Controller {
 		}
 	}
 
-
 	/**
 	 * @NoCSRFRequired
 	 * @PublicPage
@@ -738,7 +719,6 @@ class ApiController extends Controller {
 			return $this->error($e->getMessage());
 		}
 	}
-
 
 	/**
 	 * @NoCSRFRequired
@@ -785,7 +765,6 @@ class ApiController extends Controller {
 			return $this->error($e->getMessage());
 		}
 	}
-
 
 	/**
 	 * @PublicPage
@@ -960,7 +939,6 @@ class ApiController extends Controller {
 		}
 	}
 
-
 	/**
 	 * @NoCSRFRequired
 	 * @PublicPage
@@ -1006,7 +984,6 @@ class ApiController extends Controller {
 			return $this->error($e->getMessage());
 		}
 	}
-
 
 	/**
 	 * @NoCSRFRequired
@@ -1055,7 +1032,6 @@ class ApiController extends Controller {
 		}
 	}
 
-
 	/**
 	 * @NoCSRFRequired
 	 * @PublicPage
@@ -1092,7 +1068,6 @@ class ApiController extends Controller {
 		}
 	}
 
-
 	/**
 	 * @NoCSRFRequired
 	 * @PublicPage
@@ -1121,7 +1096,6 @@ class ApiController extends Controller {
 			return $this->error($e->getMessage());
 		}
 	}
-
 
 	/**
 	 * @NoCSRFRequired
@@ -1160,7 +1134,6 @@ class ApiController extends Controller {
 		}
 	}
 
-
 	/**
 	 * @NoCSRFRequired
 	 * @PublicPage
@@ -1197,7 +1170,6 @@ class ApiController extends Controller {
 			return $this->error($e->getMessage());
 		}
 	}
-
 
 	/**
 	 * @param string $url
@@ -1280,7 +1252,6 @@ class ApiController extends Controller {
 		return $actors;
 	}
 
-
 	/**
 	 *
 	 * @param bool $exception
@@ -1343,7 +1314,6 @@ class ApiController extends Controller {
 		return false;
 	}
 
-
 	private function convertInput(string $input): array {
 		$contentType = $this->request->getHeader('Content-Type');
 
@@ -1355,10 +1325,8 @@ class ApiController extends Controller {
 		switch ($contentType) {
 			case 'application/json':
 				return json_decode($input, true);
-
 			case 'application/x-www-form-urlencoded':
 				return $this->request->getParams();
-
 			default: // in case of no header ...
 				$result = json_decode($input, true);
 				if (is_array($result)) {
@@ -1368,7 +1336,6 @@ class ApiController extends Controller {
 				return $this->request->getParams();
 		}
 	}
-
 
 	/**
 	 * @return string
@@ -1398,7 +1365,6 @@ class ApiController extends Controller {
 
 		throw new AccountDoesNotExistException('userId not defined');
 	}
-
 
 	/**
 	 * The scope a bearer token needs for the current route. Everything defaults
@@ -1434,7 +1400,6 @@ class ApiController extends Controller {
 			);
 		}
 	}
-
 
 	/**
 	 * @param string $error

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -45,7 +45,6 @@ class ConfigController extends Controller {
 		return new DataResponse([]);
 	}
 
-
 	/**
 	 * Local Version+Setup Test
 	 *
@@ -67,7 +66,6 @@ class ConfigController extends Controller {
 			]
 		);
 	}
-
 
 	/**
 	 * Actor Test

--- a/lib/Controller/LocalController.php
+++ b/lib/Controller/LocalController.php
@@ -128,7 +128,6 @@ class LocalController extends Controller {
 		}
 	}
 
-
 	/**
 	 * Upload a banner/header image for the current user's profile.
 	 *
@@ -402,7 +401,6 @@ class LocalController extends Controller {
 		}
 	}
 
-
 	/**
 	 * Get replies about a post (limited to viewer rights).
 	 *
@@ -418,7 +416,6 @@ class LocalController extends Controller {
 			return $this->fail($e);
 		}
 	}
-
 
 	/**
 	 * Delete your own post.
@@ -448,7 +445,6 @@ class LocalController extends Controller {
 		}
 	}
 
-
 	/**
 	 * Create a new boost.
 	 *
@@ -470,7 +466,6 @@ class LocalController extends Controller {
 			return $this->fail($e);
 		}
 	}
-
 
 	/**
 	 * Delete a boost.
@@ -494,7 +489,6 @@ class LocalController extends Controller {
 		}
 	}
 
-
 	/**
 	 * Like a post.
 	 *
@@ -517,7 +511,6 @@ class LocalController extends Controller {
 		}
 	}
 
-
 	/**
 	 * Unlike a post.
 	 *
@@ -539,7 +532,6 @@ class LocalController extends Controller {
 			return $this->fail($e);
 		}
 	}
-
 
 	/**
 	 * @NoCSRFRequired
@@ -567,7 +559,6 @@ class LocalController extends Controller {
 		}
 	}
 
-
 	/**
 	 * @NoCSRFRequired
 	 * @NoAdminRequired
@@ -582,7 +573,6 @@ class LocalController extends Controller {
 			return $this->fail($e);
 		}
 	}
-
 
 	/**
 	 * @NoAdminRequired
@@ -608,7 +598,6 @@ class LocalController extends Controller {
 		}
 	}
 
-
 	/**
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
@@ -623,7 +612,6 @@ class LocalController extends Controller {
 			return $this->fail($e);
 		}
 	}
-
 
 	/**
 	 * Get timeline
@@ -653,7 +641,6 @@ class LocalController extends Controller {
 		}
 	}
 
-
 	/**
 	 * Get timeline
 	 *
@@ -669,7 +656,6 @@ class LocalController extends Controller {
 			return $this->fail($e);
 		}
 	}
-
 
 	/**
 	 * Get timeline
@@ -687,7 +673,6 @@ class LocalController extends Controller {
 		}
 	}
 
-
 	/**
 	 * Get liked post
 	 *
@@ -703,7 +688,6 @@ class LocalController extends Controller {
 			return $this->fail($e);
 		}
 	}
-
 
 	/**
 	 * @NoAdminRequired
@@ -723,7 +707,6 @@ class LocalController extends Controller {
 		}
 	}
 
-
 	/**
 	 * @NoAdminRequired
 	 */
@@ -741,7 +724,6 @@ class LocalController extends Controller {
 			return $this->fail($e);
 		}
 	}
-
 
 	/**
 	 * @NoAdminRequired
@@ -763,7 +745,6 @@ class LocalController extends Controller {
 		}
 	}
 
-
 	/**
 	 * @NoAdminRequired
 	 */
@@ -783,7 +764,6 @@ class LocalController extends Controller {
 		}
 	}
 
-
 	/**
 	 * @NoAdminRequired
 	 */
@@ -802,7 +782,6 @@ class LocalController extends Controller {
 			return $this->fail($e);
 		}
 	}
-
 
 	/**
 	 * @NoAdminRequired
@@ -839,7 +818,6 @@ class LocalController extends Controller {
 		}
 	}
 
-
 	/**
 	 * @NoAdminRequired
 	 * @PublicPage
@@ -856,7 +834,6 @@ class LocalController extends Controller {
 			return $this->fail($e);
 		}
 	}
-
 
 	/**
 	 * @NoAdminRequired
@@ -934,7 +911,6 @@ class LocalController extends Controller {
 		}
 	}
 
-
 	/**
 	 * @NoAdminRequired
 	 * @PublicPage
@@ -985,8 +961,8 @@ class LocalController extends Controller {
 				$mime = '';
 				$document = $this->documentService->getFromCache($avatar->getId(), $mime);
 
-				$response =
-					new FileDisplayResponse($document, Http::STATUS_OK, ['Content-Type' => $mime]);
+				$response
+					= new FileDisplayResponse($document, Http::STATUS_OK, ['Content-Type' => $mime]);
 				$response->cacheFor(86400);
 
 				return $response;
@@ -997,7 +973,6 @@ class LocalController extends Controller {
 			return $this->fail($e, [], Http::STATUS_NOT_FOUND, false);
 		}
 	}
-
 
 	/**
 	 * @NoCSRFRequired
@@ -1020,7 +995,6 @@ class LocalController extends Controller {
 			return $this->fail($e, [], Http::STATUS_NOT_FOUND, false);
 		}
 	}
-
 
 	/**
 	 * @NoAdminRequired
@@ -1054,7 +1028,6 @@ class LocalController extends Controller {
 		}
 	}
 
-
 	/**
 	 * @NoAdminRequired
 	 * @throws Exception
@@ -1085,7 +1058,6 @@ class LocalController extends Controller {
 		}
 	}
 
-
 	/**
 	 * TODO - remove this tag
 	 * @NoCSRFRequired
@@ -1104,7 +1076,6 @@ class LocalController extends Controller {
 
 		return $this->success($result);
 	}
-
 
 	/**
 	 * @NoAdminRequired
@@ -1125,7 +1096,6 @@ class LocalController extends Controller {
 			return $this->fail($e);
 		}
 	}
-
 
 	/**
 	 * @throws AccountDoesNotExistException

--- a/lib/Controller/NavigationController.php
+++ b/lib/Controller/NavigationController.php
@@ -87,7 +87,6 @@ class NavigationController extends Controller {
 		$this->logger = $logger;
 	}
 
-
 	/**
 	 * Display the navigation page of the Social app.
 	 *
@@ -199,8 +198,8 @@ class NavigationController extends Controller {
 	}
 
 	private function setupCloudAddress(): string {
-		$frontControllerActive =
-			($this->config->getSystemValue('htaccess.IgnoreFrontController', false) === true
+		$frontControllerActive
+			= ($this->config->getSystemValue('htaccess.IgnoreFrontController', false) === true
 			 || getenv('front_controller_active') === 'true');
 
 		$cloudAddress = rtrim($this->config->getSystemValue('overwrite.cli.url', ''), '/');
@@ -218,8 +217,8 @@ class NavigationController extends Controller {
 
 	private function getCliUrl() {
 		$url = rtrim($this->urlGenerator->getBaseUrl(), '/');
-		$frontControllerActive =
-			($this->config->getSystemValue('htaccess.IgnoreFrontController', false) === true
+		$frontControllerActive
+			= ($this->config->getSystemValue('htaccess.IgnoreFrontController', false) === true
 			 || getenv('front_controller_active') === 'true');
 		if (!$frontControllerActive) {
 			$url .= '/index.php';
@@ -227,7 +226,6 @@ class NavigationController extends Controller {
 
 		return $url;
 	}
-
 
 	/**
 	 * Display the navigation page of the Social app.
@@ -257,7 +255,6 @@ class NavigationController extends Controller {
 	public function account(string $path = ''): TemplateResponse {
 		return $this->navigate();
 	}
-
 
 	/**
 	 * @NoAdminRequired
@@ -316,7 +313,6 @@ class NavigationController extends Controller {
 		}
 	}
 
-
 	/**
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
@@ -335,7 +331,6 @@ class NavigationController extends Controller {
 			return $this->fail($e);
 		}
 	}
-
 
 	/**
 	 * @PublicPage

--- a/lib/Controller/OAuthController.php
+++ b/lib/Controller/OAuthController.php
@@ -64,7 +64,6 @@ class OAuthController extends Controller {
 
 	}
 
-
 	/**
 	 * @NoCSRFRequired
 	 * @PublicPage
@@ -100,7 +99,6 @@ class OAuthController extends Controller {
 
 		return new DataResponse($nodeInfo, Http::STATUS_OK);
 	}
-
 
 	/**
 	 * @NoCSRFRequired
@@ -142,7 +140,6 @@ class OAuthController extends Controller {
 		);
 	}
 
-
 	/**
 	 * @NoCSRFRequired
 	 * @NoAdminRequired
@@ -176,8 +173,8 @@ class OAuthController extends Controller {
 		$this->initialState->provideInitialState('appName', $client->getAppName());
 
 		return new TemplateResponse(Application::APP_ID, 'oauth2', [
-			'request' =>
-				[
+			'request'
+				=> [
 					'clientId' => $client_id,
 					'redirectUri' => $redirect_uri,
 					'responseType' => $response_type,
@@ -185,7 +182,6 @@ class OAuthController extends Controller {
 				]
 		]);
 	}
-
 
 	/**
 	 * @NoAdminRequired
@@ -235,7 +231,6 @@ class OAuthController extends Controller {
 			return new DataResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
 		}
 	}
-
 
 	/**
 	 * @NoCSRFRequired
@@ -309,7 +304,6 @@ class OAuthController extends Controller {
 			return $response;
 		}
 	}
-
 
 	/**
 	 * Token revocation (RFC 7009). Only the client the token was issued to may

--- a/lib/Controller/OStatusController.php
+++ b/lib/Controller/OStatusController.php
@@ -52,7 +52,6 @@ class OStatusController extends Controller {
 		$this->userSession = $userSession;
 	}
 
-
 	/**
 	 * @NoCSRFRequired
 	 * @NoAdminRequired
@@ -84,7 +83,6 @@ class OStatusController extends Controller {
 			return $this->fail($e);
 		}
 	}
-
 
 	/**
 	 * @NoCSRFRequired

--- a/lib/Controller/QueueController.php
+++ b/lib/Controller/QueueController.php
@@ -45,7 +45,6 @@ class QueueController extends Controller {
 		$this->miscService = $miscService;
 	}
 
-
 	/**
 	 * The whole worker's time budget. Whatever is left over stays STANDBY and is
 	 * delivered by the cron, so a post with many recipient inboxes (or a slow

--- a/lib/Controller/SocialPubController.php
+++ b/lib/Controller/SocialPubController.php
@@ -65,7 +65,6 @@ class SocialPubController extends Controller {
 		$this->configService = $configService;
 	}
 
-
 	/**
 	 * @throws UrlCloudException
 	 * @throws SocialAppConfigException
@@ -96,7 +95,6 @@ class SocialPubController extends Controller {
 		return $page;
 	}
 
-
 	/**
 	 * Return webpage content for human navigation.
 	 * Should return information about a Social account, based on username.
@@ -111,7 +109,6 @@ class SocialPubController extends Controller {
 		return $this->renderPage($username);
 	}
 
-
 	/**
 	 * Return webpage content for human navigation.
 	 * Should return followers of a Social account, based on username.
@@ -125,7 +122,6 @@ class SocialPubController extends Controller {
 		return $this->renderPage($username);
 	}
 
-
 	/**
 	 * Return webpage content for human navigation.
 	 * Should return following of a Social account, based on username.
@@ -138,7 +134,6 @@ class SocialPubController extends Controller {
 	public function following(string $username): Response {
 		return $this->renderPage($username);
 	}
-
 
 	/**
 	 * Display the navigation page of the Social app.

--- a/lib/Dashboard/SocialWidget.php
+++ b/lib/Dashboard/SocialWidget.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/Db/ActionsRequest.php
+++ b/lib/Db/ActionsRequest.php
@@ -49,7 +49,6 @@ class ActionsRequest extends ActionsRequestBuilder {
 		$qb->executeStatement();
 	}
 
-
 	/**
 	 * @param string $actorId
 	 * @param string $objectId
@@ -68,7 +67,6 @@ class ActionsRequest extends ActionsRequestBuilder {
 		return $this->getActionFromRequest($qb);
 	}
 
-
 	/**
 	 * @param ACore $item
 	 *
@@ -84,7 +82,6 @@ class ActionsRequest extends ActionsRequestBuilder {
 
 		return $this->getActionFromRequest($qb);
 	}
-
 
 	/**
 	 * @param string $objectId
@@ -104,7 +101,6 @@ class ActionsRequest extends ActionsRequestBuilder {
 		return $this->getInt('count', $data, 0);
 	}
 
-
 	/**
 	 * @param string $objectId
 	 *
@@ -118,7 +114,6 @@ class ActionsRequest extends ActionsRequestBuilder {
 		return $this->getActionsFromRequest($qb);
 	}
 
-
 	/**
 	 * @param ACore $item
 	 */
@@ -130,14 +125,12 @@ class ActionsRequest extends ActionsRequestBuilder {
 		$qb->executeStatement();
 	}
 
-
 	public function deleteByActor(string $actorId): void {
 		$qb = $this->getActionsDeleteSql();
 		$qb->limitToDBField('actor_id_prim', $qb->prim($actorId));
 
 		$qb->executeStatement();
 	}
-
 
 	public function moveAccount(string $actorId, string $newId): void {
 		$qb = $this->getActionsUpdateSql();

--- a/lib/Db/ActionsRequestBuilder.php
+++ b/lib/Db/ActionsRequestBuilder.php
@@ -30,7 +30,6 @@ class ActionsRequestBuilder extends CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * Base of the Sql Update request
 	 */
@@ -40,7 +39,6 @@ class ActionsRequestBuilder extends CoreRequestBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * Base of the Sql Select request for Shares
@@ -58,7 +56,6 @@ class ActionsRequestBuilder extends CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * Base of the Sql Select request for Shares
 	 *
@@ -75,7 +72,6 @@ class ActionsRequestBuilder extends CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * Base of the Sql Delete request
 	 *
@@ -88,7 +84,6 @@ class ActionsRequestBuilder extends CoreRequestBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * @param SocialQueryBuilder $qb
@@ -107,7 +102,6 @@ class ActionsRequestBuilder extends CoreRequestBuilder {
 		return $result;
 	}
 
-
 	/**
 	 * @param SocialQueryBuilder $qb
 	 *
@@ -119,7 +113,6 @@ class ActionsRequestBuilder extends CoreRequestBuilder {
 
 		return $result;
 	}
-
 
 	/**
 	 * @param array $data

--- a/lib/Db/ActorsRequest.php
+++ b/lib/Db/ActorsRequest.php
@@ -67,7 +67,6 @@ class ActorsRequest extends ActorsRequestBuilder {
 		$qb->executeStatement();
 	}
 
-
 	public function refreshKeys(Person $actor): void {
 		$qb = $this->getActorsUpdateSql();
 		$qb->set('public_key', $qb->createNamedParameter($actor->getPublicKey()))
@@ -85,7 +84,6 @@ class ActorsRequest extends ActorsRequestBuilder {
 
 		$qb->executeStatement();
 	}
-
 
 	/**
 	 * Return Actor from database based on the username
@@ -127,7 +125,6 @@ class ActorsRequest extends ActorsRequestBuilder {
 		return $this->parseActorsSelectSql($data);
 	}
 
-
 	/**
 	 * return Actor from database, based on the userId of the owner.
 	 *
@@ -152,7 +149,6 @@ class ActorsRequest extends ActorsRequestBuilder {
 		return $this->parseActorsSelectSql($data);
 	}
 
-
 	public function setAsDeleted(string $handle): void {
 		$qb = $this->getActorsUpdateSql();
 		$qb->set(
@@ -174,7 +170,6 @@ class ActorsRequest extends ActorsRequestBuilder {
 		$qb->executeStatement();
 	}
 
-
 	/**
 	 * @return Person[]
 	 * @throws SocialAppConfigException
@@ -191,7 +186,6 @@ class ActorsRequest extends ActorsRequestBuilder {
 
 		return $accounts;
 	}
-
 
 	/**
 	 * @return Person[]

--- a/lib/Db/ActorsRequestBuilder.php
+++ b/lib/Db/ActorsRequestBuilder.php
@@ -37,7 +37,6 @@ class ActorsRequestBuilder extends CoreRequestBuilder {
 		$this->keyCipher = $keyCipher;
 	}
 
-
 	/**
 	 * Base of the Sql Insert request
 	 *
@@ -50,7 +49,6 @@ class ActorsRequestBuilder extends CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * Base of the Sql Update request
 	 *
@@ -62,7 +60,6 @@ class ActorsRequestBuilder extends CoreRequestBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * Base of the Sql Select request for Shares
@@ -86,7 +83,6 @@ class ActorsRequestBuilder extends CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * Base of the Sql Delete request
 	 *
@@ -98,7 +94,6 @@ class ActorsRequestBuilder extends CoreRequestBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * @param array $data

--- a/lib/Db/CacheActorsRequest.php
+++ b/lib/Db/CacheActorsRequest.php
@@ -25,7 +25,6 @@ class CacheActorsRequest extends CacheActorsRequestBuilder {
 	public const SYNC_BATCH = 50;
 	public const DETAILS_TTL = 60 * 18; // 18h
 
-
 	/**
 	 * Insert cache about an Actor in database.
 	 */
@@ -83,7 +82,6 @@ class CacheActorsRequest extends CacheActorsRequestBuilder {
 		}
 	}
 
-
 	public function update(Person $actor): int {
 		$qb = $this->getCacheActorsUpdateSql();
 		$qb->set('following', $qb->createNamedParameter($actor->getFollowing()))
@@ -129,7 +127,6 @@ class CacheActorsRequest extends CacheActorsRequestBuilder {
 		return $qb->executeStatement();
 	}
 
-
 	public function updateDetails(Person $actor): int {
 		$qb = $this->getCacheActorsUpdateSql();
 		$qb->set('details', $qb->createNamedParameter(json_encode($actor->getDetailsAll())));
@@ -147,7 +144,6 @@ class CacheActorsRequest extends CacheActorsRequestBuilder {
 		return $qb->executeStatement();
 	}
 
-
 	/**
 	 * get Cached version of an Actor, based on the UriId
 	 *
@@ -163,7 +159,6 @@ class CacheActorsRequest extends CacheActorsRequestBuilder {
 
 		return $this->getCacheActorFromRequest($qb);
 	}
-
 
 	/**
 	 * get Cached version of an Actor, based on the Account
@@ -181,7 +176,6 @@ class CacheActorsRequest extends CacheActorsRequestBuilder {
 
 		return $this->getCacheActorFromRequest($qb);
 	}
-
 
 	/**
 	 * get Cached version of a local Actor, based on the preferred username
@@ -201,7 +195,6 @@ class CacheActorsRequest extends CacheActorsRequestBuilder {
 		return $this->getCacheActorFromRequest($qb);
 	}
 
-
 	/**
 	 * @param string $search
 	 *
@@ -216,7 +209,6 @@ class CacheActorsRequest extends CacheActorsRequestBuilder {
 
 		return $this->getCacheActorsFromRequest($qb);
 	}
-
 
 	/**
 	 * @return Person[]
@@ -234,7 +226,6 @@ class CacheActorsRequest extends CacheActorsRequestBuilder {
 
 		return $this->getCacheActorsFromRequest($qb);
 	}
-
 
 	/**
 	 * @return Person[]
@@ -264,7 +255,6 @@ class CacheActorsRequest extends CacheActorsRequestBuilder {
 		$qb->executeStatement();
 	}
 
-
 	/**
 	 * @return array
 	 */
@@ -281,7 +271,6 @@ class CacheActorsRequest extends CacheActorsRequestBuilder {
 
 		return $inbox;
 	}
-
 
 	/**
 	 * @param ProbeOptions $options
@@ -334,7 +323,6 @@ class CacheActorsRequest extends CacheActorsRequestBuilder {
 
 		return $this->getCacheActorsFromRequest($qb);
 	}
-
 
 	/**
 	 * @param ProbeOptions $options

--- a/lib/Db/CacheActorsRequestBuilder.php
+++ b/lib/Db/CacheActorsRequestBuilder.php
@@ -19,7 +19,6 @@ use OCA\Social\Tools\Traits\TArrayTools;
 class CacheActorsRequestBuilder extends CoreRequestBuilder {
 	use TArrayTools;
 
-
 	/**
 	 * Base of the Sql Insert request
 	 *
@@ -32,7 +31,6 @@ class CacheActorsRequestBuilder extends CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * Base of the Sql Update request
 	 *
@@ -44,7 +42,6 @@ class CacheActorsRequestBuilder extends CoreRequestBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * Base of the Sql Select request for Shares
@@ -72,7 +69,6 @@ class CacheActorsRequestBuilder extends CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * Base of the Sql Delete request
 	 *
@@ -84,7 +80,6 @@ class CacheActorsRequestBuilder extends CoreRequestBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * @param SocialQueryBuilder $qb
@@ -103,7 +98,6 @@ class CacheActorsRequestBuilder extends CoreRequestBuilder {
 		return $result;
 	}
 
-
 	/**
 	 * @param SocialQueryBuilder $qb
 	 *
@@ -115,7 +109,6 @@ class CacheActorsRequestBuilder extends CoreRequestBuilder {
 
 		return $result;
 	}
-
 
 	/**
 	 * @param array $data
@@ -142,7 +135,6 @@ class CacheActorsRequestBuilder extends CoreRequestBuilder {
 
 		return $actor;
 	}
-
 
 	/**
 	 * @param SocialQueryBuilder $qb

--- a/lib/Db/CacheDocumentsRequest.php
+++ b/lib/Db/CacheDocumentsRequest.php
@@ -54,7 +54,6 @@ class CacheDocumentsRequest extends CacheDocumentsRequestBuilder {
 		$document->setNid($qb->getLastInsertId());
 	}
 
-
 	/**
 	 * Insert cache about an Actor in database.
 	 */
@@ -85,7 +84,6 @@ class CacheDocumentsRequest extends CacheDocumentsRequestBuilder {
 		$qb->executeStatement();
 	}
 
-
 	/**
 	 * @throws \OCP\DB\Exception
 	 */
@@ -96,7 +94,6 @@ class CacheDocumentsRequest extends CacheDocumentsRequestBuilder {
 
 		$qb->executeStatement();
 	}
-
 
 	public function initCaching(Document $document): void {
 		$qb = $this->getCacheDocumentsUpdateSql();
@@ -112,7 +109,6 @@ class CacheDocumentsRequest extends CacheDocumentsRequestBuilder {
 		$qb->executeStatement();
 	}
 
-
 	/**
 	 * @throws \OCP\DB\Exception
 	 */
@@ -127,7 +123,6 @@ class CacheDocumentsRequest extends CacheDocumentsRequestBuilder {
 
 		$qb->executeStatement();
 	}
-
 
 	/**
 	 * @param string $url
@@ -155,7 +150,6 @@ class CacheDocumentsRequest extends CacheDocumentsRequestBuilder {
 		return $this->parseCacheDocumentsSelectSql($data);
 	}
 
-
 	public function getByUrl(string $url) {
 		$qb = $this->getCacheDocumentsSelectSql();
 		$this->limitToUrl($qb, $url);
@@ -170,7 +164,6 @@ class CacheDocumentsRequest extends CacheDocumentsRequestBuilder {
 
 		return $this->parseCacheDocumentsSelectSql($data);
 	}
-
 
 	/**
 	 * @param array $mediaIds
@@ -220,7 +213,6 @@ class CacheDocumentsRequest extends CacheDocumentsRequestBuilder {
 		return $this->parseCacheDocumentsSelectSql($data);
 	}
 
-
 	/**
 	 * @param Document $item
 	 *
@@ -237,7 +229,6 @@ class CacheDocumentsRequest extends CacheDocumentsRequestBuilder {
 
 		return ($data !== false);
 	}
-
 
 	/**
 	 * @return Document[]
@@ -259,7 +250,6 @@ class CacheDocumentsRequest extends CacheDocumentsRequestBuilder {
 		return $documents;
 	}
 
-
 	/**
 	 * @param string $url
 	 */
@@ -269,7 +259,6 @@ class CacheDocumentsRequest extends CacheDocumentsRequestBuilder {
 
 		$qb->executeStatement();
 	}
-
 
 	/**
 	 * @param string $id
@@ -287,7 +276,6 @@ class CacheDocumentsRequest extends CacheDocumentsRequestBuilder {
 
 		$qb->executeStatement();
 	}
-
 
 	public function moveAccount(string $actorId, string $newId): void {
 		$qb = $this->getCacheDocumentsUpdateSql();

--- a/lib/Db/CacheDocumentsRequestBuilder.php
+++ b/lib/Db/CacheDocumentsRequestBuilder.php
@@ -52,7 +52,6 @@ class CacheDocumentsRequestBuilder extends CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * Base of the Sql Delete request
 	 */

--- a/lib/Db/ClientRequest.php
+++ b/lib/Db/ClientRequest.php
@@ -52,7 +52,6 @@ class ClientRequest extends ClientRequestBuilder {
 		$client->setId($qb->getLastInsertId());
 	}
 
-
 	/**
 	 * @param SocialClient $client
 	 */
@@ -78,7 +77,6 @@ class ClientRequest extends ClientRequestBuilder {
 
 		$qb->executeStatement();
 	}
-
 
 	/**
 	 * @param SocialClient $client
@@ -106,7 +104,6 @@ class ClientRequest extends ClientRequestBuilder {
 		$qb->executeStatement();
 	}
 
-
 	/**
 	 * @param SocialClient $client
 	 */
@@ -122,7 +119,6 @@ class ClientRequest extends ClientRequestBuilder {
 		$qb->executeStatement();
 	}
 
-
 	/**
 	 * @param string $clientId
 	 *
@@ -135,7 +131,6 @@ class ClientRequest extends ClientRequestBuilder {
 
 		return $this->getClientFromRequest($qb);
 	}
-
 
 	/**
 	 * @param string $token
@@ -157,7 +152,6 @@ class ClientRequest extends ClientRequestBuilder {
 
 		throw new ClientNotFoundException();
 	}
-
 
 	/**
 	 * @throws Exception

--- a/lib/Db/ClientRequestBuilder.php
+++ b/lib/Db/ClientRequestBuilder.php
@@ -44,7 +44,6 @@ class ClientRequestBuilder extends CoreRequestBuilder {
 		$this->secretHasher = $secretHasher;
 	}
 
-
 	/**
 	 * Base of the Sql Insert request
 	 *
@@ -57,7 +56,6 @@ class ClientRequestBuilder extends CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * Base of the Sql Update request
 	 *
@@ -69,7 +67,6 @@ class ClientRequestBuilder extends CoreRequestBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * Base of the Sql Select request for Shares
@@ -93,7 +90,6 @@ class ClientRequestBuilder extends CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * Base of the Sql Delete request
 	 *
@@ -105,7 +101,6 @@ class ClientRequestBuilder extends CoreRequestBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * @param SocialQueryBuilder $qb
@@ -124,7 +119,6 @@ class ClientRequestBuilder extends CoreRequestBuilder {
 		return $result;
 	}
 
-
 	/**
 	 * @param SocialQueryBuilder $qb
 	 *
@@ -136,7 +130,6 @@ class ClientRequestBuilder extends CoreRequestBuilder {
 
 		return $result;
 	}
-
 
 	/**
 	 * @param array $data

--- a/lib/Db/CoreRequestBuilder.php
+++ b/lib/Db/CoreRequestBuilder.php
@@ -277,7 +277,6 @@ class CoreRequestBuilder {
 		$this->miscService = $miscService;
 	}
 
-
 	/**
 	 * @return SocialQueryBuilder
 	 */
@@ -296,7 +295,6 @@ class CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * @return IDBConnection
 	 */
@@ -304,14 +302,12 @@ class CoreRequestBuilder {
 		return $this->dbConnection;
 	}
 
-
 	/**
 	 * @param Person $viewer
 	 */
 	public function setViewer(Person $viewer) {
 		$this->viewer = $viewer;
 	}
-
 
 	/**
 	 * Limit the request to the Id
@@ -324,7 +320,6 @@ class CoreRequestBuilder {
 	protected function limitToId(IQueryBuilder &$qb, int $id) {
 		$this->limitToDBFieldInt($qb, 'id', $id);
 	}
-
 
 	/**
 	 * Limit the request to the Id (string)
@@ -339,7 +334,6 @@ class CoreRequestBuilder {
 		$this->limitToDBField($qb, 'id', $id, false);
 	}
 
-
 	/**
 	 * Limit the request to the UserId
 	 *
@@ -353,7 +347,6 @@ class CoreRequestBuilder {
 		$this->limitToDBField($qb, 'user_id', $userId, false);
 	}
 
-
 	/**
 	 * Limit the request to the ActivityId
 	 *
@@ -363,7 +356,6 @@ class CoreRequestBuilder {
 	protected function limitToActivityId(IQueryBuilder &$qb, string $activityId) {
 		$this->limitToDBField($qb, 'activity_id', $activityId, false);
 	}
-
 
 	/**
 	 * Limit the request to the Id (string)
@@ -377,7 +369,6 @@ class CoreRequestBuilder {
 		$this->limitToDBField($qb, 'in_reply_to', $id, false);
 	}
 
-
 	/**
 	 * Limit the request to the StreamId
 	 *
@@ -387,7 +378,6 @@ class CoreRequestBuilder {
 	protected function limitToStreamId(IQueryBuilder &$qb, string $streamId) {
 		$this->limitToDBField($qb, 'stream_id', $streamId, false);
 	}
-
 
 	/**
 	 * Limit the request to the Type
@@ -399,7 +389,6 @@ class CoreRequestBuilder {
 		$this->limitToDBField($qb, 'type', $type);
 	}
 
-
 	/**
 	 * Limit the request to the sub-type
 	 *
@@ -410,7 +399,6 @@ class CoreRequestBuilder {
 		$this->limitToDBField($qb, 'subtype', $subType);
 	}
 
-
 	/**
 	 * @param IQueryBuilder $qb
 	 * @param string $type
@@ -418,7 +406,6 @@ class CoreRequestBuilder {
 	protected function filterType(IQueryBuilder $qb, string $type) {
 		$this->filterDBField($qb, 'type', $type);
 	}
-
 
 	/**
 	 * Limit the request to the Preferred Username
@@ -443,7 +430,6 @@ class CoreRequestBuilder {
 		);
 	}
 
-
 	/**
 	 * Limit the request to the ActorId
 	 *
@@ -452,7 +438,6 @@ class CoreRequestBuilder {
 	protected function limitToPublic(IQueryBuilder &$qb) {
 		$this->limitToDBFieldInt($qb, 'public', 1);
 	}
-
 
 	/**
 	 * Limit the request to the token
@@ -474,7 +459,6 @@ class CoreRequestBuilder {
 		$qb->setMaxResults($limit);
 	}
 
-
 	/**
 	 * Limit the request to the ActorId
 	 *
@@ -484,7 +468,6 @@ class CoreRequestBuilder {
 	protected function limitToHashtag(IQueryBuilder &$qb, string $hashtag) {
 		$this->limitToDBField($qb, 'hashtag', $hashtag, false);
 	}
-
 
 	/**
 	 * Limit the request to the ActorId
@@ -500,7 +483,6 @@ class CoreRequestBuilder {
 		);
 	}
 
-
 	/**
 	 * Limit the request to the ActorId
 	 *
@@ -512,7 +494,6 @@ class CoreRequestBuilder {
 		$this->limitToDBField($qb, 'actor_id', $actorId, false, $alias);
 	}
 
-
 	/**
 	 * Limit the request to the FollowId
 	 *
@@ -522,7 +503,6 @@ class CoreRequestBuilder {
 	protected function limitToFollowId(IQueryBuilder &$qb, string $followId) {
 		$this->limitToDBField($qb, 'follow_id', $followId, false);
 	}
-
 
 	/**
 	 * Limit the request to the FollowId
@@ -535,7 +515,6 @@ class CoreRequestBuilder {
 		$this->limitToDBField($qb, 'accepted', ($accepted) ? '1' : '0', true, $alias);
 	}
 
-
 	/**
 	 * Limit the request to the ServiceId
 	 *
@@ -545,7 +524,6 @@ class CoreRequestBuilder {
 	protected function limitToObjectId(IQueryBuilder &$qb, string $objectId) {
 		$this->limitToDBField($qb, 'object_id', $objectId, false);
 	}
-
 
 	/**
 	 * Limit the request to the account
@@ -557,7 +535,6 @@ class CoreRequestBuilder {
 		$this->limitToDBField($qb, 'account', $account, false);
 	}
 
-
 	/**
 	 * Limit the request to the account
 	 *
@@ -568,7 +545,6 @@ class CoreRequestBuilder {
 		$dbConn = $this->getConnection();
 		$this->searchInDBField($qb, 'account', $dbConn->escapeLikeParameter($account) . '%');
 	}
-
 
 	/**
 	 * Limit the request to the creation
@@ -585,7 +561,6 @@ class CoreRequestBuilder {
 		$this->limitToDBFieldDateTime($qb, 'creation', $date, true);
 	}
 
-
 	/**
 	 * Limit the request to the creation
 	 *
@@ -601,7 +576,6 @@ class CoreRequestBuilder {
 		$this->limitToDBFieldDateTime($qb, 'caching', $date, true);
 	}
 
-
 	/**
 	 * Limit the request to the url
 	 *
@@ -611,7 +585,6 @@ class CoreRequestBuilder {
 	protected function limitToUrl(IQueryBuilder &$qb, string $url) {
 		$this->limitToDBField($qb, 'url', $url);
 	}
-
 
 	/**
 	 * Limit the request to the url
@@ -623,7 +596,6 @@ class CoreRequestBuilder {
 		$this->limitToDBField($qb, 'attributed_to', $actorId, false);
 	}
 
-
 	/**
 	 * Limit the request to the status
 	 *
@@ -633,7 +605,6 @@ class CoreRequestBuilder {
 	protected function limitToStatus(IQueryBuilder &$qb, int $status) {
 		$this->limitToDBFieldInt($qb, 'status', $status);
 	}
-
 
 	/**
 	 * Limit the request to the instance
@@ -645,7 +616,6 @@ class CoreRequestBuilder {
 		$this->limitToDBField($qb, 'address', $address);
 	}
 
-
 	/**
 	 * Limit the request to the instance
 	 *
@@ -656,7 +626,6 @@ class CoreRequestBuilder {
 		$this->limitToDBField($qb, 'local', ($local) ? '1' : '0');
 	}
 
-
 	/**
 	 * Limit the request to the parent_id
 	 *
@@ -666,7 +635,6 @@ class CoreRequestBuilder {
 	protected function limitToParentId(IQueryBuilder &$qb, string $parentId) {
 		$this->limitToDBField($qb, 'parent_id', $parentId);
 	}
-
 
 	/**
 	 * @param IQueryBuilder $qb
@@ -762,10 +730,8 @@ class CoreRequestBuilder {
 		}
 		$field = $pf . $field;
 
-
 		return $expr->eq($field, $qb->createNamedParameter($value));
 	}
-
 
 	/**
 	 * @param IQueryBuilder $qb
@@ -778,7 +744,6 @@ class CoreRequestBuilder {
 
 		$qb->andWhere($expr->eq($field, $qb->createNamedParameter('')));
 	}
-
 
 	/**
 	 * @param IQueryBuilder $qb
@@ -805,7 +770,6 @@ class CoreRequestBuilder {
 		}
 		$qb->andWhere($orX);
 	}
-
 
 	/**
 	 * @param IQueryBuilder $qb
@@ -834,7 +798,6 @@ class CoreRequestBuilder {
 		$qb->andWhere($orX);
 	}
 
-
 	protected function limitToDBFieldArray(IQueryBuilder &$qb, string $field, array $values): void {
 		$expr = $qb->expr();
 		$pf = ($qb->getType() === QueryBuilder::SELECT) ? $this->defaultSelectAlias . '.' : '';
@@ -850,7 +813,6 @@ class CoreRequestBuilder {
 		$qb->andWhere($orX);
 	}
 
-
 	/**
 	 * @param IQueryBuilder $qb
 	 * @param string $field
@@ -864,7 +826,6 @@ class CoreRequestBuilder {
 
 		$qb->andWhere($expr->iLike($field, $qb->createNamedParameter($value)));
 	}
-
 
 	/**
 	 * @param IQueryBuilder $qb
@@ -927,7 +888,6 @@ class CoreRequestBuilder {
 		);
 	}
 
-
 	/**
 	 * @param IQueryBuilder $qb
 	 * @param string $fieldActorId
@@ -961,7 +921,6 @@ class CoreRequestBuilder {
 		);
 	}
 
-
 	/**
 	 * @param array $data
 	 *
@@ -985,7 +944,6 @@ class CoreRequestBuilder {
 
 		return $actor;
 	}
-
 
 	/**
 	 * @param SocialQueryBuilder $qb
@@ -1026,7 +984,6 @@ class CoreRequestBuilder {
 		);
 	}
 
-
 	/**
 	 * @param array $data
 	 *
@@ -1050,7 +1007,6 @@ class CoreRequestBuilder {
 
 		return $action;
 	}
-
 
 	/**
 	 * @param IQueryBuilder $qb
@@ -1085,7 +1041,6 @@ class CoreRequestBuilder {
 		);
 	}
 
-
 	/**
 	 * @param array $data
 	 */
@@ -1102,7 +1057,6 @@ class CoreRequestBuilder {
 
 		//		return $action;
 	}
-
 
 	/**
 	 * @param IQueryBuilder $qb
@@ -1132,7 +1086,7 @@ class CoreRequestBuilder {
 		// Build all conditions first for andX()
 		$conditions = [];
 		$conditions[] = $this->exprLimitToDBFieldInt($qb, 'accepted', 1, $prefix . '_f');
-		
+
 		if ($asFollower === true) {
 			$conditions[] = $expr->eq(
 				$func->lower($pf . '.' . $fieldActorId), $func->lower($prefix . '_f.object_id')
@@ -1163,7 +1117,6 @@ class CoreRequestBuilder {
 			);
 	}
 
-
 	/**
 	 * @param array $data
 	 * @param string $prefix
@@ -1191,7 +1144,6 @@ class CoreRequestBuilder {
 		return $follow;
 	}
 
-
 	/**
 	 * @param IQueryBuilder $qb
 	 * @param string $fieldActorId
@@ -1201,7 +1153,6 @@ class CoreRequestBuilder {
 		$this->leftJoinFollowAsViewer($qb, $fieldActorId, true, 'as_follower', $pf);
 		$this->leftJoinFollowAsViewer($qb, $fieldActorId, false, 'as_followed', $pf);
 	}
-
 
 	/**
 	 * @param Person $actor
@@ -1229,7 +1180,6 @@ class CoreRequestBuilder {
 		$actor->setCompleteDetails(true);
 	}
 
-
 	/**
 	 * this just empty all tables from the app.
 	 */
@@ -1244,7 +1194,6 @@ class CoreRequestBuilder {
 		}
 	}
 
-
 	/**
 	 * this just empty all tables from the app.
 	 */
@@ -1258,7 +1207,6 @@ class CoreRequestBuilder {
 
 		$schema->performDropTableCalls();
 	}
-
 
 	/**
 	 *

--- a/lib/Db/FollowsRequest.php
+++ b/lib/Db/FollowsRequest.php
@@ -25,7 +25,6 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
 class FollowsRequest extends FollowsRequestBuilder {
 	use TArrayTools;
 
-
 	/**
 	 * Insert a new Note in the database.
 	 *
@@ -54,7 +53,6 @@ class FollowsRequest extends FollowsRequestBuilder {
 		$qb->generatePrimaryKey($follow->getId());
 		$qb->executeStatement();
 	}
-
 
 	/**
 	 * Create a self-follow (Loopback) entry for a local actor.
@@ -92,7 +90,6 @@ class FollowsRequest extends FollowsRequestBuilder {
 		$qb->executeStatement();
 	}
 
-
 	/**
 	 * Check if a loopback (self-follow) already exists for this actor.
 	 *
@@ -108,7 +105,6 @@ class FollowsRequest extends FollowsRequestBuilder {
 			return false;
 		}
 	}
-
 
 	/**
 	 * Mark a follow as accepted.
@@ -127,7 +123,6 @@ class FollowsRequest extends FollowsRequestBuilder {
 		$qb->executeStatement();
 	}
 
-
 	/**
 	 * @return Follow[]
 	 */
@@ -136,7 +131,6 @@ class FollowsRequest extends FollowsRequestBuilder {
 
 		return $this->getFollowsFromRequest($qb);
 	}
-
 
 	/**
 	 * @param string $actorId
@@ -152,7 +146,6 @@ class FollowsRequest extends FollowsRequestBuilder {
 
 		return $this->getFollowFromRequest($qb);
 	}
-
 
 	/**
 	 * @param string $actorId
@@ -172,7 +165,6 @@ class FollowsRequest extends FollowsRequestBuilder {
 		return $this->getInt('count', $data, 0);
 	}
 
-
 	/**
 	 * @param string $actorId
 	 *
@@ -190,7 +182,6 @@ class FollowsRequest extends FollowsRequestBuilder {
 
 		return $this->getInt('count', $data, 0);
 	}
-
 
 	/**
 	 * @param string $actorId
@@ -210,7 +201,6 @@ class FollowsRequest extends FollowsRequestBuilder {
 		return $this->getInt('count', $data, 0);
 	}
 
-
 	/**
 	 * @return int
 	 */
@@ -223,7 +213,6 @@ class FollowsRequest extends FollowsRequestBuilder {
 
 		return $this->getInt('count', $data, 0);
 	}
-
 
 	/**
 	 * @param string $followId
@@ -238,7 +227,6 @@ class FollowsRequest extends FollowsRequestBuilder {
 
 		return $this->getFollowsFromRequest($qb);
 	}
-
 
 	/**
 	 * @param string $actorId
@@ -258,7 +246,6 @@ class FollowsRequest extends FollowsRequestBuilder {
 		return $this->getFollowsFromRequest($qb);
 	}
 
-
 	/**
 	 * The follows towards this actor that still wait for approval.
 	 *
@@ -274,7 +261,6 @@ class FollowsRequest extends FollowsRequestBuilder {
 
 		return $this->getFollowsFromRequest($qb);
 	}
-
 
 	/**
 	 * @param string $actorId
@@ -292,7 +278,6 @@ class FollowsRequest extends FollowsRequestBuilder {
 		return $this->getFollowsFromRequest($qb);
 	}
 
-
 	/**
 	 * @param string $followId
 	 *
@@ -306,7 +291,6 @@ class FollowsRequest extends FollowsRequestBuilder {
 
 		return $this->getFollowsFromRequest($qb);
 	}
-
 
 	/**
 	 * @param Follow $follow
@@ -352,7 +336,6 @@ class FollowsRequest extends FollowsRequestBuilder {
 		$qb->executeStatement();
 	}
 
-
 	/**
 	 * @param string $actorId
 	 * @param Person $new
@@ -369,7 +352,6 @@ class FollowsRequest extends FollowsRequestBuilder {
 		$qb->executeStatement();
 	}
 
-
 	/**
 	 * @param string $actorId
 	 * @param Person $new
@@ -383,7 +365,6 @@ class FollowsRequest extends FollowsRequestBuilder {
 
 		$qb->executeStatement();
 	}
-
 
 	/**
 	 * Returns everything related to a list of actorIds.

--- a/lib/Db/FollowsRequestBuilder.php
+++ b/lib/Db/FollowsRequestBuilder.php
@@ -23,7 +23,6 @@ use OCA\Social\Tools\Traits\TArrayTools;
 class FollowsRequestBuilder extends CoreRequestBuilder {
 	use TArrayTools;
 
-
 	/**
 	 * Base of the Sql Insert request
 	 *
@@ -36,7 +35,6 @@ class FollowsRequestBuilder extends CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * Base of the Sql Update request
 	 *
@@ -48,7 +46,6 @@ class FollowsRequestBuilder extends CoreRequestBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * Base of the Sql Select request for Shares
@@ -70,7 +67,6 @@ class FollowsRequestBuilder extends CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * Base of the Sql Select request for Shares
 	 *
@@ -87,7 +83,6 @@ class FollowsRequestBuilder extends CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * Base of the Sql Delete request
 	 *
@@ -99,7 +94,6 @@ class FollowsRequestBuilder extends CoreRequestBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * @param SocialQueryBuilder $qb
@@ -129,7 +123,6 @@ class FollowsRequestBuilder extends CoreRequestBuilder {
 
 		return $result;
 	}
-
 
 	/**
 	 * @param array $data

--- a/lib/Db/HashtagsRequest.php
+++ b/lib/Db/HashtagsRequest.php
@@ -20,7 +20,6 @@ use OCA\Social\Tools\Traits\TArrayTools;
 class HashtagsRequest extends HashtagsRequestBuilder {
 	use TArrayTools;
 
-
 	/**
 	 * Insert a new Hashtag.
 	 *
@@ -35,7 +34,6 @@ class HashtagsRequest extends HashtagsRequestBuilder {
 		$qb->executeStatement();
 	}
 
-
 	/**
 	 * Insert a new Hashtag.
 	 *
@@ -49,7 +47,6 @@ class HashtagsRequest extends HashtagsRequestBuilder {
 
 		$qb->executeStatement();
 	}
-
 
 	/**
 	 * @return array
@@ -66,7 +63,6 @@ class HashtagsRequest extends HashtagsRequestBuilder {
 
 		return $hashtags;
 	}
-
 
 	/**
 	 * @param string $hashtag
@@ -89,7 +85,6 @@ class HashtagsRequest extends HashtagsRequestBuilder {
 
 		return $this->parseHashtagsSelectSql($data);
 	}
-
 
 	/**
 	 * @param string $hashtag

--- a/lib/Db/HashtagsRequestBuilder.php
+++ b/lib/Db/HashtagsRequestBuilder.php
@@ -19,7 +19,6 @@ use OCA\Social\Tools\Traits\TArrayTools;
 class HashtagsRequestBuilder extends CoreRequestBuilder {
 	use TArrayTools;
 
-
 	/**
 	 * Base of the Sql Insert request
 	 *
@@ -32,7 +31,6 @@ class HashtagsRequestBuilder extends CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * Base of the Sql Update request
 	 *
@@ -44,7 +42,6 @@ class HashtagsRequestBuilder extends CoreRequestBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * Base of the Sql Select request for Shares
@@ -64,7 +61,6 @@ class HashtagsRequestBuilder extends CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * Base of the Sql Delete request
 	 *
@@ -76,7 +72,6 @@ class HashtagsRequestBuilder extends CoreRequestBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * @param array $data

--- a/lib/Db/InstancesRequest.php
+++ b/lib/Db/InstancesRequest.php
@@ -23,7 +23,6 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
 class InstancesRequest extends InstancesRequestBuilder {
 	use TArrayTools;
 
-
 	/**
 	 * @param Instance $instance
 	 *                           TODO: store instance in db
@@ -48,7 +47,6 @@ class InstancesRequest extends InstancesRequestBuilder {
 			->setValue('account_prim', $qb->createNamedParameter($instance->getAccountPrim() ? $qb->prim($instance->getAccountPrim()) : null));
 		$qb->executeStatement();
 	}
-
 
 	/**
 	 * @param int $format

--- a/lib/Db/InstancesRequestBuilder.php
+++ b/lib/Db/InstancesRequestBuilder.php
@@ -20,7 +20,6 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
 class InstancesRequestBuilder extends CoreRequestBuilder {
 	use TArrayTools;
 
-
 	/**
 	 * Base of the Sql Insert request
 	 *
@@ -33,7 +32,6 @@ class InstancesRequestBuilder extends CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * Base of the Sql Update request
 	 *
@@ -45,7 +43,6 @@ class InstancesRequestBuilder extends CoreRequestBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * Base of the Sql Select request for Shares
@@ -70,7 +67,6 @@ class InstancesRequestBuilder extends CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * Base of the Sql Delete request
 	 *
@@ -82,7 +78,6 @@ class InstancesRequestBuilder extends CoreRequestBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * @param SocialQueryBuilder $qb
@@ -101,7 +96,6 @@ class InstancesRequestBuilder extends CoreRequestBuilder {
 		return $result;
 	}
 
-
 	/**
 	 * @param SocialQueryBuilder $qb
 	 *
@@ -113,7 +107,6 @@ class InstancesRequestBuilder extends CoreRequestBuilder {
 
 		return $result;
 	}
-
 
 	/**
 	 * @param array $data

--- a/lib/Db/RequestQueueRequest.php
+++ b/lib/Db/RequestQueueRequest.php
@@ -59,7 +59,6 @@ class RequestQueueRequest extends RequestQueueRequestBuilder {
 		$qb->executeStatement();
 	}
 
-
 	/**
 	 * Return Queue from database based on the status=0
 	 *
@@ -81,7 +80,6 @@ class RequestQueueRequest extends RequestQueueRequestBuilder {
 
 		return $requests;
 	}
-
 
 	/**
 	 * Return Queue from database based on the token
@@ -109,7 +107,6 @@ class RequestQueueRequest extends RequestQueueRequestBuilder {
 		return $requests;
 	}
 
-
 	/**
 	 * @throws QueueStatusException|Exception
 	 */
@@ -132,7 +129,6 @@ class RequestQueueRequest extends RequestQueueRequestBuilder {
 		$queue->setStatus(RequestQueue::STATUS_RUNNING);
 	}
 
-
 	/**
 	 * @throws QueueStatusException|Exception
 	 */
@@ -150,7 +146,6 @@ class RequestQueueRequest extends RequestQueueRequestBuilder {
 
 		$queue->setStatus(RequestQueue::STATUS_SUCCESS);
 	}
-
 
 	/**
 	 * @throws QueueStatusException|Exception
@@ -174,7 +169,6 @@ class RequestQueueRequest extends RequestQueueRequestBuilder {
 		$queue->setStatus(RequestQueue::STATUS_STANDBY);
 	}
 
-
 	/**
 	 * Return every request stuck `running` since before $before to standby.
 	 *
@@ -193,7 +187,6 @@ class RequestQueueRequest extends RequestQueueRequestBuilder {
 
 		return $qb->executeStatement();
 	}
-
 
 	public function delete(RequestQueue $queue): void {
 		$qb = $this->getRequestQueueDeleteSql();

--- a/lib/Db/RequestQueueRequestBuilder.php
+++ b/lib/Db/RequestQueueRequestBuilder.php
@@ -15,7 +15,6 @@ use OCA\Social\Tools\Traits\TArrayTools;
 class RequestQueueRequestBuilder extends CoreRequestBuilder {
 	use TArrayTools;
 
-
 	/**
 	 * Base of the Sql Insert request
 	 *
@@ -28,7 +27,6 @@ class RequestQueueRequestBuilder extends CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * Base of the Sql Update request
 	 *
@@ -40,7 +38,6 @@ class RequestQueueRequestBuilder extends CoreRequestBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * Base of the Sql Select request for Shares
@@ -63,7 +60,6 @@ class RequestQueueRequestBuilder extends CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * Base of the Sql Delete request
 	 *
@@ -75,7 +71,6 @@ class RequestQueueRequestBuilder extends CoreRequestBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * @param array $data

--- a/lib/Db/SocialCoreQueryBuilder.php
+++ b/lib/Db/SocialCoreQueryBuilder.php
@@ -41,7 +41,6 @@ class SocialCoreQueryBuilder extends ExtendedQueryBuilder {
 		parent::__construct($connection, $systemConfig, $logger);
 	}
 
-
 	public function hasViewer(): bool {
 		return ($this->viewer !== null);
 	}

--- a/lib/Db/SocialCrossQueryBuilder.php
+++ b/lib/Db/SocialCrossQueryBuilder.php
@@ -68,7 +68,6 @@ class SocialCrossQueryBuilder extends SocialCoreQueryBuilder {
 		);
 	}
 
-
 	/**
 	 * @param string $alias
 	 * @param string $link
@@ -84,7 +83,6 @@ class SocialCrossQueryBuilder extends SocialCoreQueryBuilder {
 			$this->andWhere($expr->eq($alias . '.stream_id', $link));
 		}
 	}
-
 
 	/**
 	 * @param string $alias
@@ -138,7 +136,6 @@ class SocialCrossQueryBuilder extends SocialCoreQueryBuilder {
 		$this->leftJoinCacheDocuments('icon_id', $pf, 'ca_cachedocument_', 'cacd');
 	}
 
-
 	/**
 	 * @param array $data
 	 * @param string $prefix
@@ -171,7 +168,6 @@ class SocialCrossQueryBuilder extends SocialCoreQueryBuilder {
 
 		return $stream;
 	}
-
 
 	/**
 	 * @param array $data
@@ -217,7 +213,6 @@ class SocialCrossQueryBuilder extends SocialCoreQueryBuilder {
 		return $actor;
 	}
 
-
 	/**
 	 * @param string $linkField
 	 * @param string $linkAlias
@@ -252,7 +247,6 @@ class SocialCrossQueryBuilder extends SocialCoreQueryBuilder {
 			);
 	}
 
-
 	/**
 	 * @param array $data
 	 *
@@ -278,7 +272,6 @@ class SocialCrossQueryBuilder extends SocialCoreQueryBuilder {
 
 		return $document;
 	}
-
 
 	/**
 	 * @param string $alias
@@ -312,7 +305,6 @@ class SocialCrossQueryBuilder extends SocialCoreQueryBuilder {
 			'os_'
 		);
 	}
-
 
 	/**
 	 * @param string $link
@@ -353,7 +345,6 @@ class SocialCrossQueryBuilder extends SocialCoreQueryBuilder {
 		);
 	}
 
-
 	/**
 	 * @param string $alias
 	 */
@@ -377,7 +368,6 @@ class SocialCrossQueryBuilder extends SocialCoreQueryBuilder {
 		$this->leftJoin($this->getDefaultSelectAlias(), CoreRequestBuilder::TABLE_FOLLOWS, $alias, $on);
 	}
 
-
 	/**
 	 * @param string $alias
 	 */
@@ -396,7 +386,6 @@ class SocialCrossQueryBuilder extends SocialCoreQueryBuilder {
 			->selectAlias('sa.replied', 'streamaction_replied')
 			->selectAlias('sa.bookmarked', 'streamaction_bookmarked');
 	}
-
 
 	/**
 	 * @param string $alias
@@ -435,7 +424,6 @@ class SocialCrossQueryBuilder extends SocialCoreQueryBuilder {
 		);
 	}
 
-
 	/**
 	 * @param string $type
 	 * @param string $field
@@ -447,7 +435,6 @@ class SocialCrossQueryBuilder extends SocialCoreQueryBuilder {
 	) {
 		$this->andWhere($this->exprInnerJoinStreamDest($type, $field, $aliasDest, $alias));
 	}
-
 
 	/**
 	 * @param string $type
@@ -470,7 +457,6 @@ class SocialCrossQueryBuilder extends SocialCoreQueryBuilder {
 		return $andX;
 	}
 
-
 	/**
 	 * @param string $actorId
 	 * @param string $type
@@ -489,7 +475,6 @@ class SocialCrossQueryBuilder extends SocialCoreQueryBuilder {
 			)
 		);
 	}
-
 
 	/**
 	 * @param string $actorId

--- a/lib/Db/SocialLimitsQueryBuilder.php
+++ b/lib/Db/SocialLimitsQueryBuilder.php
@@ -32,7 +32,6 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 		return $this;
 	}
 
-
 	/**
 	 * Limit the request to the ActivityId
 	 *
@@ -41,7 +40,6 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 	public function limitToActivityId(string $activityId) {
 		$this->limitToDBField('activity_id', $activityId, false);
 	}
-
 
 	/**
 	 * Limit the request to the Id (string)
@@ -59,7 +57,6 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 		$this->limitToDBField('in_reply_to', $id, false);
 	}
 
-
 	/**
 	 * Limit the request to the sub-type
 	 *
@@ -68,7 +65,6 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 	public function limitToSubType(string $subType) {
 		$this->limitToDBField('subtype', $subType);
 	}
-
 
 	/**
 	 * Limit the request to clientId
@@ -79,14 +75,12 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 		$this->limitToDBField('app_client_id', $clientId);
 	}
 
-
 	/**
 	 * @param string $type
 	 */
 	public function filterType(string $type) {
 		$this->filterDBField('type', $type);
 	}
-
 
 	/**
 	 * Limit the request to the Preferred Username
@@ -97,7 +91,6 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 		$this->limitToDBField('preferred_username', $username, false);
 	}
 
-
 	/**
 	 * Limit the request to the ActorId
 	 */
@@ -105,14 +98,12 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 		$this->limitToDBFieldInt('public', 1);
 	}
 
-
 	/**
 	 * Limit the request to the ActorId
 	 */
 	public function limitToIdPrim(string $id) {
 		$this->limitToDBField('id_prim', $id);
 	}
-
 
 	/**
 	 * Limit the request to the token
@@ -124,7 +115,6 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 		$this->limitToDBField('token', $token, true, $alias);
 	}
 
-
 	/**
 	 * Limit the results to a given number
 	 *
@@ -134,7 +124,6 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 		$this->setMaxResults($limit);
 	}
 
-
 	/**
 	 * Limit the request to the ActorId
 	 *
@@ -143,7 +132,6 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 	public function limitToHashtag(string $hashtag) {
 		$this->limitToDBField('hashtag', $hashtag, false);
 	}
-
 
 	/**
 	 * Limit the request to the ActorId
@@ -155,7 +143,6 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 		$this->limitToDBField('actor_id', $actorId, false, $alias);
 	}
 
-
 	/**
 	 * Limit the request to the ActorId
 	 *
@@ -165,7 +152,6 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 	public function limitToActorIdPrim(string $actorId, string $alias = '') {
 		$this->limitToDBField('actor_id_prim', $actorId, false, $alias);
 	}
-
 
 	/**
 	 * @param string $streamId
@@ -186,7 +172,6 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 		$this->limitToDBField('follow_id', $followId, false);
 	}
 
-
 	/**
 	 * Limit the request to the FollowId
 	 *
@@ -197,7 +182,6 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 		$this->limitToDBField('accepted', ($accepted) ? '1' : '0', true, $alias);
 	}
 
-
 	/**
 	 * Limit the request to the ServiceId
 	 *
@@ -206,7 +190,6 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 	public function limitToObjectId(string $objectId) {
 		$this->limitToDBField('object_id', $objectId, false);
 	}
-
 
 	/**
 	 * Limit the request to the ActorId
@@ -218,7 +201,6 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 		$this->limitToDBField('object_id_prim', $actorId, false, $alias);
 	}
 
-
 	/**
 	 * Limit the request to the account
 	 *
@@ -227,7 +209,6 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 	public function limitToAccount(string $account) {
 		$this->limitToDBField('account', $account, false);
 	}
-
 
 	/**
 	 * Limit the request to the creation
@@ -243,7 +224,6 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 		$this->limitToDBFieldDateTime('caching', $date, true);
 	}
 
-
 	/**
 	 * Limit the request to the url
 	 *
@@ -252,7 +232,6 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 	public function limitToUrl(string $url) {
 		$this->limitToDBField('url', $url);
 	}
-
 
 	/**
 	 * Limit the request to the url
@@ -270,7 +249,6 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 		$this->limitToDBField('attributed_to', $actorId, false);
 	}
 
-
 	/**
 	 * Limit the request to the status
 	 *
@@ -279,7 +257,6 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 	public function limitToStatus(int $status) {
 		$this->limitToDBFieldInt('status', $status);
 	}
-
 
 	/**
 	 * Limit the request to the instance
@@ -290,7 +267,6 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 		$this->limitToDBField('address', $address);
 	}
 
-
 	/**
 	 * Limit the request to the instance
 	 *
@@ -300,7 +276,6 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 		$this->limitToDBFieldInt('local', ($local) ? 1 : 0);
 	}
 
-
 	/**
 	 * Limit the request to the parent_id
 	 *
@@ -309,7 +284,6 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 	public function limitToParentId(string $parentId) {
 		$this->limitToDBField('parent_id', $parentId);
 	}
-
 
 	/**
 	 * @param ProbeOptions $options
@@ -336,7 +310,6 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 		$this->orderBy($pf . '.nid', ($options->isInverted()) ? 'asc' : 'desc');
 	}
 
-
 	/**
 	 * @param int $since
 	 * @param int $limit
@@ -361,7 +334,6 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 		$this->orderBy($pf . '.published_time', 'desc');
 	}
 
-
 	/**
 	 * @param string $recipient
 	 */
@@ -370,7 +342,6 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 
 		$this->andWhere($expr->neq('actor_id', $this->createNamedParameter($this->prim($recipient))));
 	}
-
 
 	/**
 	 * @param string $actorId
@@ -381,7 +352,6 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 	public function limitToDest(string $actorId, string $type, string $subType = '', string $alias = 'sd') {
 		$this->andWhere($this->exprLimitToDest($actorId, $type, $subType, $alias));
 	}
-
 
 	/**
 	 * @param string $actorId
@@ -409,7 +379,6 @@ class SocialLimitsQueryBuilder extends SocialCrossQueryBuilder {
 
 		return $andX;
 	}
-
 
 	/**
 	 * @param string $aliasDest

--- a/lib/Db/SocialQueryBuilder.php
+++ b/lib/Db/SocialQueryBuilder.php
@@ -17,7 +17,6 @@ namespace OCA\Social\Db;
 class SocialQueryBuilder extends SocialFiltersQueryBuilder {
 	private int $format = 1;
 
-
 	/**
 	 * @param int $format
 	 */
@@ -32,7 +31,6 @@ class SocialQueryBuilder extends SocialFiltersQueryBuilder {
 		return $this->format;
 	}
 
-
 	/**
 	 * @param string $id
 	 * @param string $field
@@ -44,7 +42,6 @@ class SocialQueryBuilder extends SocialFiltersQueryBuilder {
 
 		$this->setValue($field, $this->createNamedParameter($this->prim($id)));
 	}
-
 
 	/**
 	 * search using username
@@ -66,7 +63,6 @@ class SocialQueryBuilder extends SocialFiltersQueryBuilder {
 		$dbConn = $this->getConnection();
 		$this->searchInDBField('hashtag', (($all) ? '%' : '') . $dbConn->escapeLikeParameter($hashtag) . '%');
 	}
-
 
 	/**
 	 * Limit the request to the account

--- a/lib/Db/StreamActionsRequest.php
+++ b/lib/Db/StreamActionsRequest.php
@@ -42,7 +42,6 @@ class StreamActionsRequest extends StreamActionsRequestBuilder {
 		$qb->executeStatement();
 	}
 
-
 	public function update(StreamAction $action): int {
 		$qb = $this->getStreamActionUpdateSql();
 
@@ -75,7 +74,6 @@ class StreamActionsRequest extends StreamActionsRequestBuilder {
 
 		return $qb->executeStatement();
 	}
-
 
 	/**
 	 * @throws StreamActionDoesNotExistException

--- a/lib/Db/StreamActionsRequestBuilder.php
+++ b/lib/Db/StreamActionsRequestBuilder.php
@@ -20,7 +20,6 @@ use OCA\Social\Tools\Traits\TArrayTools;
 class StreamActionsRequestBuilder extends CoreRequestBuilder {
 	use TArrayTools;
 
-
 	/**
 	 * Base of the Sql Insert request
 	 *
@@ -33,7 +32,6 @@ class StreamActionsRequestBuilder extends CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * Base of the Sql Update request
 	 *
@@ -45,7 +43,6 @@ class StreamActionsRequestBuilder extends CoreRequestBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * Base of the Sql Select request for Shares
@@ -68,7 +65,6 @@ class StreamActionsRequestBuilder extends CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * Base of the Sql Delete request
 	 *
@@ -80,7 +76,6 @@ class StreamActionsRequestBuilder extends CoreRequestBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * @param array $data

--- a/lib/Db/StreamDestRequest.php
+++ b/lib/Db/StreamDestRequest.php
@@ -70,8 +70,8 @@ class StreamDestRequest extends StreamDestRequestBuilder {
 	}
 
 	private function generateStreamHome(Stream $stream): bool {
-		$recipients =
-			[
+		$recipients
+			= [
 				'to' => array_merge($stream->getToAll(), [$stream->getAttributedTo()]),
 				'cc' => array_merge($stream->getCcArray(), $stream->getBccArray())
 			];
@@ -140,7 +140,6 @@ class StreamDestRequest extends StreamDestRequestBuilder {
 		$qb->executeStatement();
 	}
 
-
 	/**
 	 * @param string $actorId
 	 *
@@ -158,7 +157,6 @@ class StreamDestRequest extends StreamDestRequestBuilder {
 		return $this->getStreamDestsFromRequest($qb);
 	}
 
-
 	/**
 	 * @param string $actorId
 	 */
@@ -168,8 +166,6 @@ class StreamDestRequest extends StreamDestRequestBuilder {
 
 		$qb->executeStatement();
 	}
-
-
 
 	/**
 	 * @param string $actorId

--- a/lib/Db/StreamDestRequestBuilder.php
+++ b/lib/Db/StreamDestRequestBuilder.php
@@ -22,7 +22,6 @@ use OCA\Social\Tools\Traits\TArrayTools;
 class StreamDestRequestBuilder extends CoreRequestBuilder {
 	use TArrayTools;
 
-
 	/**
 	 * Base of the Sql Insert request
 	 */
@@ -32,7 +31,6 @@ class StreamDestRequestBuilder extends CoreRequestBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * Base of the Sql Update request
@@ -45,7 +43,6 @@ class StreamDestRequestBuilder extends CoreRequestBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * Base of the Sql Select request for Shares
@@ -65,7 +62,6 @@ class StreamDestRequestBuilder extends CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * Base of the Sql Delete request
 	 *
@@ -77,7 +73,6 @@ class StreamDestRequestBuilder extends CoreRequestBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * Base of the Sql Select request for Shares
@@ -94,7 +89,6 @@ class StreamDestRequestBuilder extends CoreRequestBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * @param SocialQueryBuilder $qb
@@ -121,7 +115,6 @@ class StreamDestRequestBuilder extends CoreRequestBuilder {
 	public function getStreamDestsFromRequest(SocialQueryBuilder $qb): array {
 		return $qb->getRows([$this, 'parseStreamDestSelectSql']);
 	}
-
 
 	/**
 	 * @param array $data

--- a/lib/Db/StreamQueueRequest.php
+++ b/lib/Db/StreamQueueRequest.php
@@ -35,7 +35,6 @@ class StreamQueueRequest extends StreamQueueRequestBuilder {
 		$qb->executeStatement();
 	}
 
-
 	/**
 	 * return Queue from database based on the status=0
 	 *
@@ -55,7 +54,6 @@ class StreamQueueRequest extends StreamQueueRequestBuilder {
 
 		return $requests;
 	}
-
 
 	/**
 	 * return Queue from database based on the token
@@ -77,7 +75,6 @@ class StreamQueueRequest extends StreamQueueRequestBuilder {
 
 		return $queue;
 	}
-
 
 	/**
 	 * @param StreamQueue $queue
@@ -103,7 +100,6 @@ class StreamQueueRequest extends StreamQueueRequestBuilder {
 		$queue->setStatus(StreamQueue::STATUS_RUNNING);
 	}
 
-
 	/**
 	 * @param StreamQueue $queue
 	 *
@@ -123,7 +119,6 @@ class StreamQueueRequest extends StreamQueueRequestBuilder {
 
 		$queue->setStatus(StreamQueue::STATUS_SUCCESS);
 	}
-
 
 	/**
 	 * @param StreamQueue $queue
@@ -148,7 +143,6 @@ class StreamQueueRequest extends StreamQueueRequestBuilder {
 
 		$queue->setStatus(StreamQueue::STATUS_SUCCESS);
 	}
-
 
 	/**
 	 * @param StreamQueue $queue

--- a/lib/Db/StreamQueueRequestBuilder.php
+++ b/lib/Db/StreamQueueRequestBuilder.php
@@ -15,7 +15,6 @@ use OCA\Social\Tools\Traits\TArrayTools;
 class StreamQueueRequestBuilder extends CoreRequestBuilder {
 	use TArrayTools;
 
-
 	/**
 	 * Base of the Sql Insert request
 	 *
@@ -28,7 +27,6 @@ class StreamQueueRequestBuilder extends CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * Base of the Sql Update request
 	 *
@@ -40,7 +38,6 @@ class StreamQueueRequestBuilder extends CoreRequestBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * Base of the Sql Select request for Shares
@@ -62,7 +59,6 @@ class StreamQueueRequestBuilder extends CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * Base of the Sql Delete request
 	 *
@@ -74,7 +70,6 @@ class StreamQueueRequestBuilder extends CoreRequestBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * @param array $data

--- a/lib/Db/StreamRequest.php
+++ b/lib/Db/StreamRequest.php
@@ -117,14 +117,12 @@ class StreamRequest extends StreamRequestBuilder {
 		}
 	}
 
-
 	public function updateDetails(Stream $stream): void {
 		$qb = $this->getStreamUpdateSql();
 		$qb->set('details', $qb->createNamedParameter(json_encode($stream->getDetailsAll())));
 		$qb->limitToIdPrim($qb->prim($stream->getId()));
 		$qb->executeStatement();
 	}
-
 
 	public function updateCache(Stream $stream, Cache $cache): void {
 		$qb = $this->getStreamUpdateSql();
@@ -173,7 +171,6 @@ class StreamRequest extends StreamRequestBuilder {
 		return $new;
 	}
 
-
 	public function updateAttributedTo(string $itemId, string $to): void {
 		$qb = $this->getStreamUpdateSql();
 		$qb->set('attributed_to', $qb->createNamedParameter($to));
@@ -183,7 +180,6 @@ class StreamRequest extends StreamRequestBuilder {
 
 		$qb->executeStatement();
 	}
-
 
 	/**
 	 * @param string $type
@@ -199,7 +195,6 @@ class StreamRequest extends StreamRequestBuilder {
 
 		return $this->getStreamsFromRequest($qb);
 	}
-
 
 	/**
 	 * @param string $id
@@ -236,7 +231,6 @@ class StreamRequest extends StreamRequestBuilder {
 		}
 	}
 
-
 	/**
 	 * @param string $id
 	 * @param bool $asViewer
@@ -255,7 +249,6 @@ class StreamRequest extends StreamRequestBuilder {
 
 		return $this->getStreamFromRequest($qb);
 	}
-
 
 	/**
 	 * @param string $idPrim
@@ -299,7 +292,6 @@ class StreamRequest extends StreamRequestBuilder {
 		return $this->getStreamsFromRequest($qb);
 	}
 
-
 	/**
 	 * @param string $id
 	 *
@@ -317,7 +309,6 @@ class StreamRequest extends StreamRequestBuilder {
 
 		return $this->getStreamFromRequest($qb);
 	}
-
 
 	/**
 	 * @param string $objectId
@@ -341,7 +332,6 @@ class StreamRequest extends StreamRequestBuilder {
 		return $this->getStreamFromRequest($qb);
 	}
 
-
 	/**
 	 * @param string $id
 	 *
@@ -357,7 +347,6 @@ class StreamRequest extends StreamRequestBuilder {
 
 		return $this->getInt('count', $data, 0);
 	}
-
 
 	/**
 	 * @param string $actorId
@@ -379,7 +368,6 @@ class StreamRequest extends StreamRequestBuilder {
 
 		return $this->getInt('count', $data, 0);
 	}
-
 
 	/**
 	 * @param string $actorId
@@ -471,7 +459,6 @@ class StreamRequest extends StreamRequestBuilder {
 		return $this->getStreamsFromRequest($qb);
 	}
 
-
 	/**
 	 * Should return:
 	 *  * Private message.
@@ -497,7 +484,6 @@ class StreamRequest extends StreamRequestBuilder {
 
 		return $this->getStreamsFromRequest($qb);
 	}
-
 
 	/**
 	 * Should returns:
@@ -534,7 +520,6 @@ class StreamRequest extends StreamRequestBuilder {
 		return $this->getStreamsFromRequest($qb);
 	}
 
-
 	/**
 	 * @param ProbeOptions $options
 	 *
@@ -558,7 +543,6 @@ class StreamRequest extends StreamRequestBuilder {
 
 		return $this->getStreamsFromRequest($qb);
 	}
-
 
 	/**
 	 * @param ProbeOptions $options
@@ -584,7 +568,6 @@ class StreamRequest extends StreamRequestBuilder {
 		return $this->getStreamsFromRequest($qb);
 	}
 
-
 	/**
 	 * @param ProbeOptions $options
 	 *
@@ -608,7 +591,6 @@ class StreamRequest extends StreamRequestBuilder {
 		return $this->getStreamsFromRequest($qb);
 	}
 
-
 	/**
 	 * @param ProbeOptions $options
 	 *
@@ -631,7 +613,6 @@ class StreamRequest extends StreamRequestBuilder {
 
 		return $this->getStreamsFromRequest($qb);
 	}
-
 
 	/**
 	 * Should return:
@@ -662,7 +643,6 @@ class StreamRequest extends StreamRequestBuilder {
 
 		return $this->getStreamsFromRequest($qb);
 	}
-
 
 	/**
 	 * Should return:
@@ -696,7 +676,6 @@ class StreamRequest extends StreamRequestBuilder {
 		return $this->getStreamsFromRequest($qb);
 	}
 
-
 	/**
 	 * Should return:
 	 *  * public message from actorId.
@@ -725,7 +704,6 @@ class StreamRequest extends StreamRequestBuilder {
 
 		return $this->getStreamsFromRequest($qb);
 	}
-
 
 	/**
 	 * Should return:
@@ -782,7 +760,6 @@ class StreamRequest extends StreamRequestBuilder {
 		return $this->getStreamsFromRequest($qb);
 	}
 
-
 	/**
 	 * Should returns:
 	 *  * All local public/federated posts
@@ -812,7 +789,6 @@ class StreamRequest extends StreamRequestBuilder {
 
 		return $this->getStreamsFromRequest($qb);
 	}
-
 
 	/**
 	 * Should returns:
@@ -846,7 +822,6 @@ class StreamRequest extends StreamRequestBuilder {
 		return $this->getStreamsFromRequest($qb);
 	}
 
-
 	/**
 	 * Should return:
 	 *  - All public post related to a tag (not yet)
@@ -879,7 +854,6 @@ class StreamRequest extends StreamRequestBuilder {
 		return $this->getStreamsFromRequest($qb);
 	}
 
-
 	/**
 	 * @param int $since
 	 *
@@ -904,7 +878,6 @@ class StreamRequest extends StreamRequestBuilder {
 		return $this->getStreamsFromRequest($qb);
 	}
 
-
 	/**
 	 * @param string $id
 	 * @param string $type
@@ -920,7 +893,6 @@ class StreamRequest extends StreamRequestBuilder {
 		$qb->executeStatement();
 	}
 
-
 	/**
 	 * @param string $actorId
 	 */
@@ -930,7 +902,6 @@ class StreamRequest extends StreamRequestBuilder {
 
 		$qb->executeStatement();
 	}
-
 
 	/**
 	 * @param string $actorId
@@ -943,7 +914,6 @@ class StreamRequest extends StreamRequestBuilder {
 
 		$qb->executeStatement();
 	}
-
 
 	/**
 	 * Insert a new Stream in the database.
@@ -1038,10 +1008,8 @@ class StreamRequest extends StreamRequestBuilder {
 		return $qb;
 	}
 
-
 	public function getRelatedToActor(string $actorId) {
 	}
-
 
 	/**
 	 * @param string $id

--- a/lib/Db/StreamRequestBuilder.php
+++ b/lib/Db/StreamRequestBuilder.php
@@ -30,7 +30,6 @@ use OCA\Social\Tools\Traits\TArrayTools;
 class StreamRequestBuilder extends CoreRequestBuilder {
 	use TArrayTools;
 
-
 	/**
 	 * Base of the Sql Insert request
 	 *
@@ -43,7 +42,6 @@ class StreamRequestBuilder extends CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * Base of the Sql Update request
 	 *
@@ -55,7 +53,6 @@ class StreamRequestBuilder extends CoreRequestBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * Base of the Sql Select request for Shares
@@ -82,7 +79,6 @@ class StreamRequestBuilder extends CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * Base of the Sql Select request for Shares
 	 *
@@ -98,7 +94,6 @@ class StreamRequestBuilder extends CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * Base of the Sql Delete request
 	 *
@@ -110,7 +105,6 @@ class StreamRequestBuilder extends CoreRequestBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * @param SocialQueryBuilder $qb
@@ -138,7 +132,6 @@ class StreamRequestBuilder extends CoreRequestBuilder {
 		$qb->andWhere($orX);
 	}
 
-
 	/**
 	 * @param SocialQueryBuilder $qb
 	 *
@@ -156,7 +149,6 @@ class StreamRequestBuilder extends CoreRequestBuilder {
 		return $result;
 	}
 
-
 	/**
 	 * @param SocialQueryBuilder $qb
 	 *
@@ -168,7 +160,6 @@ class StreamRequestBuilder extends CoreRequestBuilder {
 
 		return $result;
 	}
-
 
 	/**
 	 * @param array $data
@@ -222,7 +213,6 @@ class StreamRequestBuilder extends CoreRequestBuilder {
 			} catch (CacheItemNotFoundException $e) {
 			}
 		}
-
 
 		if ($item->getType() === Announce::TYPE) {
 			$item->setAttributedTo($this->get('following_actor_id', $data, ''));

--- a/lib/Db/StreamTagsRequestBuilder.php
+++ b/lib/Db/StreamTagsRequestBuilder.php
@@ -20,7 +20,6 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
 class StreamTagsRequestBuilder extends CoreRequestBuilder {
 	use TArrayTools;
 
-
 	/**
 	 * Base of the Sql Insert request
 	 *
@@ -33,7 +32,6 @@ class StreamTagsRequestBuilder extends CoreRequestBuilder {
 		return $qb;
 	}
 
-
 	/**
 	 * Base of the Sql Update request
 	 *
@@ -45,7 +43,6 @@ class StreamTagsRequestBuilder extends CoreRequestBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * Base of the Sql Select request for Shares
@@ -64,7 +61,6 @@ class StreamTagsRequestBuilder extends CoreRequestBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * Base of the Sql Delete request

--- a/lib/Exceptions/FollowSameAccountException.php
+++ b/lib/Exceptions/FollowSameAccountException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/Interfaces/Activity/MoveInterface.php
+++ b/lib/Interfaces/Activity/MoveInterface.php
@@ -50,7 +50,6 @@ class MoveInterface extends AbstractActivityPubInterface implements IActivityPub
 		$this->cacheActorService = $cacheActorService;
 	}
 
-
 	/**
 	 * @throws InvalidOriginException
 	 */
@@ -83,7 +82,6 @@ class MoveInterface extends AbstractActivityPubInterface implements IActivityPub
 		$this->moveAccount($old, $new);
 	}
 
-
 	public function moveAccount(Person $actor, Person $target): void {
 		$this->actionsRequest->moveAccount($actor->getId(), $target->getId());
 		$this->cacheDocumentsRequest->moveAccount($actor->getId(), $target->getId());
@@ -93,7 +91,6 @@ class MoveInterface extends AbstractActivityPubInterface implements IActivityPub
 
 		$this->updateStreamFromActor($actor, $target);
 	}
-
 
 	/**
 	 * @param Person $actor

--- a/lib/Interfaces/Actor/PersonInterface.php
+++ b/lib/Interfaces/Actor/PersonInterface.php
@@ -123,7 +123,6 @@ class PersonInterface extends AbstractActivityPubInterface implements IActivityP
 		}
 	}
 
-
 	public function delete(ACore $item): void {
 		if (!($item instanceof Person)) {
 			return;
@@ -138,7 +137,6 @@ class PersonInterface extends AbstractActivityPubInterface implements IActivityP
 
 		$this->deleteStreamFromActor($item);
 	}
-
 
 	/**
 	 * @param Person $actor
@@ -191,12 +189,10 @@ class PersonInterface extends AbstractActivityPubInterface implements IActivityP
 		$this->streamDestRequest->deleteRelatedToActor($actor->getId());
 	}
 
-
 	// get stream's relative and remove everything
 	private function removeStreamAndRelated(string $idPrim): void {
 		$this->streamRequest->deleteById($idPrim);
 	}
-
 
 	private function updateActor(Person $actor, ACore $activity) {
 		$actor->setCreation($activity->getOriginCreationTime());

--- a/lib/Interfaces/IActivityPubInterface.php
+++ b/lib/Interfaces/IActivityPubInterface.php
@@ -24,12 +24,10 @@ interface IActivityPubInterface {
 	 */
 	public function processIncomingRequest(ACore $item): void;
 
-
 	/**
 	 * Freshly imported item can be processed/parsed on result of outgoing request.
 	 */
 	public function processResult(ACore $item): void;
-
 
 	/**
 	 * When an activity is triggered by an 'Model\ActivityPub\Activity' model.
@@ -38,20 +36,17 @@ interface IActivityPubInterface {
 	 */
 	public function activity(ACore $activity, ACore $item): void;
 
-
 	/**
 	 * Get Item by its Id.
 	 * @throws ItemNotFoundException
 	 */
 	public function getItemById(string $id): ACore;
 
-
 	/**
 	 * Get Item when Id is not known.
 	 * @throws ItemNotFoundException
 	 */
 	public function getItem(ACore $item): ACore;
-
 
 	/**
 	 * Save the current item.
@@ -62,7 +57,6 @@ interface IActivityPubInterface {
 	 */
 	public function save(ACore $item): void;
 
-
 	/**
 	 * Update the current item.
 	 *
@@ -72,14 +66,12 @@ interface IActivityPubInterface {
 	 */
 	public function update(ACore $item): void;
 
-
 	/**
 	 * Event on the current item.
 	 *
 	 * !! Should not be called from an other IActivityPubInterface !!
 	 */
 	public function event(ACore $item, string $source): void;
-
 
 	/**
 	 * Delete the current item.

--- a/lib/Interfaces/Object/AnnounceInterface.php
+++ b/lib/Interfaces/Object/AnnounceInterface.php
@@ -81,7 +81,6 @@ class AnnounceInterface extends AbstractActivityPubInterface implements IActivit
 		$this->save($item);
 	}
 
-
 	/**
 	 * @throws InvalidOriginException
 	 * @throws InvalidResourceException
@@ -118,7 +117,6 @@ class AnnounceInterface extends AbstractActivityPubInterface implements IActivit
 	public function getItemById(string $id): ACore {
 		throw new ItemNotFoundException();
 	}
-
 
 	/**
 	 * @throws Exception
@@ -166,7 +164,6 @@ class AnnounceInterface extends AbstractActivityPubInterface implements IActivit
 		$this->generateNotification($post, $actor);
 	}
 
-
 	/**
 	 * @throws InvalidOriginException
 	 * @throws InvalidResourceException
@@ -181,8 +178,8 @@ class AnnounceInterface extends AbstractActivityPubInterface implements IActivit
 	 */
 	public function delete(ACore $item): void {
 		try {
-			$knownItem =
-				$this->streamRequest->getStreamByObjectId($item->getObjectId(), Announce::TYPE);
+			$knownItem
+				= $this->streamRequest->getStreamByObjectId($item->getObjectId(), Announce::TYPE);
 
 			if ($item->hasActor()) {
 				$actor = $item->getActor();
@@ -245,8 +242,8 @@ class AnnounceInterface extends AbstractActivityPubInterface implements IActivit
 		}
 
 		/** @var SocialAppNotificationInterface $notificationInterface */
-		$notificationInterface =
-			AP::$activityPub->getInterfaceFromType(SocialAppNotification::TYPE);
+		$notificationInterface
+			= AP::$activityPub->getInterfaceFromType(SocialAppNotification::TYPE);
 
 		try {
 			$notification = $this->streamRequest->getStreamByObjectId(
@@ -274,7 +271,6 @@ class AnnounceInterface extends AbstractActivityPubInterface implements IActivit
 		}
 	}
 
-
 	/**
 	 * @throws ItemUnknownException
 	 * @throws SocialAppConfigException
@@ -285,8 +281,8 @@ class AnnounceInterface extends AbstractActivityPubInterface implements IActivit
 		}
 
 		/** @var SocialAppNotificationInterface $notificationInterface */
-		$notificationInterface =
-			AP::$activityPub->getInterfaceFromType(SocialAppNotification::TYPE);
+		$notificationInterface
+			= AP::$activityPub->getInterfaceFromType(SocialAppNotification::TYPE);
 
 		try {
 			$notification = $this->streamRequest->getStreamByObjectId(

--- a/lib/Interfaces/Object/FollowInterface.php
+++ b/lib/Interfaces/Object/FollowInterface.php
@@ -150,7 +150,6 @@ class FollowInterface extends AbstractActivityPubInterface implements IActivityP
 		}
 	}
 
-
 	/**
 	 * Process an incoming Follow activity (remote user wants to follow a local user).
 	 *

--- a/lib/Interfaces/Object/LikeInterface.php
+++ b/lib/Interfaces/Object/LikeInterface.php
@@ -50,7 +50,6 @@ class LikeInterface extends AbstractActivityPubInterface implements IActivityPub
 		$this->cacheActorService = $cacheActorService;
 	}
 
-
 	/**
 	 * @throws InvalidOriginException
 	 */
@@ -65,7 +64,6 @@ class LikeInterface extends AbstractActivityPubInterface implements IActivityPub
 		} catch (ItemAlreadyExistsException $e) {
 		}
 	}
-
 
 	/**
 	 * @throws InvalidOriginException
@@ -157,7 +155,6 @@ class LikeInterface extends AbstractActivityPubInterface implements IActivityPub
 		$this->streamRequest->updateDetails($post);
 	}
 
-
 	/**
 	 * @throws ItemAlreadyExistsException
 	 * @throws ItemNotFoundException
@@ -170,8 +167,8 @@ class LikeInterface extends AbstractActivityPubInterface implements IActivityPub
 		}
 
 		/** @var SocialAppNotificationInterface $notificationInterface */
-		$notificationInterface =
-			AP::$activityPub->getInterfaceFromType(SocialAppNotification::TYPE);
+		$notificationInterface
+			= AP::$activityPub->getInterfaceFromType(SocialAppNotification::TYPE);
 
 		try {
 			$notification = $this->streamRequest->getStreamByObjectId(
@@ -198,7 +195,6 @@ class LikeInterface extends AbstractActivityPubInterface implements IActivityPub
 		}
 	}
 
-
 	/**
 	 * @throws ItemUnknownException
 	 * @throws SocialAppConfigException
@@ -209,8 +205,8 @@ class LikeInterface extends AbstractActivityPubInterface implements IActivityPub
 		}
 
 		/** @var SocialAppNotificationInterface $notificationInterface */
-		$notificationInterface =
-			AP::$activityPub->getInterfaceFromType(SocialAppNotification::TYPE);
+		$notificationInterface
+			= AP::$activityPub->getInterfaceFromType(SocialAppNotification::TYPE);
 
 		try {
 			$notification = $this->streamRequest->getStreamByObjectId(

--- a/lib/Interfaces/Object/NoteInterface.php
+++ b/lib/Interfaces/Object/NoteInterface.php
@@ -59,7 +59,6 @@ class NoteInterface extends AbstractActivityPubInterface implements IActivityPub
 		}
 	}
 
-
 	/**
 	 * @throws InvalidOriginException|ItemAlreadyExistsException
 	 */
@@ -130,7 +129,6 @@ class NoteInterface extends AbstractActivityPubInterface implements IActivityPub
 		/** @var Note $item */
 		$this->streamRequest->deleteById($item->getId(), Note::TYPE);
 	}
-
 
 	public function updateDetails(Note $stream): void {
 		if ($stream->getInReplyTo() === '') {

--- a/lib/Migration/Version1000Date20221118000001.php
+++ b/lib/Migration/Version1000Date20221118000001.php
@@ -44,10 +44,8 @@ class Version1000Date20221118000001 extends SimpleMigrationStep {
 		$this->createStreamQueue($schema);
 		$this->createStreamTags($schema);
 
-
 		return $schema;
 	}
-
 
 	/**
 	 * @param ISchemaWrapper $schema
@@ -121,7 +119,6 @@ class Version1000Date20221118000001 extends SimpleMigrationStep {
 		$table->setPrimaryKey(['id_prim']);
 		$table->addUniqueIndex(['actor_id_prim', 'object_id_prim', 'type'], 'apopt');
 	}
-
 
 	/**
 	 * @param ISchemaWrapper $schema
@@ -211,7 +208,6 @@ class Version1000Date20221118000001 extends SimpleMigrationStep {
 
 		$table->setPrimaryKey(['id_prim']);
 	}
-
 
 	/**
 	 * @param ISchemaWrapper $schema
@@ -309,7 +305,6 @@ class Version1000Date20221118000001 extends SimpleMigrationStep {
 		$table->addUniqueIndex(['accepted', 'object_id_prim', 'actor_id_prim'], 'aoa');
 	}
 
-
 	/**
 	 * @param ISchemaWrapper $schema
 	 *
@@ -338,7 +333,6 @@ class Version1000Date20221118000001 extends SimpleMigrationStep {
 
 		$table->setPrimaryKey(['hashtag']);
 	}
-
 
 	/**
 	 * @param ISchemaWrapper $schema
@@ -467,7 +461,6 @@ class Version1000Date20221118000001 extends SimpleMigrationStep {
 		$table->setPrimaryKey(['uri']);
 		$table->addIndex(['local', 'uri', 'account_prim']);
 	}
-
 
 	/**
 	 * @param ISchemaWrapper $schema
@@ -713,7 +706,6 @@ class Version1000Date20221118000001 extends SimpleMigrationStep {
 		$table->addIndex(['attributed_to_prim'], 'attributed_to_prim');
 	}
 
-
 	/**
 	 * @param ISchemaWrapper $schema
 	 *
@@ -885,7 +877,6 @@ class Version1000Date20221118000001 extends SimpleMigrationStep {
 		$table->setPrimaryKey(['nid']);
 		$table->addUniqueIndex(['id_prim']);
 	}
-
 
 	/**
 	 * @param ISchemaWrapper $schema
@@ -1153,7 +1144,6 @@ class Version1000Date20221118000001 extends SimpleMigrationStep {
 		$table->addUniqueIndex(['auth_code', 'token', 'app_client_id', 'app_client_secret']);
 	}
 
-
 	/**
 	 * @param ISchemaWrapper $schema
 	 *
@@ -1245,7 +1235,6 @@ class Version1000Date20221118000001 extends SimpleMigrationStep {
 		$table->addIndex(['token']);
 	}
 
-
 	/**
 	 * @param ISchemaWrapper $schema
 	 *
@@ -1312,7 +1301,6 @@ class Version1000Date20221118000001 extends SimpleMigrationStep {
 		$table->addUniqueIndex(['stream_id_prim', 'actor_id_prim'], 'sa');
 	}
 
-
 	/**
 	 * @param ISchemaWrapper $schema
 	 *
@@ -1360,7 +1348,6 @@ class Version1000Date20221118000001 extends SimpleMigrationStep {
 		$table->addUniqueIndex(['stream_id', 'actor_id', 'type'], 'sat');
 		$table->addIndex(['type', 'subtype'], 'ts');
 	}
-
 
 	/**
 	 * @param ISchemaWrapper $schema
@@ -1430,7 +1417,6 @@ class Version1000Date20221118000001 extends SimpleMigrationStep {
 		$table->setPrimaryKey(['id']);
 		$table->addIndex(['token']);
 	}
-
 
 	/**
 	 * @param ISchemaWrapper $schema

--- a/lib/Migration/Version1000Date20230217000002.php
+++ b/lib/Migration/Version1000Date20230217000002.php
@@ -35,7 +35,6 @@ class Version1000Date20230217000002 extends SimpleMigrationStep {
 			}
 		}
 
-
 		// fix nid as primary on social_cache_actor
 		if ($schema->hasTable('social_cache_actor')) {
 			$table = $schema->getTable('social_cache_actor');
@@ -53,7 +52,6 @@ class Version1000Date20230217000002 extends SimpleMigrationStep {
 				$table->setPrimaryKey(['nid']);
 			}
 		}
-
 
 		if ($schema->hasTable('social_cache_doc')) {
 			$table = $schema->getTable('social_cache_doc');
@@ -90,7 +88,7 @@ class Version1000Date20230217000002 extends SimpleMigrationStep {
 					]
 				);
 			}
-			
+
 			if (!$table->hasColumn('blurhash')) {
 				$table->addColumn(
 					'blurhash', Types::STRING,

--- a/lib/Model/ActivityPub/ACore.php
+++ b/lib/Model/ActivityPub/ACore.php
@@ -27,7 +27,6 @@ class ACore extends Item implements JsonSerializable, IQueryRow {
 	use TStringTools;
 	use TPathTools;
 
-
 	public const CONTEXT_PUBLIC = 'https://www.w3.org/ns/activitystreams#Public';
 	public const CONTEXT_ACTIVITYSTREAMS = 'https://www.w3.org/ns/activitystreams';
 	public const CONTEXT_SECURITY = 'https://w3id.org/security/v1';
@@ -46,7 +45,6 @@ class ACore extends Item implements JsonSerializable, IQueryRow {
 	public const FORMAT_LOCAL = 2;
 	public const FORMAT_NOTIFICATION = 3;
 
-
 	/** @var null Item */
 	private $parent = null;
 
@@ -59,7 +57,6 @@ class ACore extends Item implements JsonSerializable, IQueryRow {
 	private ?LinkedDataSignature $signature = null;
 	private int $format = self::FORMAT_ACTIVITYPUB;
 
-
 	/**
 	 * Core constructor.
 	 *
@@ -70,7 +67,6 @@ class ACore extends Item implements JsonSerializable, IQueryRow {
 			$this->setParent($parent);
 		}
 	}
-
 
 	/**
 	 * @return string
@@ -95,7 +91,6 @@ class ACore extends Item implements JsonSerializable, IQueryRow {
 		return $this;
 	}
 
-
 	/**
 	 * @param ACore $parent
 	 *
@@ -113,7 +108,6 @@ class ACore extends Item implements JsonSerializable, IQueryRow {
 	public function getParent(): ACore {
 		return $this->parent;
 	}
-
 
 	/**
 	 * @return bool
@@ -157,7 +151,6 @@ class ACore extends Item implements JsonSerializable, IQueryRow {
 		return parent::getObjectId();
 	}
 
-
 	/**
 	 * @param bool $filter - will remove general url like Public
 	 *
@@ -172,7 +165,6 @@ class ACore extends Item implements JsonSerializable, IQueryRow {
 
 		return array_diff($recipients, [self::CONTEXT_PUBLIC]);
 	}
-
 
 	/**
 	 * @return bool
@@ -197,7 +189,6 @@ class ACore extends Item implements JsonSerializable, IQueryRow {
 		return $this;
 	}
 
-
 	/**
 	 * @return bool
 	 */
@@ -216,14 +207,12 @@ class ACore extends Item implements JsonSerializable, IQueryRow {
 		return $this;
 	}
 
-
 	/**
 	 * @return bool
 	 */
 	public function isPublic(): bool {
 		return in_array(self::CONTEXT_PUBLIC, $this->getRecipients());
 	}
-
 
 	/**
 	 * @return bool
@@ -247,7 +236,6 @@ class ACore extends Item implements JsonSerializable, IQueryRow {
 		return $this;
 	}
 
-
 	/**
 	 * @param string $base
 	 * @param bool $root
@@ -270,7 +258,6 @@ class ACore extends Item implements JsonSerializable, IQueryRow {
 		$this->setId($url . $base . '/' . $this->uuid());
 	}
 
-
 	/**
 	 * @param string $id
 	 *
@@ -289,7 +276,6 @@ class ACore extends Item implements JsonSerializable, IQueryRow {
 			'ACore::checkOrigin - id: ' . $id . ' - origin: ' . $origin
 		);
 	}
-
 
 	/**
 	 * @param string $url
@@ -316,7 +302,6 @@ class ACore extends Item implements JsonSerializable, IQueryRow {
 		}
 	}
 
-
 	/**
 	 * @return bool
 	 */
@@ -338,7 +323,6 @@ class ACore extends Item implements JsonSerializable, IQueryRow {
 		return $this->getParent()
 			->getRoot($chain);
 	}
-
 
 	/**
 	 * @param array $arr
@@ -426,7 +410,6 @@ class ACore extends Item implements JsonSerializable, IQueryRow {
 		return $this;
 	}
 
-
 	/**
 	 * @param string $k
 	 * @param ACore $v
@@ -445,7 +428,6 @@ class ACore extends Item implements JsonSerializable, IQueryRow {
 		return $this;
 	}
 
-
 	/**
 	 * @param int $as
 	 * @param string $k
@@ -461,7 +443,6 @@ class ACore extends Item implements JsonSerializable, IQueryRow {
 			return $default;
 		}
 	}
-
 
 	/**
 	 * @param int $as
@@ -489,7 +470,6 @@ class ACore extends Item implements JsonSerializable, IQueryRow {
 		return $result;
 	}
 
-
 	/**
 	 * // TODO - better checks
 	 *
@@ -510,7 +490,6 @@ class ACore extends Item implements JsonSerializable, IQueryRow {
 
 			case self::AS_TYPE:
 				return $value;
-
 			case self::AS_URL:
 				if (parse_url($value) !== false) {
 					return $value;
@@ -519,7 +498,6 @@ class ACore extends Item implements JsonSerializable, IQueryRow {
 
 			case self::AS_DATE:
 				return $value;
-
 			case self::AS_STRING:
 				// Decode first: stripping tags and *then* decoding entities lets
 				// `&lt;script&gt;` come back to life as a real element
@@ -527,18 +505,15 @@ class ACore extends Item implements JsonSerializable, IQueryRow {
 				$value = strip_tags($value);
 
 				return $value;
-
 			case self::AS_CONTENT:
 				// Remote HTML is rendered into every local reader's timeline.
 				// strip_tags() cannot do this job: it keeps attributes on the
 				// tags it allows, so `onclick` and `javascript:` survive it.
 				return HtmlSanitizer::sanitize($value);
-
 			case self::AS_USERNAME:
 				$value = strip_tags($value);
 
 				return $value;
-
 			case self::AS_ACCOUNT:
 				$value = strip_tags($value);
 
@@ -551,7 +526,6 @@ class ACore extends Item implements JsonSerializable, IQueryRow {
 			return '';
 		}
 	}
-
 
 	/**
 	 * @param int $as
@@ -580,7 +554,6 @@ class ACore extends Item implements JsonSerializable, IQueryRow {
 		throw new InvalidResourceEntryException($as . ' ' . json_encode($values));
 	}
 
-
 	/**
 	 * @param array $data
 	 */
@@ -596,7 +569,6 @@ class ACore extends Item implements JsonSerializable, IQueryRow {
 		$this->setObjectId($this->validate(self::AS_ID, 'object', $data, ''));
 		$this->setTags($this->validateArray(self::AS_TAGS, 'tag', $data, []));
 	}
-
 
 	/**
 	 * @param array $data
@@ -648,7 +620,6 @@ class ACore extends Item implements JsonSerializable, IQueryRow {
 		return $this->format;
 	}
 
-
 	/**
 	 * @return array
 	 */
@@ -663,7 +634,6 @@ class ACore extends Item implements JsonSerializable, IQueryRow {
 
 		return $this->exportAsActivityPub();
 	}
-
 
 	/**
 	 * @return array
@@ -730,7 +700,6 @@ class ACore extends Item implements JsonSerializable, IQueryRow {
 
 		return $result;
 	}
-
 
 	/**
 	 * @return array

--- a/lib/Model/ActivityPub/Activity/Accept.php
+++ b/lib/Model/ActivityPub/Activity/Accept.php
@@ -20,8 +20,6 @@ use OCA\Social\Model\ActivityPub\ACore;
 class Accept extends ACore implements JsonSerializable {
 	public const TYPE = 'Accept';
 
-
-
 	/**
 	 * Undo constructor.
 	 *
@@ -33,14 +31,12 @@ class Accept extends ACore implements JsonSerializable {
 		$this->setType(self::TYPE);
 	}
 
-
 	/**
 	 * @param array $data
 	 */
 	public function import(array $data) {
 		parent::import($data);
 	}
-
 
 	/**
 	 * @return array

--- a/lib/Model/ActivityPub/Activity/Add.php
+++ b/lib/Model/ActivityPub/Activity/Add.php
@@ -20,7 +20,6 @@ use OCA\Social\Model\ActivityPub\ACore;
 class Add extends ACore implements JsonSerializable {
 	public const TYPE = 'Add';
 
-
 	/**
 	 * Activity constructor.
 	 *
@@ -32,14 +31,12 @@ class Add extends ACore implements JsonSerializable {
 		$this->setType(self::TYPE);
 	}
 
-
 	/**
 	 * @param array $data
 	 */
 	public function import(array $data) {
 		parent::import($data);
 	}
-
 
 	/**
 	 * @return array

--- a/lib/Model/ActivityPub/Activity/Block.php
+++ b/lib/Model/ActivityPub/Activity/Block.php
@@ -20,7 +20,6 @@ use OCA\Social\Model\ActivityPub\ACore;
 class Block extends ACore implements JsonSerializable {
 	public const TYPE = 'Block';
 
-
 	/**
 	 * Block constructor.
 	 *
@@ -32,14 +31,12 @@ class Block extends ACore implements JsonSerializable {
 		$this->setType(self::TYPE);
 	}
 
-
 	/**
 	 * @param array $data
 	 */
 	public function import(array $data) {
 		parent::import($data);
 	}
-
 
 	/**
 	 * @return array

--- a/lib/Model/ActivityPub/Activity/Create.php
+++ b/lib/Model/ActivityPub/Activity/Create.php
@@ -20,7 +20,6 @@ use OCA\Social\Model\ActivityPub\ACore;
 class Create extends ACore implements JsonSerializable {
 	public const TYPE = 'Create';
 
-
 	/**
 	 * Create constructor.
 	 *
@@ -32,14 +31,12 @@ class Create extends ACore implements JsonSerializable {
 		$this->setType(self::TYPE);
 	}
 
-
 	/**
 	 * @param array $data
 	 */
 	public function import(array $data) {
 		parent::import($data);
 	}
-
 
 	/**
 	 * @return array

--- a/lib/Model/ActivityPub/Activity/Delete.php
+++ b/lib/Model/ActivityPub/Activity/Delete.php
@@ -20,7 +20,6 @@ use OCA\Social\Model\ActivityPub\ACore;
 class Delete extends ACore implements JsonSerializable {
 	public const TYPE = 'Delete';
 
-
 	/**
 	 * Activity constructor.
 	 *
@@ -32,7 +31,6 @@ class Delete extends ACore implements JsonSerializable {
 		$this->setType(self::TYPE);
 	}
 
-
 	/**
 	 * @param array $data
 	 */
@@ -40,7 +38,6 @@ class Delete extends ACore implements JsonSerializable {
 		parent::import($data);
 		$this->setActorId($this->validate(ACore::AS_ID, 'actor', $data, ''));
 	}
-
 
 	/**
 	 * @return array

--- a/lib/Model/ActivityPub/Activity/Move.php
+++ b/lib/Model/ActivityPub/Activity/Move.php
@@ -21,7 +21,6 @@ class Move extends ACore implements JsonSerializable {
 		$this->setType(self::TYPE);
 	}
 
-
 	/**
 	 * @param array $data
 	 */
@@ -31,7 +30,6 @@ class Move extends ACore implements JsonSerializable {
 		$this->setObjectId($this->validate(ACore::AS_ID, 'object', $data, ''));
 		$this->setTarget($this->validate(ACore::AS_ID, 'target', $data, ''));
 	}
-
 
 	/**
 	 * @return array

--- a/lib/Model/ActivityPub/Activity/Reject.php
+++ b/lib/Model/ActivityPub/Activity/Reject.php
@@ -20,8 +20,6 @@ use OCA\Social\Model\ActivityPub\ACore;
 class Reject extends ACore implements JsonSerializable {
 	public const TYPE = 'Reject';
 
-
-
 	/**
 	 * Undo constructor.
 	 *
@@ -33,14 +31,12 @@ class Reject extends ACore implements JsonSerializable {
 		$this->setType(self::TYPE);
 	}
 
-
 	/**
 	 * @param array $data
 	 */
 	public function import(array $data) {
 		parent::import($data);
 	}
-
 
 	/**
 	 * @return array

--- a/lib/Model/ActivityPub/Activity/Remove.php
+++ b/lib/Model/ActivityPub/Activity/Remove.php
@@ -20,7 +20,6 @@ use OCA\Social\Model\ActivityPub\ACore;
 class Remove extends ACore implements JsonSerializable {
 	public const TYPE = 'Remove';
 
-
 	/**
 	 * Remove constructor.
 	 *
@@ -32,14 +31,12 @@ class Remove extends ACore implements JsonSerializable {
 		$this->setType(self::TYPE);
 	}
 
-
 	/**
 	 * @param array $data
 	 */
 	public function import(array $data) {
 		parent::import($data);
 	}
-
 
 	/**
 	 * @return array

--- a/lib/Model/ActivityPub/Activity/Undo.php
+++ b/lib/Model/ActivityPub/Activity/Undo.php
@@ -20,7 +20,6 @@ use OCA\Social\Model\ActivityPub\ACore;
 class Undo extends ACore implements JsonSerializable {
 	public const TYPE = 'Undo';
 
-
 	/**
 	 * Undo constructor.
 	 *
@@ -32,14 +31,12 @@ class Undo extends ACore implements JsonSerializable {
 		$this->setType(self::TYPE);
 	}
 
-
 	/**
 	 * @param array $data
 	 */
 	public function import(array $data) {
 		parent::import($data);
 	}
-
 
 	/**
 	 * @return array

--- a/lib/Model/ActivityPub/Activity/Update.php
+++ b/lib/Model/ActivityPub/Activity/Update.php
@@ -20,7 +20,6 @@ use OCA\Social\Model\ActivityPub\ACore;
 class Update extends ACore implements JsonSerializable {
 	public const TYPE = 'Update';
 
-
 	/**
 	 * Update constructor.
 	 *
@@ -32,14 +31,12 @@ class Update extends ACore implements JsonSerializable {
 		$this->setType(self::TYPE);
 	}
 
-
 	/**
 	 * @param array $data
 	 */
 	public function import(array $data) {
 		parent::import($data);
 	}
-
 
 	/**
 	 * @return array

--- a/lib/Model/ActivityPub/Actor/Person.php
+++ b/lib/Model/ActivityPub/Actor/Person.php
@@ -32,14 +32,11 @@ use OCP\Server;
 class Person extends ACore implements IQueryRow, JsonSerializable {
 	use TDetails;
 
-
 	public const TYPE = 'Person';
-
 
 	public const LINK_VIEWER = 'viewer';
 	public const LINK_REMOTE = 'remote';
 	public const LINK_LOCAL = 'local';
-
 
 	private string $userId = '';
 	private string $name = '';
@@ -83,7 +80,6 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 		$this->setType(self::TYPE);
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -102,7 +98,6 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -120,7 +115,6 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return string
@@ -144,7 +138,6 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -162,7 +155,6 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return string
@@ -187,7 +179,6 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -210,7 +201,6 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -228,7 +218,6 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return string
@@ -248,7 +237,6 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return int
 	 */
@@ -267,7 +255,6 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return int
 	 */
@@ -285,7 +272,6 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return string
@@ -344,7 +330,6 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return string
@@ -422,7 +407,6 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -440,7 +424,6 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return bool
@@ -460,7 +443,6 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return bool
 	 */
@@ -478,7 +460,6 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return bool
@@ -498,7 +479,6 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -516,7 +496,6 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return bool
@@ -536,7 +515,6 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -554,7 +532,6 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return int
@@ -574,7 +551,6 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return int
 	 */
@@ -592,7 +568,6 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return string
@@ -765,7 +740,6 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 		}
 	}
 
-
 	/**
 	 * @return array
 	 */
@@ -830,7 +804,6 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 		return $result;
 	}
 
-
 	/**
 	 * @return array
 	 */
@@ -841,8 +814,8 @@ class Person extends ACore implements IQueryRow, JsonSerializable {
 
 		$headerUrl = $this->getHeader();
 		$details = $this->getDetailsAll();
-		$result =
-			[
+		$result
+			= [
 				'id' => (string)$this->getNid(),
 				'username' => $this->getPreferredUsername(),
 				'acct' => $this->isLocal() ? $this->getPreferredUsername() : $this->getAccount(),

--- a/lib/Model/ActivityPub/Internal/SocialAppNotification.php
+++ b/lib/Model/ActivityPub/Internal/SocialAppNotification.php
@@ -16,7 +16,6 @@ use OCA\Social\Model\ActivityPub\Stream;
 class SocialAppNotification extends Stream implements JsonSerializable {
 	public const TYPE = 'SocialAppNotification';
 
-
 	/**
 	 * Notification constructor.
 	 *
@@ -28,7 +27,6 @@ class SocialAppNotification extends Stream implements JsonSerializable {
 		$this->setType(self::TYPE);
 	}
 
-
 	/**
 	 * @param array $data
 	 *
@@ -38,7 +36,6 @@ class SocialAppNotification extends Stream implements JsonSerializable {
 		//parent::import($data);
 	}
 
-
 	/**
 	 * @param array $data
 	 *
@@ -47,7 +44,6 @@ class SocialAppNotification extends Stream implements JsonSerializable {
 	public function importFromDatabase(array $data) {
 		parent::importFromDatabase($data);
 	}
-
 
 	/**
 	 * @return array

--- a/lib/Model/ActivityPub/Item.php
+++ b/lib/Model/ActivityPub/Item.php
@@ -146,7 +146,6 @@ class Item {
 		return $this;
 	}
 
-
 	/**
 	 * @return Person
 	 */
@@ -171,7 +170,6 @@ class Item {
 		return true;
 	}
 
-
 	/**
 	 * @param string $actorId
 	 *
@@ -195,7 +193,6 @@ class Item {
 		return $this->actorId;
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -213,7 +210,6 @@ class Item {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return string
@@ -233,7 +229,6 @@ class Item {
 		return $this;
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -251,7 +246,6 @@ class Item {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return string
@@ -312,7 +306,6 @@ class Item {
 		return $this;
 	}
 
-
 	/**
 	 * @param string $cc
 	 *
@@ -350,7 +343,6 @@ class Item {
 		return (in_array($cc, $this->cc));
 	}
 
-
 	/**
 	 * @return array
 	 */
@@ -369,7 +361,6 @@ class Item {
 		return $this;
 	}
 
-
 	/**
 	 * @return array
 	 */
@@ -387,7 +378,6 @@ class Item {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return string
@@ -410,7 +400,6 @@ class Item {
 		return $this->originCreationTime;
 	}
 
-
 	/**
 	 * @param string $origin
 	 *
@@ -427,7 +416,6 @@ class Item {
 
 		return $this;
 	}
-
 
 	/**
 	 * @param string $published
@@ -446,7 +434,6 @@ class Item {
 	public function getPublished(): string {
 		return $this->published;
 	}
-
 
 	/**
 	 * @param array $tag
@@ -489,7 +476,6 @@ class Item {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return string
@@ -537,7 +523,6 @@ class Item {
 		return $this;
 	}
 
-
 	/**
 	 * @return bool
 	 */
@@ -556,7 +541,6 @@ class Item {
 		return $this;
 	}
 
-
 	/**
 	 * @return bool
 	 */
@@ -574,7 +558,6 @@ class Item {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return string

--- a/lib/Model/ActivityPub/Object/Announce.php
+++ b/lib/Model/ActivityPub/Object/Announce.php
@@ -22,7 +22,6 @@ use OCA\Social\Model\ActivityPub\Stream;
 class Announce extends Stream implements JsonSerializable {
 	public const TYPE = 'Announce';
 
-
 	/**
 	 * Follow constructor.
 	 *
@@ -33,7 +32,6 @@ class Announce extends Stream implements JsonSerializable {
 
 		$this->setType(self::TYPE);
 	}
-
 
 	/**
 	 * @param array $data

--- a/lib/Model/ActivityPub/Object/Document.php
+++ b/lib/Model/ActivityPub/Object/Document.php
@@ -44,7 +44,6 @@ class Document extends ACore implements JsonSerializable {
 	private array $localCopySize = [0, 0];
 	private array $resizedCopySize = [0, 0];
 
-
 	/**
 	 * Document constructor.
 	 *
@@ -56,7 +55,6 @@ class Document extends ACore implements JsonSerializable {
 		$this->setType(self::TYPE);
 	}
 
-
 	public function setAccount(string $account): self {
 		$this->account = $account;
 
@@ -66,7 +64,6 @@ class Document extends ACore implements JsonSerializable {
 	public function getAccount(): string {
 		return $this->account;
 	}
-
 
 	/**
 	 * @return string
@@ -86,7 +83,6 @@ class Document extends ACore implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -105,7 +101,6 @@ class Document extends ACore implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -123,7 +118,6 @@ class Document extends ACore implements JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return string
@@ -161,7 +155,6 @@ class Document extends ACore implements JsonSerializable {
 		return $this->resizedCopySize;
 	}
 
-
 	public function setBlurHash(string $blurHash): self {
 		$this->blurHash = $blurHash;
 
@@ -192,7 +185,6 @@ class Document extends ACore implements JsonSerializable {
 		return $this->description;
 	}
 
-
 	/**
 	 * @return bool
 	 */
@@ -210,7 +202,6 @@ class Document extends ACore implements JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return string
@@ -230,7 +221,6 @@ class Document extends ACore implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return int
 	 */
@@ -249,7 +239,6 @@ class Document extends ACore implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return int
 	 */
@@ -267,7 +256,6 @@ class Document extends ACore implements JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @param array $data
@@ -292,7 +280,6 @@ class Document extends ACore implements JsonSerializable {
 			//			$this->checkOrigin($this->getId());
 		}
 	}
-
 
 	/**
 	 * @param array $data
@@ -349,7 +336,6 @@ class Document extends ACore implements JsonSerializable {
 		return $result;
 	}
 
-
 	public function getMediaUrl(IURLGenerator $urlGenerator, string $mime = ''): string {
 		$ext = '';
 		if ($mime !== '') {
@@ -375,7 +361,6 @@ class Document extends ACore implements JsonSerializable {
 			['uuid' => $this->getResizedCopy() . $ext]
 		);
 	}
-
 
 	/**
 	 * @param IURLGenerator|null $urlGenerator

--- a/lib/Model/ActivityPub/Object/Follow.php
+++ b/lib/Model/ActivityPub/Object/Follow.php
@@ -38,7 +38,6 @@ class Follow extends ACore implements JsonSerializable, IQueryRow {
 		$this->setType(self::TYPE);
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -56,7 +55,6 @@ class Follow extends ACore implements JsonSerializable, IQueryRow {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return string
@@ -76,7 +74,6 @@ class Follow extends ACore implements JsonSerializable, IQueryRow {
 		return $this;
 	}
 
-
 	/**
 	 * @return bool
 	 */
@@ -95,14 +92,12 @@ class Follow extends ACore implements JsonSerializable, IQueryRow {
 		return $this;
 	}
 
-
 	/**
 	 * @param array $data
 	 */
 	public function import(array $data) {
 		parent::import($data);
 	}
-
 
 	/**
 	 * @param array $data
@@ -114,7 +109,6 @@ class Follow extends ACore implements JsonSerializable, IQueryRow {
 		$this->setFollowId($this->get('follow_id', $data, ''));
 		$this->setFollowIdPrim($this->get('follow_id_prim', $data, ''));
 	}
-
 
 	/**
 	 * @return array

--- a/lib/Model/ActivityPub/Object/Image.php
+++ b/lib/Model/ActivityPub/Object/Image.php
@@ -22,7 +22,6 @@ use OCA\Social\Model\ActivityPub\ACore;
 class Image extends Document implements JsonSerializable {
 	public const TYPE = 'Image';
 
-
 	/**
 	 * Image constructor.
 	 *
@@ -34,7 +33,6 @@ class Image extends Document implements JsonSerializable {
 		$this->setType(self::TYPE);
 	}
 
-
 	/**
 	 * @param array $data
 	 *
@@ -44,7 +42,6 @@ class Image extends Document implements JsonSerializable {
 	public function import(array $data) {
 		parent::import($data);
 	}
-
 
 	/**
 	 * @return array

--- a/lib/Model/ActivityPub/Object/Like.php
+++ b/lib/Model/ActivityPub/Object/Like.php
@@ -20,7 +20,6 @@ use OCA\Social\Model\ActivityPub\ACore;
 class Like extends ACore implements JsonSerializable {
 	public const TYPE = 'Like';
 
-
 	/**
 	 * Like constructor.
 	 *
@@ -32,14 +31,12 @@ class Like extends ACore implements JsonSerializable {
 		$this->setType(self::TYPE);
 	}
 
-
 	/**
 	 * @param array $data
 	 */
 	public function import(array $data) {
 		parent::import($data);
 	}
-
 
 	/**
 	 * @return array

--- a/lib/Model/ActivityPub/Object/Note.php
+++ b/lib/Model/ActivityPub/Object/Note.php
@@ -66,7 +66,6 @@ class Note extends Stream implements JsonSerializable {
 		$this->setDetailArray('mentions', $mentions);
 	}
 
-
 	public function fillHashtags(): void {
 		$tags = $this->getTags('Hashtag');
 		$hashtags = [];
@@ -81,7 +80,6 @@ class Note extends Stream implements JsonSerializable {
 		$this->setHashtags($hashtags);
 	}
 
-
 	/**
 	 * @throws ItemAlreadyExistsException
 	 */
@@ -91,7 +89,6 @@ class Note extends Stream implements JsonSerializable {
 		$this->fillHashtags();
 		$this->fillMentions();
 	}
-
 
 	public function importFromDatabase(array $data): void {
 		parent::importFromDatabase($data);

--- a/lib/Model/ActivityPub/Object/Tombstone.php
+++ b/lib/Model/ActivityPub/Object/Tombstone.php
@@ -20,8 +20,6 @@ use OCA\Social\Model\ActivityPub\ACore;
 class Tombstone extends ACore implements JsonSerializable {
 	public const TYPE = 'Tombstone';
 
-
-
 	/**
 	 * Undo constructor.
 	 *
@@ -33,14 +31,12 @@ class Tombstone extends ACore implements JsonSerializable {
 		$this->setType(self::TYPE);
 	}
 
-
 	/**
 	 * @param array $data
 	 */
 	public function import(array $data) {
 		parent::import($data);
 	}
-
 
 	/**
 	 * @return array

--- a/lib/Model/ActivityPub/Stream.php
+++ b/lib/Model/ActivityPub/Stream.php
@@ -40,9 +40,7 @@ use OCP\Server;
 class Stream extends ACore implements IQueryRow, JsonSerializable {
 	use TDetails;
 
-
 	public const TYPE = 'Stream';
-
 
 	public const TYPE_PUBLIC = 'public';
 	public const TYPE_UNLISTED = 'unlisted';
@@ -75,7 +73,6 @@ class Stream extends ACore implements IQueryRow, JsonSerializable {
 		parent::__construct($parent);
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -94,14 +91,12 @@ class Stream extends ACore implements IQueryRow, JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return string
 	 */
 	public function getContent(): string {
 		return $this->content;
 	}
-
 
 	/**
 	 * @param string $content
@@ -132,7 +127,6 @@ class Stream extends ACore implements IQueryRow, JsonSerializable {
 		return $this->visibility;
 	}
 
-
 	/**
 	 * The content warning. On ActivityPub this is the object's `summary`
 	 * (which is also the database column), so the two accessors share one field —
@@ -155,7 +149,6 @@ class Stream extends ACore implements IQueryRow, JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -173,7 +166,6 @@ class Stream extends ACore implements IQueryRow, JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return string
@@ -211,7 +203,6 @@ class Stream extends ACore implements IQueryRow, JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return MediaAttachment[]
 	 */
@@ -230,7 +221,6 @@ class Stream extends ACore implements IQueryRow, JsonSerializable {
 		return $this;
 	}
 
-
 	public function getMentions(): array {
 		return $this->mentions;
 	}
@@ -240,7 +230,6 @@ class Stream extends ACore implements IQueryRow, JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return bool
@@ -260,7 +249,6 @@ class Stream extends ACore implements IQueryRow, JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -278,7 +266,6 @@ class Stream extends ACore implements IQueryRow, JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return int
@@ -308,7 +295,6 @@ class Stream extends ACore implements IQueryRow, JsonSerializable {
 		}
 	}
 
-
 	/**
 	 * @return bool
 	 */
@@ -333,7 +319,6 @@ class Stream extends ACore implements IQueryRow, JsonSerializable {
 
 		return $this;
 	}
-
 
 	public function addCacheItem(string $url): Stream {
 		$cacheItem = new CacheItem($url);
@@ -365,7 +350,6 @@ class Stream extends ACore implements IQueryRow, JsonSerializable {
 		return ($this->action !== null);
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -384,7 +368,6 @@ class Stream extends ACore implements IQueryRow, JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return bool
 	 */
@@ -402,7 +385,6 @@ class Stream extends ACore implements IQueryRow, JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @param array $data
@@ -436,7 +418,6 @@ class Stream extends ACore implements IQueryRow, JsonSerializable {
 			$this->setDetailInt('replies', (int)$data['replies']['totalItems']);
 		}
 	}
-
 
 	/**
 	 * @throws ItemAlreadyExistsException
@@ -482,7 +463,6 @@ class Stream extends ACore implements IQueryRow, JsonSerializable {
 
 		$this->setAttachments($new);
 	}
-
 
 	/**
 	 * @param array $data
@@ -589,7 +569,6 @@ class Stream extends ACore implements IQueryRow, JsonSerializable {
 		//		$this->setCompleteDetails(true);
 	}
 
-
 	/**
 	 * @return array
 	 */
@@ -623,7 +602,6 @@ class Stream extends ACore implements IQueryRow, JsonSerializable {
 
 		return $result;
 	}
-
 
 	/**
 	 * @return array
@@ -682,7 +660,6 @@ class Stream extends ACore implements IQueryRow, JsonSerializable {
 		return array_merge(parent::exportAsLocal(), $result);
 	}
 
-
 	public function exportAsNotification(): array {
 		// TODO - implements:
 		// status = Someone you enabled notifications for has posted a status
@@ -723,7 +700,6 @@ class Stream extends ACore implements IQueryRow, JsonSerializable {
 
 		return array_merge(parent::exportAsNotification(), $result);
 	}
-
 
 	public function jsonSerialize(): array {
 		$result = parent::jsonSerialize();

--- a/lib/Model/Client/AttachmentMeta.php
+++ b/lib/Model/Client/AttachmentMeta.php
@@ -221,7 +221,6 @@ class AttachmentMeta implements JsonSerializable {
 		return $this;
 	}
 
-
 	public function jsonSerialize(): array {
 		return array_filter(
 			[

--- a/lib/Model/Client/MediaAttachment.php
+++ b/lib/Model/Client/MediaAttachment.php
@@ -118,7 +118,6 @@ class MediaAttachment implements JsonSerializable {
 		return $this->blurHash;
 	}
 
-
 	public function setExportFormat(int $exportFormat): self {
 		$this->exportFormat = $exportFormat;
 
@@ -128,7 +127,6 @@ class MediaAttachment implements JsonSerializable {
 	public function getExportFormat(): int {
 		return $this->exportFormat;
 	}
-
 
 	public function import(array $data): self {
 		$this->setId($this->get('id', $data));

--- a/lib/Model/Client/Options/CoreOptions.php
+++ b/lib/Model/Client/Options/CoreOptions.php
@@ -19,7 +19,6 @@ use OCA\Social\Model\ActivityPub\ACore;
 class CoreOptions {
 	private int $format = ACore::FORMAT_ACTIVITYPUB;
 
-
 	/**
 	 * @return int
 	 */

--- a/lib/Model/Client/Options/ProbeOptions.php
+++ b/lib/Model/Client/Options/ProbeOptions.php
@@ -50,7 +50,6 @@ class ProbeOptions extends CoreOptions implements JsonSerializable {
 	private array $excludeTypes = [];
 	private string $accountId = '';
 
-
 	/**
 	 * ProbeOptions constructor.
 	 *
@@ -61,7 +60,6 @@ class ProbeOptions extends CoreOptions implements JsonSerializable {
 			$this->fromArray($request->getParams());
 		}
 	}
-
 
 	/**
 	 * @return string
@@ -81,7 +79,6 @@ class ProbeOptions extends CoreOptions implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return bool
 	 */
@@ -99,7 +96,6 @@ class ProbeOptions extends CoreOptions implements JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return bool
@@ -119,7 +115,6 @@ class ProbeOptions extends CoreOptions implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return bool
 	 */
@@ -137,7 +132,6 @@ class ProbeOptions extends CoreOptions implements JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return int
@@ -157,7 +151,6 @@ class ProbeOptions extends CoreOptions implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return int
 	 */
@@ -176,7 +169,6 @@ class ProbeOptions extends CoreOptions implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return int
 	 */
@@ -194,7 +186,6 @@ class ProbeOptions extends CoreOptions implements JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return int
@@ -216,7 +207,6 @@ class ProbeOptions extends CoreOptions implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return bool
 	 */
@@ -234,7 +224,6 @@ class ProbeOptions extends CoreOptions implements JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @param string $argument
@@ -254,7 +243,6 @@ class ProbeOptions extends CoreOptions implements JsonSerializable {
 		return $this->argument;
 	}
 
-
 	/**
 	 * @param array $types
 	 *
@@ -272,7 +260,6 @@ class ProbeOptions extends CoreOptions implements JsonSerializable {
 	public function getTypes(): array {
 		return $this->types;
 	}
-
 
 	/**
 	 * @param array $excludeTypes
@@ -292,7 +279,6 @@ class ProbeOptions extends CoreOptions implements JsonSerializable {
 		return $this->excludeTypes;
 	}
 
-
 	/**
 	 * @param string $accountId
 	 *
@@ -304,14 +290,12 @@ class ProbeOptions extends CoreOptions implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return string
 	 */
 	public function getAccountId(): string {
 		return $this->accountId;
 	}
-
 
 	/**
 	 * @param array $arr
@@ -330,7 +314,6 @@ class ProbeOptions extends CoreOptions implements JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return array

--- a/lib/Model/Client/SocialClient.php
+++ b/lib/Model/Client/SocialClient.php
@@ -41,13 +41,11 @@ class SocialClient implements IQueryRow, JsonSerializable {
 	//	/** @var array */
 	//	private $tokenScopes = [];
 
-
 	/**
 	 * SocialClient constructor.
 	 */
 	public function __construct() {
 	}
-
 
 	/**
 	 * @return int
@@ -67,7 +65,6 @@ class SocialClient implements IQueryRow, JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -85,7 +82,6 @@ class SocialClient implements IQueryRow, JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return string
@@ -105,7 +101,6 @@ class SocialClient implements IQueryRow, JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return array
 	 */
@@ -123,7 +118,6 @@ class SocialClient implements IQueryRow, JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return string
@@ -143,7 +137,6 @@ class SocialClient implements IQueryRow, JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -161,7 +154,6 @@ class SocialClient implements IQueryRow, JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return array
@@ -181,7 +173,6 @@ class SocialClient implements IQueryRow, JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return array
 	 */
@@ -199,7 +190,6 @@ class SocialClient implements IQueryRow, JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return string
@@ -219,7 +209,6 @@ class SocialClient implements IQueryRow, JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -237,7 +226,6 @@ class SocialClient implements IQueryRow, JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return string
@@ -276,7 +264,6 @@ class SocialClient implements IQueryRow, JsonSerializable {
 	//		return $this;
 	//	}
 
-
 	/**
 	 * @return int
 	 */
@@ -294,7 +281,6 @@ class SocialClient implements IQueryRow, JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return string
@@ -314,7 +300,6 @@ class SocialClient implements IQueryRow, JsonSerializable {
 		return $this;
 	}
 
-
 	//	/**
 	//	 * @return array
 	//	 */
@@ -333,7 +318,6 @@ class SocialClient implements IQueryRow, JsonSerializable {
 	//		return $this;
 	//	}
 
-
 	/**
 	 * @return int
 	 */
@@ -348,7 +332,6 @@ class SocialClient implements IQueryRow, JsonSerializable {
 		$this->creation = $creation;
 	}
 
-
 	/**
 	 * @param string $scopes
 	 *
@@ -357,7 +340,6 @@ class SocialClient implements IQueryRow, JsonSerializable {
 	public function getScopesFromString(string $scopes): array {
 		return explode(' ', $scopes);
 	}
-
 
 	/**
 	 * @param array $data
@@ -385,7 +367,6 @@ class SocialClient implements IQueryRow, JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return array

--- a/lib/Model/Client/Status.php
+++ b/lib/Model/Client/Status.php
@@ -27,7 +27,6 @@ class Status implements \JsonSerializable {
 	public function __construct() {
 	}
 
-
 	/**
 	 * @param string $contentType
 	 *
@@ -45,7 +44,6 @@ class Status implements \JsonSerializable {
 	public function getContentType(): string {
 		return $this->contentType;
 	}
-
 
 	/**
 	 * @param bool $sensitive
@@ -65,7 +63,6 @@ class Status implements \JsonSerializable {
 		return $this->sensitive;
 	}
 
-
 	/**
 	 * @param string $visibility
 	 *
@@ -83,7 +80,6 @@ class Status implements \JsonSerializable {
 	public function getVisibility(): string {
 		return $this->visibility;
 	}
-
 
 	/**
 	 * @param string $spoilerText
@@ -125,7 +121,6 @@ class Status implements \JsonSerializable {
 		return $this->inReplyToId;
 	}
 
-
 	/**
 	 * @param string $status
 	 *
@@ -143,7 +138,6 @@ class Status implements \JsonSerializable {
 	public function getStatus(): string {
 		return $this->status;
 	}
-
 
 	public function import(array $data): self {
 		$this->setContentType($this->get('content_type', $data));

--- a/lib/Model/Instance.php
+++ b/lib/Model/Instance.php
@@ -155,7 +155,6 @@ class Instance implements IQueryRow, JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -209,7 +208,6 @@ class Instance implements IQueryRow, JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return bool
 	 */
@@ -242,7 +240,6 @@ class Instance implements IQueryRow, JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @param array $data
 	 *
@@ -268,7 +265,6 @@ class Instance implements IQueryRow, JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return array

--- a/lib/Model/InstancePath.php
+++ b/lib/Model/InstancePath.php
@@ -20,7 +20,6 @@ use OCA\Social\Tools\Traits\TArrayTools;
 class InstancePath implements JsonSerializable {
 	use TArrayTools;
 
-
 	public const TYPE_PUBLIC = 0;
 	public const TYPE_INBOX = 1;
 	public const TYPE_GLOBAL = 2;
@@ -37,7 +36,6 @@ class InstancePath implements JsonSerializable {
 	private int $type = 0;
 	private int $priority = 0;
 
-
 	/**
 	 * InstancePath constructor.
 	 *
@@ -50,7 +48,6 @@ class InstancePath implements JsonSerializable {
 		$this->type = $type;
 		$this->priority = $priority;
 	}
-
 
 	/**
 	 * @param string $uri
@@ -70,7 +67,6 @@ class InstancePath implements JsonSerializable {
 		return $this->uri;
 	}
 
-
 	/**
 	 * @param int $type
 	 *
@@ -88,7 +84,6 @@ class InstancePath implements JsonSerializable {
 	public function getType(): int {
 		return $this->type;
 	}
-
 
 	/**
 	 * @return int
@@ -108,13 +103,11 @@ class InstancePath implements JsonSerializable {
 		return $this;
 	}
 
-
 	public function getProtocol(): string {
 		$info = parse_url($this->getUri());
 
 		return $this->get('scheme', $info, '');
 	}
-
 
 	/**
 	 * @return string
@@ -125,7 +118,6 @@ class InstancePath implements JsonSerializable {
 		return $this->get('host', $info, '');
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -135,7 +127,6 @@ class InstancePath implements JsonSerializable {
 		return $this->get('path', $info, '');
 	}
 
-
 	/**
 	 * @param array $data
 	 */
@@ -144,7 +135,6 @@ class InstancePath implements JsonSerializable {
 		$this->setType($this->getInt('type', $data, 0));
 		$this->setPriority($this->getInt('priority', $data, 0));
 	}
-
 
 	/**
 	 * @return array

--- a/lib/Model/LinkedDataSignature.php
+++ b/lib/Model/LinkedDataSignature.php
@@ -183,7 +183,6 @@ class LinkedDataSignature implements JsonSerializable {
 		return hash('sha256', $res);
 	}
 
-
 	/**
 	 * @throws LinkedDataSignatureMissingException
 	 */
@@ -207,7 +206,6 @@ class LinkedDataSignature implements JsonSerializable {
 
 		$this->setObject($data);
 	}
-
 
 	/**
 	 * @return array

--- a/lib/Model/Post.php
+++ b/lib/Model/Post.php
@@ -54,7 +54,6 @@ class Post implements JsonSerializable {
 		return $this->actor;
 	}
 
-
 	/**
 	 * @param string $to
 	 *
@@ -86,7 +85,6 @@ class Post implements JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return string
@@ -123,7 +121,6 @@ class Post implements JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return array
@@ -186,7 +183,6 @@ class Post implements JsonSerializable {
 		return $this->medias;
 	}
 
-
 	/**
 	 * @return Document[]
 	 */
@@ -205,7 +201,6 @@ class Post implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -219,7 +214,6 @@ class Post implements JsonSerializable {
 	public function setContent(string $content) {
 		$this->content = $content;
 	}
-
 
 	/**
 	 * @return array

--- a/lib/Model/Relationship.php
+++ b/lib/Model/Relationship.php
@@ -42,7 +42,6 @@ class Relationship implements JsonSerializable {
 		return $this->id;
 	}
 
-
 	public function setFollowing(bool $following): self {
 		$this->following = $following;
 

--- a/lib/Model/RequestQueue.php
+++ b/lib/Model/RequestQueue.php
@@ -49,7 +49,6 @@ class RequestQueue implements JsonSerializable {
 		$this->resetToken();
 	}
 
-
 	/**
 	 * @return int
 	 */
@@ -67,7 +66,6 @@ class RequestQueue implements JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return string
@@ -97,7 +95,6 @@ class RequestQueue implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -115,7 +112,6 @@ class RequestQueue implements JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return string
@@ -135,7 +131,6 @@ class RequestQueue implements JsonSerializable {
 		return $this;
 	}
 
-
 	public function getInstance(): ?InstancePath {
 		return $this->instance;
 	}
@@ -151,7 +146,6 @@ class RequestQueue implements JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return int
@@ -171,7 +165,6 @@ class RequestQueue implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return int
 	 */
@@ -189,7 +182,6 @@ class RequestQueue implements JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return int
@@ -209,7 +201,6 @@ class RequestQueue implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return int
 	 */
@@ -227,7 +218,6 @@ class RequestQueue implements JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @param int $timeout

--- a/lib/Model/StreamDetails.php
+++ b/lib/Model/StreamDetails.php
@@ -32,7 +32,6 @@ class StreamDetails implements JsonSerializable {
 	private bool $public = false;
 	private bool $federated = false;
 
-
 	/**
 	 * StreamDetails constructor.
 	 */

--- a/lib/Model/StreamQueue.php
+++ b/lib/Model/StreamQueue.php
@@ -68,7 +68,6 @@ class StreamQueue implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -86,7 +85,6 @@ class StreamQueue implements JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return string
@@ -106,7 +104,6 @@ class StreamQueue implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return int
 	 */
@@ -124,7 +121,6 @@ class StreamQueue implements JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return int
@@ -144,7 +140,6 @@ class StreamQueue implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return int
 	 */
@@ -162,7 +157,6 @@ class StreamQueue implements JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @param array $data
@@ -186,7 +180,6 @@ class StreamQueue implements JsonSerializable {
 			}
 		}
 	}
-
 
 	/**
 	 * @return array

--- a/lib/Model/Test.php
+++ b/lib/Model/Test.php
@@ -21,11 +21,9 @@ use OCA\Social\Tools\Traits\TArrayTools;
 class Test extends SimpleDataStore implements JsonSerializable {
 	use TArrayTools;
 
-
 	public const SEVERITY_USELESS = 'useless';
 	public const SEVERITY_OPTIONAL = 'optional';
 	public const SEVERITY_MANDATORY = 'mandatory';
-
 
 	private string $name;
 
@@ -34,7 +32,6 @@ class Test extends SimpleDataStore implements JsonSerializable {
 	private bool $success = false;
 
 	private array $messages = [];
-
 
 	/**
 	 * Test constructor.
@@ -49,7 +46,6 @@ class Test extends SimpleDataStore implements JsonSerializable {
 		$this->severity = $severity;
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -57,14 +53,12 @@ class Test extends SimpleDataStore implements JsonSerializable {
 		return $this->name;
 	}
 
-
 	/**
 	 * @return string
 	 */
 	public function getSeverity(): string {
 		return $this->severity;
 	}
-
 
 	/**
 	 * @return bool
@@ -84,7 +78,6 @@ class Test extends SimpleDataStore implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return array
 	 */
@@ -102,7 +95,6 @@ class Test extends SimpleDataStore implements JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return array

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -35,7 +35,6 @@ class Notifier implements INotifier {
 
 	protected ICloudIdManager $cloudIdManager;
 
-
 	public function __construct(
 		IL10N $l10n, IFactory $factory, IManager $contactsManager, IURLGenerator $url,
 		ICloudIdManager $cloudIdManager,
@@ -115,7 +114,6 @@ class Notifier implements INotifier {
 			default:
 				throw new InvalidArgumentException();
 		}
-
 
 		foreach ($notification->getActions() as $action) {
 			switch ($action->getLabel()) {

--- a/lib/Providers/ContactsMenuProvider.php
+++ b/lib/Providers/ContactsMenuProvider.php
@@ -37,7 +37,6 @@ class ContactsMenuProvider implements IProvider {
 
 	private AccountService $accountService;
 
-
 	/**
 	 * ContactsMenuProvider constructor.
 	 *
@@ -57,7 +56,6 @@ class ContactsMenuProvider implements IProvider {
 		$this->l10n = $l10n;
 		$this->accountService = $accountService;
 	}
-
 
 	/**
 	 * @param IEntry $entry
@@ -81,7 +79,6 @@ class ContactsMenuProvider implements IProvider {
 			return;
 		}
 	}
-
 
 	/**
 	 * @param IEntry $entry

--- a/lib/Search/UnifiedSearchProvider.php
+++ b/lib/Search/UnifiedSearchProvider.php
@@ -50,7 +50,6 @@ class UnifiedSearchProvider implements IProvider {
 
 	private ?Person $viewer = null;
 
-
 	/**
 	 * UnifiedSearchProvider constructor.
 	 *
@@ -86,7 +85,6 @@ class UnifiedSearchProvider implements IProvider {
 		$this->logger = $logger;
 	}
 
-
 	/**
 	 * return unique id of the provider
 	 */
@@ -94,14 +92,12 @@ class UnifiedSearchProvider implements IProvider {
 		return self::PROVIDER_ID;
 	}
 
-
 	/**
 	 * @return string
 	 */
 	public function getName(): string {
 		return $this->l10n->t('Social');
 	}
-
 
 	/**
 	 * @param string $route
@@ -112,7 +108,6 @@ class UnifiedSearchProvider implements IProvider {
 	public function getOrder(string $route, array $routeParameters): int {
 		return self::ORDER;
 	}
-
 
 	/**
 	 * @param IUser $user
@@ -137,7 +132,6 @@ class UnifiedSearchProvider implements IProvider {
 			$this->l10n->t('Social'), $result, ($query->getCursor() ?? 0) + $query->getLimit()
 		);
 	}
-
 
 	/**
 	 * TODO: switch to SessionService
@@ -170,7 +164,6 @@ class UnifiedSearchProvider implements IProvider {
 		}
 	}
 
-
 	/**
 	 * @param Person[] $accounts
 	 *
@@ -192,7 +185,6 @@ class UnifiedSearchProvider implements IProvider {
 
 		return $result;
 	}
-
 
 	/**
 	 * @param array $hashtags

--- a/lib/Search/UnifiedSearchResult.php
+++ b/lib/Search/UnifiedSearchResult.php
@@ -35,7 +35,6 @@ class UnifiedSearchResult extends SearchResultEntry {
 		parent::__construct($thumbnailUrl, $title, $subline, $resourceUrl, $icon, $rounded);
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -53,7 +52,6 @@ class UnifiedSearchResult extends SearchResultEntry {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return string
@@ -73,7 +71,6 @@ class UnifiedSearchResult extends SearchResultEntry {
 		return $this;
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -91,7 +88,6 @@ class UnifiedSearchResult extends SearchResultEntry {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return string
@@ -111,7 +107,6 @@ class UnifiedSearchResult extends SearchResultEntry {
 		return $this;
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -129,7 +124,6 @@ class UnifiedSearchResult extends SearchResultEntry {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return bool

--- a/lib/Service/AccountService.php
+++ b/lib/Service/AccountService.php
@@ -93,7 +93,6 @@ class AccountService {
 		$this->logger = $logger;
 	}
 
-
 	/**
 	 * @param string $username
 	 *
@@ -120,7 +119,6 @@ class AccountService {
 		return $actor;
 	}
 
-
 	/**
 	 * @return Person
 	 * @throws AccountDoesNotExistException
@@ -137,7 +135,6 @@ class AccountService {
 			throw new AccountDoesNotExistException('Account not found for current user: ' . $e->getMessage());
 		}
 	}
-
 
 	/**
 	 * @param string $userId
@@ -166,7 +163,6 @@ class AccountService {
 
 		return $actor;
 	}
-
 
 	/**
 	 * Method should be called by the frontend and will generate a fresh Social account for
@@ -222,7 +218,6 @@ class AccountService {
 		$this->followsRequest->generateLoopbackAccount($actor);
 	}
 
-
 	/**
 	 * @param string $handle
 	 *
@@ -262,7 +257,6 @@ class AccountService {
 		$this->activityService->request($delete);
 	}
 
-
 	/**
 	 * Stores whether new follows towards this user's actor need manual approval,
 	 * and refreshes the actor cache so the flag reaches the actor document and
@@ -280,7 +274,6 @@ class AccountService {
 		$this->actorsRequest->updateLocked($actor);
 		$this->cacheLocalActorByUsername($actor->getPreferredUsername());
 	}
-
 
 	/**
 	 * @param string $username
@@ -313,7 +306,6 @@ class AccountService {
 		}
 	}
 
-
 	/**
 	 * Load the cached header document URL for a local actor.
 	 *
@@ -328,7 +320,6 @@ class AccountService {
 		} catch (Exception $e) {
 		}
 	}
-
 
 	/**
 	 * @param string $username
@@ -354,7 +345,6 @@ class AccountService {
 		$this->actorService->cacheLocalActorDetails($actor);
 	}
 
-
 	/**
 	 * @param Person $actor
 	 */
@@ -375,7 +365,6 @@ class AccountService {
 		$actor->setDetailArray('count', $count);
 		$actor->setDetail('last_post_creation', $lastPostCreation);
 	}
-
 
 	/**
 	 * @param Person $actor
@@ -399,7 +388,6 @@ class AccountService {
 		}
 	}
 
-
 	/**
 	 * @param string $username
 	 */
@@ -408,7 +396,6 @@ class AccountService {
 
 		return;
 	}
-
 
 	/**
 	 * @return int
@@ -432,7 +419,6 @@ class AccountService {
 		return $deleted;
 	}
 
-
 	/**
 	 * @return int
 	 * @throws Exception
@@ -448,7 +434,6 @@ class AccountService {
 
 		return sizeof($update);
 	}
-
 
 	/**
 	 * @return int
@@ -470,7 +455,6 @@ class AccountService {
 
 		return $count;
 	}
-
 
 	/**
 	 * @param string $userId

--- a/lib/Service/ActionService.php
+++ b/lib/Service/ActionService.php
@@ -62,7 +62,6 @@ class ActionService {
 		$this->streamActionService = $streamActionService;
 	}
 
-
 	/**
 	 * should return null
 	 * will return Stream only with translate action
@@ -83,7 +82,6 @@ class ActionService {
 		switch ($action) {
 			case self::TRANSLATE:
 				return $this->translate($nid);
-
 			case self::FAVOURITE:
 				$this->favourite($actor, $post->getId());
 				break;
@@ -119,7 +117,6 @@ class ActionService {
 
 		return null;
 	}
-
 
 	/**
 	 * TODO: returns a translated version of the Status

--- a/lib/Service/ActivityService.php
+++ b/lib/Service/ActivityService.php
@@ -84,7 +84,6 @@ class ActivityService {
 		$this->logger = $logger;
 	}
 
-
 	/**
 	 * @param Person $actor
 	 * @param ACore $item
@@ -119,7 +118,6 @@ class ActivityService {
 		return $this->request($activity);
 	}
 
-
 	/**
 	 * @param Person $actor
 	 * @param ACore $item
@@ -141,7 +139,6 @@ class ActivityService {
 		return $this->request($update);
 	}
 
-
 	/**
 	 * @param ACore $item
 	 *
@@ -161,7 +158,6 @@ class ActivityService {
 
 		return $this->request($delete);
 	}
-
 
 	/**
 	 * @param string $id
@@ -189,7 +185,6 @@ class ActivityService {
 
 		throw new InvalidResourceException();
 	}
-
 
 	/**
 	 * @throws SocialAppConfigException
@@ -222,11 +217,9 @@ class ActivityService {
 		return $token;
 	}
 
-
 	public function manageInit() {
 		$this->failInstances = [];
 	}
-
 
 	/**
 	 * @param RequestQueue $queue
@@ -274,7 +267,6 @@ class ActivityService {
 		}
 	}
 
-
 	/** // ====> instanceService
 	 *
 	 * @param ACore $activity
@@ -286,8 +278,8 @@ class ActivityService {
 		foreach ($activity->getInstancePaths() as $instancePath) {
 			switch ($instancePath->getType()) {
 				case InstancePath::TYPE_FOLLOWERS:
-					$instancePaths =
-						array_merge($instancePaths, $this->generateInstancePathsFollowers($instancePath));
+					$instancePaths
+						= array_merge($instancePaths, $this->generateInstancePathsFollowers($instancePath));
 					break;
 
 				case InstancePath::TYPE_ALL:
@@ -302,7 +294,6 @@ class ActivityService {
 
 		return $instancePaths;
 	}
-
 
 	/**
 	 * @param InstancePath $instancePath
@@ -334,7 +325,6 @@ class ActivityService {
 		return $instancePaths;
 	}
 
-
 	/**
 	 * @return InstancePath[]
 	 */
@@ -351,7 +341,6 @@ class ActivityService {
 
 		return $instancePaths;
 	}
-
 
 	private function generateRequestFromQueue(RequestQueue $queue): NCRequest {
 		$path = $queue->getInstance();
@@ -372,7 +361,6 @@ class ActivityService {
 		return $request;
 	}
 
-
 	/**
 	 * $signature = new LinkedDataSignature();
 	 *
@@ -389,7 +377,6 @@ class ActivityService {
 		return $activity->getActorId();
 	}
 
-
 	/**
 	 * @param ACore $activity
 	 */
@@ -400,7 +387,6 @@ class ActivityService {
 			$this->saveObject($activity->getObject());
 		}
 	}
-
 
 	/**
 	 * @param ACore $item

--- a/lib/Service/ActorService.php
+++ b/lib/Service/ActorService.php
@@ -26,7 +26,6 @@ use OCA\Social\Tools\Traits\TArrayTools;
 class ActorService {
 	use TArrayTools;
 
-
 	private CacheActorsRequest $cacheActorsRequest;
 
 	private CacheDocumentsRequest $cacheDocumentsRequest;
@@ -36,7 +35,6 @@ class ActorService {
 	private ConfigService $configService;
 
 	private MiscService $miscService;
-
 
 	/**
 	 * ActorService constructor.
@@ -60,7 +58,6 @@ class ActorService {
 		$this->miscService = $miscService;
 	}
 
-
 	/**
 	 * @param Person $actor
 	 *
@@ -78,7 +75,6 @@ class ActorService {
 		}
 	}
 
-
 	/**
 	 * @param Person $actor
 	 *
@@ -87,7 +83,6 @@ class ActorService {
 	public function cacheLocalActorDetails(Person $actor) {
 		$this->cacheActorsRequest->updateDetails($actor);
 	}
-
 
 	/**
 	 * @param Person $actor
@@ -98,7 +93,6 @@ class ActorService {
 		$this->cacheDocumentIfNeeded($actor);
 		$this->cacheActorsRequest->save($actor);
 	}
-
 
 	/**
 	 * @param Person $actor
@@ -111,7 +105,6 @@ class ActorService {
 
 		return $this->cacheActorsRequest->update($actor);
 	}
-
 
 	/**
 	 * Get the cached header URL for a local actor.
@@ -131,7 +124,6 @@ class ActorService {
 			return '';
 		}
 	}
-
 
 	/**
 	 * @param Person $actor

--- a/lib/Service/BoostService.php
+++ b/lib/Service/BoostService.php
@@ -59,7 +59,6 @@ class BoostService {
 		$this->logger = $logger;
 	}
 
-
 	/**
 	 * @param Person $actor
 	 * @param string $postId
@@ -125,7 +124,6 @@ class BoostService {
 		return $announce;
 	}
 
-
 	/**
 	 * @param string $postId
 	 *
@@ -139,7 +137,6 @@ class BoostService {
 
 		return $stream;
 	}
-
 
 	/**
 	 * @param Person $actor

--- a/lib/Service/CacheActorService.php
+++ b/lib/Service/CacheActorService.php
@@ -74,14 +74,12 @@ class CacheActorService {
 		$this->logger = $logger;
 	}
 
-
 	/**
 	 * @param Person $viewer
 	 */
 	public function setViewer(Person $viewer) {
 		$this->cacheActorsRequest->setViewer($viewer);
 	}
-
 
 	/**
 	 * @param string $id
@@ -150,7 +148,6 @@ class CacheActorService {
 
 		return $actor;
 	}
-
 
 	/**
 	 * @param string $account
@@ -237,7 +234,6 @@ class CacheActorService {
 		return $actor;
 	}
 
-
 	/**
 	 * @param string $search
 	 *
@@ -246,7 +242,6 @@ class CacheActorService {
 	public function searchCachedAccounts(string $search): array {
 		return $this->cacheActorsRequest->searchAccounts($search);
 	}
-
 
 	/**
 	 * @return int
@@ -266,7 +261,6 @@ class CacheActorService {
 		return sizeof($missing);
 	}
 
-
 	/**
 	 * @return int
 	 * @throws Exception
@@ -283,7 +277,6 @@ class CacheActorService {
 
 		return sizeof($update);
 	}
-
 
 	/**
 	 * @return int
@@ -305,7 +298,6 @@ class CacheActorService {
 		return sizeof($update);
 	}
 
-
 	public function addRemoteActorDetailCount(Person $actor): void {
 		try {
 			$followers = $this->getCollectionFromId($actor->getFollowers());
@@ -322,7 +314,6 @@ class CacheActorService {
 		];
 		$actor->setDetailArray('count', $count);
 	}
-
 
 	/**
 	 * @param string $id
@@ -345,7 +336,6 @@ class CacheActorService {
 
 		return $collection;
 	}
-
 
 	/**
 	 * @param Person $actor
@@ -373,7 +363,6 @@ class CacheActorService {
 		}
 	}
 
-
 	/**
 	 * @param ProbeOptions $options
 	 *
@@ -382,7 +371,6 @@ class CacheActorService {
 	public function probeActors(ProbeOptions $options): array {
 		return $this->cacheActorsRequest->probeActors($options);
 	}
-
 
 	public function getFromNids(array $ids): array {
 		return $this->cacheActorsRequest->getFromNids($ids);

--- a/lib/Service/CacheDocumentService.php
+++ b/lib/Service/CacheDocumentService.php
@@ -56,7 +56,6 @@ class CacheDocumentService {
 		$this->configService = $configService;
 	}
 
-
 	/**
 	 * @brief Save the local upload to the cache
 	 *
@@ -69,7 +68,6 @@ class CacheDocumentService {
 
 		$this->saveContentToCache($document, $content, $mime);
 	}
-
 
 	/**
 	 * @param Document $document
@@ -91,7 +89,6 @@ class CacheDocumentService {
 
 		$this->saveContentToCache($document, $content, $mime);
 	}
-
 
 	/**
 	 * @param Document $document
@@ -139,7 +136,6 @@ class CacheDocumentService {
 		$document->setResizedCopy($resized);
 	}
 
-
 	/**
 	 * @param string $content
 	 *
@@ -163,7 +159,6 @@ class CacheDocumentService {
 		return $filename;
 	}
 
-
 	/**
 	 * creating a path aa/bb/cc/dd/ from the filename aabbccdd-0123-[...]
 	 *
@@ -174,7 +169,6 @@ class CacheDocumentService {
 	private function generatePath(string $filename): string {
 		return chunk_split(substr($filename, 0, 8), 2, '/');
 	}
-
 
 	/**
 	 *
@@ -195,7 +189,6 @@ class CacheDocumentService {
 
 		throw new CacheContentMimeTypeException();
 	}
-
 
 	/**
 	 * @param string $content
@@ -222,7 +215,6 @@ class CacheDocumentService {
 		$document->setBlurHash($hash);
 	}
 
-
 	/**
 	 * @param string $filename
 	 *
@@ -248,7 +240,6 @@ class CacheDocumentService {
 			throw new CacheContentException();
 		}
 	}
-
 
 	public function getFromUuid(string $uuid): ISimpleFile {
 		try {

--- a/lib/Service/CheckService.php
+++ b/lib/Service/CheckService.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -40,7 +41,6 @@ class CheckService {
 	use TArrayTools;
 	use TStringTools;
 
-
 	public const CACHE_PREFIX = 'social_check_';
 
 	private IUserManager $userManager;
@@ -81,7 +81,6 @@ class CheckService {
 		$this->userId = $userId;
 	}
 
-
 	/**
 	 * @return array
 	 */
@@ -101,7 +100,6 @@ class CheckService {
 			'checks' => $checks
 		];
 	}
-
 
 	/**
 	 * @return bool
@@ -131,7 +129,6 @@ class CheckService {
 		return false;
 	}
 
-
 	/**
 	 * @param bool $light
 	 *
@@ -156,7 +153,6 @@ class CheckService {
 		return $result;
 	}
 
-
 	/**
 	 * create a fake follow entry. Mandatory to have Home Stream working.
 	 */
@@ -174,7 +170,6 @@ class CheckService {
 
 		$this->followRequest->save($follow);
 	}
-
 
 	/**
 	 * create entries in follows so that user follows itself.
@@ -199,7 +194,6 @@ class CheckService {
 		}
 	}
 
-
 	/**
 	 * @return int
 	 */
@@ -220,7 +214,6 @@ class CheckService {
 
 		return $count;
 	}
-
 
 	/**
 	 * @return int

--- a/lib/Service/ClientService.php
+++ b/lib/Service/ClientService.php
@@ -33,16 +33,13 @@ class ClientService {
 	// an authorization code is single-use plumbing; it expires quickly
 	public const TIME_CODE_TTL = 600; // 10m
 
-
 	use TStringTools;
-
 
 	private ClientRequest $clientRequest;
 
 	private SecretHasher $secretHasher;
 
 	private MiscService $miscService;
-
 
 	/**
 	 * ClientService constructor.
@@ -56,7 +53,6 @@ class ClientService {
 		$this->secretHasher = $secretHasher;
 		$this->miscService = $miscService;
 	}
-
 
 	/**
 	 * @param SocialClient $client
@@ -78,7 +74,6 @@ class ClientService {
 		$this->clientRequest->saveApp($client);
 	}
 
-
 	/**
 	 * @param SocialClient $client
 	 */
@@ -89,7 +84,6 @@ class ClientService {
 		$this->clientRequest->authClient($client);
 	}
 
-
 	/**
 	 * @param SocialClient $client
 	 */
@@ -98,7 +92,6 @@ class ClientService {
 
 		$this->clientRequest->updateToken($client);
 	}
-
 
 	/**
 	 * @param string $clientId
@@ -109,7 +102,6 @@ class ClientService {
 	public function getFromClientId(string $clientId): SocialClient {
 		return $this->clientRequest->getFromClientId($clientId);
 	}
-
 
 	/**
 	 * @param string $token
@@ -155,7 +147,6 @@ class ClientService {
 
 		$this->clientRequest->revokeToken($stored);
 	}
-
 
 	/**
 	 * @param SocialClient $client

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -29,7 +29,6 @@ class ConfigService {
 	use TPathTools;
 	use TArrayTools;
 
-
 	public const CLOUD_URL = 'cloud_url';
 	public const SOCIAL_URL = 'social_url';
 	public const SOCIAL_ADDRESS = 'social_address';
@@ -40,7 +39,6 @@ class ConfigService {
 	public const SOCIAL_ACCESS_LIST = 'access_list';
 
 	public const SOCIAL_SELF_SIGNED = 'allow_self_signed';
-
 
 	public const BACKGROUND_CRON = 1;
 	public const BACKGROUND_ASYNC = 2;
@@ -80,7 +78,6 @@ class ConfigService {
 		$this->miscService = $miscService;
 	}
 
-
 	/**
 	 * @return array
 	 */
@@ -94,7 +91,6 @@ class ConfigService {
 
 		return $data;
 	}
-
 
 	/**
 	 * /**
@@ -225,7 +221,6 @@ class ConfigService {
 		return $this->config->setUserValue($userId, Application::APP_ID, $key, $value);
 	}
 
-
 	/**
 	 * @param string $key
 	 * @param string $value
@@ -250,14 +245,12 @@ class ConfigService {
 		$this->config->deleteAppValue('core', $key);
 	}
 
-
 	/**
 	 *
 	 */
 	public function unsetAppConfig() {
 		$this->config->deleteAppValues(Application::APP_ID);
 	}
-
 
 	/**
 	 * @param $key
@@ -270,7 +263,6 @@ class ConfigService {
 		return $this->config->getSystemValue($key, '');
 	}
 
-
 	/**
 	 * Whether outbound requests may reach the instance's own network.
 	 *
@@ -280,7 +272,6 @@ class ConfigService {
 	public function isLocalNetworkAllowed(): bool {
 		return $this->config->getSystemValueBool('allow_local_remote_servers', false);
 	}
-
 
 	/**
 	 * getCloudHost - cloud.example.com
@@ -293,7 +284,6 @@ class ConfigService {
 
 		return parse_url($url, PHP_URL_HOST);
 	}
-
 
 	/**
 	 * getCloudUrl - https://cloud.example.com/index.php
@@ -331,7 +321,6 @@ class ConfigService {
 		$this->setAppValue(self::CLOUD_URL, $cloudAddress);
 	}
 
-
 	/**
 	 * getSocialAddress - example.com
 	 *
@@ -354,7 +343,6 @@ class ConfigService {
 	public function setSocialAddress(string $address) {
 		$this->setAppValue(self::SOCIAL_ADDRESS, $address);
 	}
-
 
 	/**
 	 * getSocialUrl - https://cloud.example.com/apps/social/
@@ -390,7 +378,6 @@ class ConfigService {
 		$this->setAppValue(self::SOCIAL_URL, $url);
 	}
 
-
 	/**
 	 * @param string $path
 	 * @param bool $generateId
@@ -408,7 +395,6 @@ class ConfigService {
 
 		return $id;
 	}
-
 
 	public function configureRequest(NCRequest $request): void {
 		$request->setVerifyPeer($this->getAppValue(ConfigService::SOCIAL_SELF_SIGNED) !== '1');

--- a/lib/Service/CurlService.php
+++ b/lib/Service/CurlService.php
@@ -67,7 +67,6 @@ class CurlService {
 		$this->maxDownloadSize = $this->configService->getAppValue(ConfigService::SOCIAL_MAX_SIZE) * 1048576;
 	}
 
-
 	/**
 	 * @param string $account
 	 *
@@ -122,7 +121,6 @@ class CurlService {
 		return $result;
 	}
 
-
 	/**
 	 * @param string $host
 	 * @param array $protocols
@@ -155,7 +153,6 @@ class CurlService {
 
 		return parse_url($url, PHP_URL_PATH);
 	}
-
 
 	/**
 	 * @param string $account
@@ -207,7 +204,6 @@ class CurlService {
 		return $actor;
 	}
 
-
 	/**
 	 * @param $id
 	 *
@@ -245,7 +241,6 @@ class CurlService {
 		return $result;
 	}
 
-
 	/**
 	 * @param NCRequest $request
 	 *
@@ -264,7 +259,6 @@ class CurlService {
 		return $this->doRequestOrig($request);
 	}
 
-
 	/**
 	 * @param NCRequest $request
 	 */
@@ -273,7 +267,6 @@ class CurlService {
 			self::USER_AGENT . ' ' . $this->configService->getAppValue('installed_version')
 		);
 	}
-
 
 	/**
 	 * @param string $token
@@ -298,7 +291,6 @@ class CurlService {
 			$this->logger->error('Cannot initiate AsyncWithToken', ['token' => $token, 'exception' => $e]);
 		}
 	}
-
 
 	/**
 	 * @param NCRequest $request
@@ -327,7 +319,6 @@ class CurlService {
 
 		throw new RequestResultNotJsonException();
 	}
-
 
 	/**
 	 * @throws RequestContentException
@@ -373,7 +364,6 @@ class CurlService {
 
 		return (string)$result;
 	}
-
 
 	/**
 	 * @param Request $request
@@ -429,7 +419,6 @@ class CurlService {
 		return $curl;
 	}
 
-
 	/**
 	 * @param Request $request
 	 *
@@ -460,7 +449,6 @@ class CurlService {
 		return $curl;
 	}
 
-
 	/**
 	 * @param Request $request
 	 */
@@ -483,7 +471,6 @@ class CurlService {
 		curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
 	}
 
-
 	/**
 	 * @param CurlHandle $curl
 	 * @param Request $request
@@ -500,7 +487,6 @@ class CurlService {
 		$request->setContentType((!is_string($contentType)) ? '' : $contentType);
 		$request->setResultCode($code);
 	}
-
 
 	/**
 	 * @param CurlHandle $curl

--- a/lib/Service/DetailsService.php
+++ b/lib/Service/DetailsService.php
@@ -28,7 +28,6 @@ class DetailsService {
 
 	private CacheActorService $cacheActorService;
 
-
 	/**
 	 * DetailsService constructor.
 	 *
@@ -46,7 +45,6 @@ class DetailsService {
 		$this->followService = $followService;
 		$this->cacheActorService = $cacheActorService;
 	}
-
 
 	/**
 	 * @param Stream $stream
@@ -70,7 +68,6 @@ class DetailsService {
 
 		return $details;
 	}
-
 
 	/**
 	 * @param StreamDetails $details

--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -41,7 +41,6 @@ class DocumentService {
 	public const ERROR_MIMETYPE = 2;
 	public const ERROR_PERMISSION = 3;
 
-
 	private \OCP\IURLGenerator $urlGenerator;
 
 	private CacheDocumentsRequest $cacheDocumentsRequest;
@@ -55,7 +54,6 @@ class DocumentService {
 	private ConfigService $configService;
 
 	private MiscService $miscService;
-
 
 	/**
 	 * DocumentInterface constructor.
@@ -81,7 +79,6 @@ class DocumentService {
 		$this->cacheService = $cacheService;
 		$this->miscService = $miscService;
 	}
-
 
 	/**
 	 * @param string $id
@@ -154,7 +151,6 @@ class DocumentService {
 		throw new CacheDocumentDoesNotExistException();
 	}
 
-
 	/**
 	 * @param string $id
 	 * @param string $mime
@@ -173,7 +169,6 @@ class DocumentService {
 
 		return $this->cacheService->getContentFromCache($document->getResizedCopy());
 	}
-
 
 	/**
 	 * @param string $id
@@ -248,8 +243,6 @@ class DocumentService {
 		$this->cacheDocumentsRequest->updateDescription($document);
 	}
 
-
-
 	/**
 	 * @return int
 	 * @throws Exception
@@ -274,7 +267,6 @@ class DocumentService {
 		return $count;
 	}
 
-
 	/**
 	 * @param Person $actor
 	 *
@@ -289,8 +281,8 @@ class DocumentService {
 			'core.avatar.getAvatar', ['userId' => $actor->getUserId(), 'size' => 128]
 		);
 
-		$versionCurrent =
-			(int)$this->configService->getUserValue('version', $actor->getUserId(), 'avatar');
+		$versionCurrent
+			= (int)$this->configService->getUserValue('version', $actor->getUserId(), 'avatar');
 		$versionCached = $actor->getAvatarVersion();
 		if ($versionCurrent > $versionCached) {
 			/** @var Image $icon */
@@ -315,7 +307,6 @@ class DocumentService {
 
 		return $icon->getId();
 	}
-
 
 	/**
 	 * Cache a banner/header image for a local actor.

--- a/lib/Service/FediverseService.php
+++ b/lib/Service/FediverseService.php
@@ -23,7 +23,6 @@ class FediverseService {
 
 	private MiscService $miscService;
 
-
 	/**
 	 * FediverseService constructor.
 	 *
@@ -37,7 +36,6 @@ class FediverseService {
 		$this->miscService = $miscService;
 	}
 
-
 	/**
 	 * @param string $address
 	 *
@@ -50,21 +48,20 @@ class FediverseService {
 			throw new UnauthorizedFediverseException('Empty Origin');
 		}
 
-		if ($this->getAccessType() ===
-			$this->configService->accessTypeList['BLACKLIST']
+		if ($this->getAccessType()
+			=== $this->configService->accessTypeList['BLACKLIST']
 			&& !$this->isListed($address)) {
 			return true;
 		}
 
-		if ($this->getAccessType() ===
-			$this->configService->accessTypeList['WHITELIST']
+		if ($this->getAccessType()
+			=== $this->configService->accessTypeList['WHITELIST']
 			&& ($this->isListed($address) || $this->isLocal($address))) {
 			return true;
 		}
 
 		throw new UnauthorizedFediverseException('Unauthorized Fediverse');
 	}
-
 
 	/**
 	 * @throws UnauthorizedFediverseException
@@ -78,14 +75,12 @@ class FediverseService {
 		throw new UnauthorizedFediverseException('Jailed Fediverse');
 	}
 
-
 	/**
 	 * @return string
 	 */
 	public function getAccessType(): string {
 		return $this->configService->getAppValue(ConfigService::SOCIAL_ACCESS_TYPE);
 	}
-
 
 	/**
 	 * @param string $type
@@ -101,7 +96,6 @@ class FediverseService {
 		$this->configService->setAppValue(ConfigService::SOCIAL_ACCESS_TYPE, $type);
 	}
 
-
 	/**
 	 * @param string $address
 	 *
@@ -114,14 +108,12 @@ class FediverseService {
 		return ($local === $address);
 	}
 
-
 	/**
 	 * @return array
 	 */
 	public function getKnownAddresses(): array {
 		return [];
 	}
-
 
 	/**
 	 * @return array
@@ -174,7 +166,6 @@ class FediverseService {
 		$list = array_values(array_udiff($this->getListedAddresses(), [$address], 'strcasecmp'));
 		$this->configService->setAppValue(ConfigService::SOCIAL_ACCESS_LIST, json_encode($list));
 	}
-
 
 	//
 	//	/**

--- a/lib/Service/FollowService.php
+++ b/lib/Service/FollowService.php
@@ -46,7 +46,6 @@ use Throwable;
 class FollowService {
 	use TArrayTools;
 
-
 	private IURLGenerator $urlGenerator;
 	private FollowsRequest $followsRequest;
 	private ActorRelationRequest $actorRelationRequest;
@@ -56,7 +55,6 @@ class FollowService {
 	private FollowInterface $followInterface;
 	private LoggerInterface $logger;
 	private ?Person $viewer = null;
-
 
 	/**
 	 * FollowService constructor.
@@ -86,7 +84,6 @@ class FollowService {
 		$this->followInterface = $followInterface;
 		$this->logger = $logger;
 	}
-
 
 	/**
 	 * The accounts whose follows towards the viewer wait for approval.
@@ -130,7 +127,6 @@ class FollowService {
 		$this->followInterface->rejectFollowRequest($follow);
 	}
 
-
 	/**
 	 * @param Person $viewer
 	 */
@@ -138,7 +134,6 @@ class FollowService {
 		$this->viewer = $viewer;
 		$this->followsRequest->setViewer($viewer);
 	}
-
 
 	/**
 	 * @param Person $actor
@@ -215,7 +210,6 @@ class FollowService {
 		}
 	}
 
-
 	/**
 	 * @param Person $actor
 	 * @param string $account
@@ -259,7 +253,6 @@ class FollowService {
 		}
 	}
 
-
 	/**
 	 * @param Person $local
 	 * @param Person $actor
@@ -287,7 +280,6 @@ class FollowService {
 		return $links;
 	}
 
-
 	/**
 	 * @param Person $actor
 	 *
@@ -298,7 +290,6 @@ class FollowService {
 	public function getFollowers(Person $actor): array {
 		return $this->followsRequest->getFollowersByActorId($actor->getId());
 	}
-
 
 	/**
 	 * @param Person $actor
@@ -320,7 +311,6 @@ class FollowService {
 		return $collection;
 	}
 
-
 	/**
 	 * @param Person $actor
 	 *
@@ -331,7 +321,6 @@ class FollowService {
 	public function getFollowing(Person $actor): array {
 		return $this->followsRequest->getFollowingByActorId($actor->getId());
 	}
-
 
 	/**
 	 * @param Person $actor
@@ -352,7 +341,6 @@ class FollowService {
 
 		return $collection;
 	}
-
 
 	/**
 	 * @param string $recipient

--- a/lib/Service/HashtagService.php
+++ b/lib/Service/HashtagService.php
@@ -25,9 +25,7 @@ class HashtagService {
 	public const TREND_3D = 259200;
 	public const TREND_10D = 864000;
 
-
 	use TArrayTools;
-
 
 	private HashtagsRequest $hashtagsRequest;
 
@@ -36,7 +34,6 @@ class HashtagService {
 	private ConfigService $configService;
 
 	private MiscService $miscService;
-
 
 	/**
 	 * ImportService constructor.
@@ -67,7 +64,6 @@ class HashtagService {
 	 *   '10d' => x
 	 * ]
 	 */
-
 
 	/**
 	 * @return int
@@ -102,7 +98,6 @@ class HashtagService {
 		return $count;
 	}
 
-
 	/**
 	 * @param string $hashtag
 	 *
@@ -117,7 +112,6 @@ class HashtagService {
 		return $this->hashtagsRequest->getHashtag($hashtag);
 	}
 
-
 	/**
 	 * @param string $hashtag
 	 * @param bool $all
@@ -127,7 +121,6 @@ class HashtagService {
 	public function searchHashtags(string $hashtag, bool $all = false): array {
 		return $this->hashtagsRequest->searchHashtags($hashtag, $all);
 	}
-
 
 	/**
 	 * @param int $timestamp
@@ -154,7 +147,6 @@ class HashtagService {
 		return $result;
 	}
 
-
 	/**
 	 * @param array $hashtags
 	 *
@@ -178,7 +170,6 @@ class HashtagService {
 		return $trends;
 	}
 
-
 	/**
 	 * @param array $list
 	 * @param string $hashtag
@@ -194,7 +185,6 @@ class HashtagService {
 
 		return 0;
 	}
-
 
 	/**
 	 * @param array $list

--- a/lib/Service/ImportService.php
+++ b/lib/Service/ImportService.php
@@ -25,11 +25,9 @@ class ImportService {
 	use TArrayTools;
 	use TStringTools;
 
-
 	private ConfigService $configService;
 
 	private MiscService $miscService;
-
 
 	/**
 	 * ImportService constructor.
@@ -41,7 +39,6 @@ class ImportService {
 		$this->configService = $configService;
 		$this->miscService = $miscService;
 	}
-
 
 	/**
 	 * @param string $json
@@ -60,7 +57,6 @@ class ImportService {
 
 		return AP::$activityPub->getItemFromData($data);
 	}
-
 
 	/**
 	 * @param ACore $activity

--- a/lib/Service/LikeService.php
+++ b/lib/Service/LikeService.php
@@ -35,7 +35,6 @@ use Psr\Log\LoggerInterface;
 class LikeService {
 	use TStringTools;
 
-
 	private StreamRequest $streamRequest;
 
 	private StreamService $streamService;
@@ -53,7 +52,6 @@ class LikeService {
 	private MiscService $miscService;
 
 	private LoggerInterface $logger;
-
 
 	/**
 	 * LikeService constructor.
@@ -84,7 +82,6 @@ class LikeService {
 		$this->miscService = $miscService;
 		$this->logger = $logger;
 	}
-
 
 	/**
 	 * @param Person $actor
@@ -128,7 +125,9 @@ class LikeService {
 		$this->assignInstance($like, $actor, $note);
 
 		$this->logger->info('LikeService::create - instance paths', [
-			'paths' => array_map(function ($p) { return $p->getAddress(); }, $like->getInstancePaths()),
+			'paths' => array_map(function ($p) {
+				return $p->getAddress();
+			}, $like->getInstancePaths()),
 			'likeId' => $like->getId(),
 		]);
 
@@ -147,7 +146,6 @@ class LikeService {
 
 		return $like;
 	}
-
 
 	/**
 	 * @param Person $actor
@@ -193,7 +191,6 @@ class LikeService {
 
 		return $undo;
 	}
-
 
 	/**
 	 * @param ACore $item

--- a/lib/Service/MiscService.php
+++ b/lib/Service/MiscService.php
@@ -23,12 +23,10 @@ class MiscService {
 	private LoggerInterface $logger;
 	private IUserManager $userManager;
 
-
 	public function __construct(LoggerInterface $logger, IUserManager $userManager) {
 		$this->logger = $logger;
 		$this->userManager = $userManager;
 	}
-
 
 	/**
 	 * @param $message
@@ -42,7 +40,6 @@ class MiscService {
 
 		$this->logger->log($level, $message, $data);
 	}
-
 
 	/**
 	 * @return int

--- a/lib/Service/PostService.php
+++ b/lib/Service/PostService.php
@@ -46,7 +46,6 @@ class PostService {
 		$this->logger = $logger;
 	}
 
-
 	/**
 	 * @param Post $post
 	 * @param string $token
@@ -127,7 +126,6 @@ class PostService {
 
 		return $updated;
 	}
-
 
 	/**
 	 * @param Post $post

--- a/lib/Service/PushService.php
+++ b/lib/Service/PushService.php
@@ -20,7 +20,6 @@ use OCA\Social\Tools\Traits\TAsync;
 //use OCP\Push\IPushManager;
 //use OCP\Push\Model\IPushWrapper;
 
-
 /**
  * Class PushService
  *
@@ -32,7 +31,6 @@ class PushService {
 	private DetailsService $detailsService;
 	private StreamService $streamService;
 	private MiscService $miscService;
-
 
 	/**
 	 * PushService constructor.
@@ -53,7 +51,6 @@ class PushService {
 		//			}
 		//		}
 	}
-
 
 	/**
 	 * @param string $streamId

--- a/lib/Service/RequestQueueService.php
+++ b/lib/Service/RequestQueueService.php
@@ -27,13 +27,11 @@ class RequestQueueService {
 
 	use TArrayTools;
 
-
 	private RequestQueueRequest $requestQueueRequest;
 
 	private ConfigService $configService;
 
 	private MiscService $miscService;
-
 
 	/**
 	 * RequestQueueService constructor.
@@ -50,7 +48,6 @@ class RequestQueueService {
 		$this->configService = $configService;
 		$this->miscService = $miscService;
 	}
-
 
 	/**
 	 * @param array $instancePaths
@@ -80,7 +77,6 @@ class RequestQueueService {
 		return $token;
 	}
 
-
 	/**
 	 * deciding if we run request on main thread,
 	 * based on set priority, and number of request linked to one token
@@ -102,7 +98,6 @@ class RequestQueueService {
 		switch ($request->getPriority()) {
 			case InstancePath::PRIORITY_TOP:
 				return $request;
-
 			case InstancePath::PRIORITY_HIGH:
 				if (sizeof($requests) === 1) {
 					return $request;
@@ -123,7 +118,6 @@ class RequestQueueService {
 
 		throw new NoHighPriorityRequestException();
 	}
-
 
 	/**
 	 * @param int $total
@@ -152,7 +146,6 @@ class RequestQueueService {
 		return $result;
 	}
 
-
 	/**
 	 * @param string $token
 	 * @param int $status
@@ -167,7 +160,6 @@ class RequestQueueService {
 		return $this->requestQueueRequest->getFromToken($token, $status);
 	}
 
-
 	/**
 	 * @param RequestQueue $queue
 	 *
@@ -176,7 +168,6 @@ class RequestQueueService {
 	public function initRequest(RequestQueue $queue) {
 		$this->requestQueueRequest->setAsRunning($queue);
 	}
-
 
 	/**
 	 * @param RequestQueue $queue
@@ -202,7 +193,6 @@ class RequestQueueService {
 	public function reapStaleRunning(): int {
 		return $this->requestQueueRequest->resetStaleRunning(time() - self::STALE_RUNNING_SECONDS);
 	}
-
 
 	/**
 	 * @param RequestQueue $queue

--- a/lib/Service/SearchService.php
+++ b/lib/Service/SearchService.php
@@ -22,7 +22,6 @@ use Psr\Log\LoggerInterface;
 class SearchService {
 	use TArrayTools;
 
-
 	public const SEARCH_URI = 1;
 	public const SEARCH_ACCOUNTS = 2;
 	public const SEARCH_HASHTAGS = 4;
@@ -33,7 +32,6 @@ class SearchService {
 	private HashtagService $hashtagService;
 	private ConfigService $configService;
 	private LoggerInterface $logger;
-
 
 	/**
 	 * ImportService constructor.
@@ -55,7 +53,6 @@ class SearchService {
 		$this->logger = $logger;
 	}
 
-
 	/**
 	 * @param string $search
 	 *
@@ -73,7 +70,6 @@ class SearchService {
 
 		return [];
 	}
-
 
 	/**
 	 * @param string $search
@@ -98,7 +94,6 @@ class SearchService {
 		return $this->cacheActorService->searchCachedAccounts($search);
 	}
 
-
 	/**
 	 * @param string $search
 	 *
@@ -118,7 +113,6 @@ class SearchService {
 		return $this->hashtagService->searchHashtags($search, true);
 	}
 
-
 	/**
 	 * @param string $search
 	 *
@@ -136,7 +130,6 @@ class SearchService {
 		return $result;
 	}
 
-
 	/**
 	 * @param string $search
 	 *
@@ -147,10 +140,8 @@ class SearchService {
 		switch ($char) {
 			case '@':
 				return self::SEARCH_ACCOUNTS;
-
 			case '#':
 				return self::SEARCH_HASHTAGS;
-
 			default:
 				if (substr($search, 0, 4) === 'http') {
 					return self::SEARCH_URI;

--- a/lib/Service/SignatureService.php
+++ b/lib/Service/SignatureService.php
@@ -86,7 +86,6 @@ class SignatureService {
 		$this->logger = $logger;
 	}
 
-
 	/**
 	 * @param Person $actor
 	 */
@@ -115,7 +114,6 @@ class SignatureService {
 		$actor->setPublicKey($details['key']);
 		$actor->setPrivateKey($privateKey);
 	}
-
 
 	/**
 	 * @param NCRequest $request
@@ -156,7 +154,6 @@ class SignatureService {
 		$request->addHeader('Signature', $signature);
 	}
 
-
 	/**
 	 * @param array $elements
 	 * @param array $data
@@ -176,7 +173,6 @@ class SignatureService {
 		return implode("\n", $signingElements);
 	}
 
-
 	/**
 	 * @param array $elements
 	 * @param string $actorId
@@ -193,7 +189,6 @@ class SignatureService {
 		return implode(',', $signatureElements);
 	}
 
-
 	/**
 	 * @param string $data
 	 *
@@ -204,7 +199,6 @@ class SignatureService {
 
 		return 'SHA-256=' . base64_encode($encoded);
 	}
-
 
 	/**
 	 * @param IRequest $request
@@ -259,8 +253,8 @@ class SignatureService {
 
 		if ($this->generateDigest($data) !== $request->getHeader('digest')) {
 			throw new SignatureException(
-				'issue with digest -- sent: ' .
-				$request->getHeader('digest') . ', expected: ' . $this->generateDigest($data)
+				'issue with digest -- sent: '
+				. $request->getHeader('digest') . ', expected: ' . $this->generateDigest($data)
 			);
 		}
 
@@ -281,7 +275,6 @@ class SignatureService {
 			);
 		}
 	}
-
 
 	/**
 	 * @param ACore $object
@@ -355,7 +348,6 @@ class SignatureService {
 		return false;
 	}
 
-
 	/**
 	 * @param Person $actor
 	 * @param ACore $object
@@ -374,7 +366,6 @@ class SignatureService {
 		} catch (Exception $e) {
 		}
 	}
-
 
 	/**
 	 * @param IRequest $request
@@ -432,7 +423,6 @@ class SignatureService {
 		return $origin;
 	}
 
-
 	/**
 	 * @param string $publicKey
 	 * @param array $sign
@@ -453,7 +443,6 @@ class SignatureService {
 			);
 		}
 	}
-
 
 	/**
 	 * @param string $headers
@@ -495,7 +484,6 @@ class SignatureService {
 		return trim($estimated, "\n");
 	}
 
-
 	/**
 	 * @param $signatureHeader
 	 *
@@ -521,7 +509,6 @@ class SignatureService {
 		return $sign;
 	}
 
-
 	/**
 	 * @param string $keyId
 	 *
@@ -546,7 +533,6 @@ class SignatureService {
 
 		return $actor->getPublicKey();
 	}
-
 
 	/**
 	 * @param $id
@@ -574,15 +560,12 @@ class SignatureService {
 		switch ($this->get('algorithm', $sign, '')) {
 			case 'rsa-sha512':
 				return 'sha512';
-
 			case 'rsa-sha256':
 				return 'sha256';
-
 			default:
 				return 'sha256';
 		}
 	}
-
 
 	/** Shipped copies of the only JSON-LD contexts signature normalisation may use. */
 	public const LOCAL_CONTEXTS = [

--- a/lib/Service/StreamActionService.php
+++ b/lib/Service/StreamActionService.php
@@ -23,7 +23,6 @@ class StreamActionService {
 
 	private MiscService $miscService;
 
-
 	/**
 	 * StreamActionService constructor.
 	 *
@@ -35,7 +34,6 @@ class StreamActionService {
 		$this->streamActionsRequest = $streamActionsRequest;
 		$this->miscService = $miscService;
 	}
-
 
 	/**
 	 * @param string $actorId
@@ -49,7 +47,6 @@ class StreamActionService {
 		$this->saveAction($action);
 	}
 
-
 	/**
 	 * @param string $actorId
 	 * @param string $streamId
@@ -62,7 +59,6 @@ class StreamActionService {
 		$this->saveAction($action);
 	}
 
-
 	/**
 	 * @param string $actorId
 	 * @param string $streamId
@@ -74,7 +70,6 @@ class StreamActionService {
 		$action->updateValueBool($key, $value);
 		$this->saveAction($action);
 	}
-
 
 	/**
 	 * @param string $actorId
@@ -91,7 +86,6 @@ class StreamActionService {
 
 		return $action;
 	}
-
 
 	/**
 	 * @param StreamAction $action

--- a/lib/Service/StreamQueueService.php
+++ b/lib/Service/StreamQueueService.php
@@ -50,7 +50,6 @@ class StreamQueueService {
 
 	private MiscService $miscService;
 
-
 	/**
 	 * StreamQueueService constructor.
 	 *
@@ -74,7 +73,6 @@ class StreamQueueService {
 		$this->miscService = $miscService;
 	}
 
-
 	/**
 	 * @param string $token
 	 * @param string $type
@@ -85,7 +83,6 @@ class StreamQueueService {
 
 		$this->streamQueueRequest->create($cache);
 	}
-
 
 	/**
 	 * @param int $total
@@ -107,7 +104,6 @@ class StreamQueueService {
 		return $result;
 	}
 
-
 	/**
 	 * @param string $token
 	 */
@@ -118,7 +114,6 @@ class StreamQueueService {
 			$this->manageStreamQueue($item);
 		}
 	}
-
 
 	/**
 	 * @param StreamQueue $queue
@@ -140,7 +135,6 @@ class StreamQueueService {
 				break;
 		}
 	}
-
 
 	/**
 	 * @param StreamQueue $queue
@@ -169,7 +163,6 @@ class StreamQueueService {
 		} catch (SocialAppConfigException $e) {
 		}
 	}
-
 
 	/**
 	 * @param Stream $stream
@@ -265,7 +258,6 @@ class StreamQueueService {
 		return $this->updateCache($stream, $cache);
 	}
 
-
 	/**
 	 * @param CacheItem $item
 	 *
@@ -316,7 +308,6 @@ class StreamQueueService {
 		$item->setContent(json_encode($note, JSON_UNESCAPED_SLASHES));
 	}
 
-
 	/**
 	 * @param Stream $stream
 	 * @param Cache $cache
@@ -341,7 +332,6 @@ class StreamQueueService {
 		return $done;
 	}
 
-
 	/**
 	 * @param StreamQueue $queue
 	 *
@@ -350,7 +340,6 @@ class StreamQueueService {
 	private function initCache(StreamQueue $queue) {
 		$this->streamQueueRequest->setAsRunning($queue);
 	}
-
 
 	/**
 	 * @param StreamQueue $queue
@@ -366,7 +355,6 @@ class StreamQueueService {
 		} catch (QueueStatusException $e) {
 		}
 	}
-
 
 	/**
 	 * @param StreamQueue $queue

--- a/lib/Service/StreamService.php
+++ b/lib/Service/StreamService.php
@@ -67,14 +67,12 @@ class StreamService {
 		$this->logger = $logger;
 	}
 
-
 	/**
 	 * @param Person $viewer
 	 */
 	public function setViewer(Person $viewer) {
 		$this->streamRequest->setViewer($viewer);
 	}
-
 
 	/**
 	 * @param ACore $stream
@@ -96,7 +94,6 @@ class StreamService {
 		}
 	}
 
-
 	/**
 	 * @param Stream $stream
 	 *
@@ -105,7 +102,6 @@ class StreamService {
 	public function assignStream(Stream $stream) {
 		$stream->convertPublished();
 	}
-
 
 	/**
 	 * @param ACore $stream
@@ -161,7 +157,6 @@ class StreamService {
 		}
 	}
 
-
 	/**
 	 * Classify a stream by who can see it, for `DetailsService`.
 	 */
@@ -193,7 +188,6 @@ class StreamService {
 				: Stream::TYPE_DIRECT
 		);
 	}
-
 
 	/**
 	 * @param Stream $stream
@@ -233,7 +227,6 @@ class StreamService {
 		$stream->addInstancePath($instancePath);
 	}
 
-
 	/**
 	 * @param Note $note
 	 * @param string $hashtag
@@ -251,7 +244,6 @@ class StreamService {
 		}
 	}
 
-
 	/**
 	 * @param Stream $stream
 	 * @param string $type
@@ -263,7 +255,6 @@ class StreamService {
 		}
 	}
 
-
 	/**
 	 * @param Note $note
 	 * @param array $hashtags
@@ -274,7 +265,6 @@ class StreamService {
 			$this->addHashtag($note, $hashtag);
 		}
 	}
-
 
 	/**
 	 * @param Note $note
@@ -309,7 +299,6 @@ class StreamService {
 		);
 	}
 
-
 	/**
 	 * @param Stream $item
 	 * @param string $type
@@ -335,7 +324,6 @@ class StreamService {
 		$this->streamRequest->deleteById($item->getId(), $type);
 	}
 
-
 	/**
 	 * @param string $id
 	 * @param bool $asViewer
@@ -350,7 +338,6 @@ class StreamService {
 	): Stream {
 		return $this->streamRequest->getStreamById($id, $asViewer, $format);
 	}
-
 
 	/**
 	 * @param int $nid
@@ -381,7 +368,6 @@ class StreamService {
 		];
 	}
 
-
 	/**
 	 * @param string $id
 	 * @param bool $asViewer
@@ -393,11 +379,9 @@ class StreamService {
 		return $this->streamRequest->getStreamByNid($nid);
 	}
 
-
 	public function updateStream(Stream $stream): void {
 		$this->streamRequest->update($stream);
 	}
-
 
 	/**
 	 * @param string $id
@@ -418,7 +402,6 @@ class StreamService {
 		return $this->streamRequest->getRepliesByParentId($id, $since, $limit, $asViewer);
 	}
 
-
 	/**
 	 * @param int $since
 	 * @param int $limit
@@ -435,7 +418,6 @@ class StreamService {
 	): array {
 		return $this->streamRequest->getTimelineHome_dep($since, $limit, $format);
 	}
-
 
 	/**
 	 * @param ProbeOptions $options
@@ -458,7 +440,6 @@ class StreamService {
 		return $this->streamRequest->getTimelineNotifications_dep($since, $limit);
 	}
 
-
 	/**
 	 * @param string $actorId
 	 * @param int $since
@@ -472,7 +453,6 @@ class StreamService {
 		return $this->streamRequest->getTimelineAccount_dep($actorId, $since, $limit);
 	}
 
-
 	/**
 	 * @param int $since
 	 * @param int $limit
@@ -484,7 +464,6 @@ class StreamService {
 	public function getStreamDirect(int $since = 0, int $limit = 5): array {
 		return $this->streamRequest->getTimelineDirect_dep($since, $limit);
 	}
-
 
 	/**
 	 * @param int $since
@@ -498,7 +477,6 @@ class StreamService {
 		return $this->streamRequest->getTimelineGlobal_dep($since, $limit, true);
 	}
 
-
 	/**
 	 * @param string $hashtag
 	 * @param int $since
@@ -511,7 +489,6 @@ class StreamService {
 		return $this->streamRequest->getTimelineTag($hashtag, $since, $limit);
 	}
 
-
 	/**
 	 * @param int $since
 	 * @param int $limit
@@ -522,7 +499,6 @@ class StreamService {
 		// TODO - admin should be able to provide a list of 'friendly/internal' instance of ActivityPub
 		return [];
 	}
-
 
 	/**
 	 *
@@ -536,7 +512,6 @@ class StreamService {
 		return $this->streamRequest->getTimelineGlobal_dep($since, $limit, false);
 	}
 
-
 	/**
 	 *
 	 * @param int $since
@@ -548,7 +523,6 @@ class StreamService {
 	public function getStreamLiked(int $since = 0, int $limit = 5): array {
 		return $this->streamRequest->getTimelineLiked($since, $limit);
 	}
-
 
 	/**
 	 * @param $noteId
@@ -573,7 +547,6 @@ class StreamService {
 
 		return $this->cacheActorService->getFromId($note->getAttributedTo());
 	}
-
 
 	/**
 	 * @param Person $actor

--- a/lib/Service/TestService.php
+++ b/lib/Service/TestService.php
@@ -30,13 +30,11 @@ use OCA\Social\Tools\Traits\TArrayTools;
 class TestService {
 	use TArrayTools;
 
-
 	private CurlService $curlService;
 
 	private ConfigService $configService;
 
 	private MiscService $miscService;
-
 
 	/**
 	 * PostService constructor.
@@ -52,7 +50,6 @@ class TestService {
 		$this->configService = $configService;
 		$this->miscService = $miscService;
 	}
-
 
 	public function testWebfinger(SimpleDataStore $tests) {
 		$account = ltrim($tests->g('account'), '@');
@@ -79,7 +76,6 @@ class TestService {
 			$path = '/.well-known/webfinger';
 		}
 		$tests->aObj('tests', $testHostMeta);
-
 
 		$request = new NCRequest($path);
 		$request->addParam('resource', 'acct:' . $account);
@@ -114,7 +110,6 @@ class TestService {
 
 		$tests->aObj('tests', $testActorLink);
 
-
 		$id = $this->get('href', $link, '');
 
 		$testActorData = new Test('actor-data', Test::SEVERITY_MANDATORY);
@@ -130,7 +125,6 @@ class TestService {
 		}
 
 		$tests->aObj('tests', $testActorData);
-
 
 		$testActor = new Test('actor', Test::SEVERITY_MANDATORY);
 		try {

--- a/lib/Service/UpdateService.php
+++ b/lib/Service/UpdateService.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -26,9 +27,7 @@ class UpdateService {
 
 	private INotificationManager $notificationManager;
 
-
 	private string $updateId = 'alpha3';
-
 
 	/**
 	 * UpdateService constructor.
@@ -48,7 +47,6 @@ class UpdateService {
 		$this->notificationManager = $notificationManager;
 	}
 
-
 	public function checkUpdateStatus() {
 		$notifications = $this->generateNotifications(true, 'update_alpha3', []);
 
@@ -61,7 +59,6 @@ class UpdateService {
 			$this->notificationManager->notify($notif);
 		}
 	}
-
 
 	/**
 	 * @param bool $adminOnly
@@ -90,7 +87,6 @@ class UpdateService {
 
 		return $notifications;
 	}
-
 
 	/**
 	 * @param string $userId

--- a/lib/Tools/Db/ExtendedQueryBuilder.php
+++ b/lib/Tools/Db/ExtendedQueryBuilder.php
@@ -47,7 +47,6 @@ class ExtendedQueryBuilder extends QueryBuilder implements IExtendedQueryBuilder
 		return $this->defaultSelectAlias;
 	}
 
-
 	/**
 	 * Limit the request to the Id
 	 *
@@ -61,11 +60,9 @@ class ExtendedQueryBuilder extends QueryBuilder implements IExtendedQueryBuilder
 		return $this;
 	}
 
-
 	public function limitToNid(int $id): void {
 		$this->limitToDBFieldInt('nid', $id);
 	}
-
 
 	/**
 	 * @param array $ids
@@ -77,7 +74,6 @@ class ExtendedQueryBuilder extends QueryBuilder implements IExtendedQueryBuilder
 
 		return $this;
 	}
-
 
 	/**
 	 * Limit the request to the Id (string)
@@ -92,7 +88,6 @@ class ExtendedQueryBuilder extends QueryBuilder implements IExtendedQueryBuilder
 		return $this;
 	}
 
-
 	/**
 	 * Limit the request to the UserId
 	 *
@@ -105,7 +100,6 @@ class ExtendedQueryBuilder extends QueryBuilder implements IExtendedQueryBuilder
 
 		return $this;
 	}
-
 
 	/**
 	 * Limit the request to the creation
@@ -124,7 +118,6 @@ class ExtendedQueryBuilder extends QueryBuilder implements IExtendedQueryBuilder
 		return $this;
 	}
 
-
 	/**
 	 * @param string $field
 	 * @param string $value
@@ -136,7 +129,6 @@ class ExtendedQueryBuilder extends QueryBuilder implements IExtendedQueryBuilder
 
 		$this->andWhere($expr);
 	}
-
 
 	/**
 	 * @param string $field
@@ -177,7 +169,6 @@ class ExtendedQueryBuilder extends QueryBuilder implements IExtendedQueryBuilder
 		}
 	}
 
-
 	/**
 	 * @param string $field
 	 * @param array $values
@@ -191,7 +182,6 @@ class ExtendedQueryBuilder extends QueryBuilder implements IExtendedQueryBuilder
 		$this->andWhere($expr);
 	}
 
-
 	/**
 	 * @param string $field
 	 * @param string $value
@@ -204,7 +194,6 @@ class ExtendedQueryBuilder extends QueryBuilder implements IExtendedQueryBuilder
 		$expr = $this->exprLimitToDBField($field, $value, false, $cs, $alias);
 		$this->andWhere($expr);
 	}
-
 
 	/**
 	 * @param string $field
@@ -249,7 +238,6 @@ class ExtendedQueryBuilder extends QueryBuilder implements IExtendedQueryBuilder
 		return $junc;
 	}
 
-
 	/**
 	 * @param string $field
 	 * @param int $value
@@ -259,7 +247,6 @@ class ExtendedQueryBuilder extends QueryBuilder implements IExtendedQueryBuilder
 		$expr = $this->exprLimitToDBFieldInt($field, $value, $alias, true);
 		$this->andWhere($expr);
 	}
-
 
 	/**
 	 * @param string $field
@@ -289,34 +276,31 @@ class ExtendedQueryBuilder extends QueryBuilder implements IExtendedQueryBuilder
 		return $expr->$comp($field, $this->createNamedParameter($value, IQueryBuilder::PARAM_INT));
 	}
 
-
 	/**
 	 * @param string $field
 	 */
 	public function limitToDBFieldEmpty(string $field) {
 		$expr = $this->expr();
-		$pf =
-			($this->getType() === DBALQueryBuilder::SELECT) ? $this->getDefaultSelectAlias()
+		$pf
+			= ($this->getType() === DBALQueryBuilder::SELECT) ? $this->getDefaultSelectAlias()
 															  . '.' : '';
 		$field = $pf . $field;
 
 		$this->andWhere($expr->eq($field, $this->createNamedParameter('')));
 	}
 
-
 	/**
 	 * @param string $field
 	 */
 	public function filterDBFieldEmpty(string $field) {
 		$expr = $this->expr();
-		$pf =
-			($this->getType() === DBALQueryBuilder::SELECT) ? $this->getDefaultSelectAlias()
+		$pf
+			= ($this->getType() === DBALQueryBuilder::SELECT) ? $this->getDefaultSelectAlias()
 															  . '.' : '';
 		$field = $pf . $field;
 
 		$this->andWhere($expr->neq($field, $this->createNamedParameter('')));
 	}
-
 
 	/**
 	 * @param string $field
@@ -325,8 +309,8 @@ class ExtendedQueryBuilder extends QueryBuilder implements IExtendedQueryBuilder
 	 */
 	public function limitToDBFieldDateTime(string $field, DateTime $date, bool $orNull = false) {
 		$expr = $this->expr();
-		$pf =
-			($this->getType() === DBALQueryBuilder::SELECT) ? $this->getDefaultSelectAlias()
+		$pf
+			= ($this->getType() === DBALQueryBuilder::SELECT) ? $this->getDefaultSelectAlias()
 															  . '.' : '';
 		$field = $pf . $field;
 
@@ -340,7 +324,6 @@ class ExtendedQueryBuilder extends QueryBuilder implements IExtendedQueryBuilder
 
 		$this->andWhere($expr->orX(...$conditions));
 	}
-
 
 	/**
 	 * @param int $timestamp
@@ -367,7 +350,6 @@ class ExtendedQueryBuilder extends QueryBuilder implements IExtendedQueryBuilder
 		);
 	}
 
-
 	/**
 	 * @param string $field
 	 * @param string $value
@@ -381,7 +363,6 @@ class ExtendedQueryBuilder extends QueryBuilder implements IExtendedQueryBuilder
 
 		$this->andWhere($expr->iLike($field, $this->createNamedParameter($value)));
 	}
-
 
 	/**
 	 * @param IQueryBuilder $qb
@@ -408,7 +389,6 @@ class ExtendedQueryBuilder extends QueryBuilder implements IExtendedQueryBuilder
 
 		return $expr->iLike($alias . '.' . $field, $concat);
 	}
-
 
 	/**
 	 * @param IQueryBuilder $qb
@@ -462,7 +442,6 @@ class ExtendedQueryBuilder extends QueryBuilder implements IExtendedQueryBuilder
 	//		);
 	//	}
 
-
 	/**
 	 * @param callable $method
 	 *
@@ -508,7 +487,6 @@ class ExtendedQueryBuilder extends QueryBuilder implements IExtendedQueryBuilder
 	public function limitInArray(string $field, array $value, string $alias = ''): void {
 		$this->andWhere($this->exprLimitInArray($field, $value, $alias));
 	}
-
 
 	/**
 	 * @param string $field

--- a/lib/Tools/Db/RequestBuilder.php
+++ b/lib/Tools/Db/RequestBuilder.php
@@ -24,7 +24,6 @@ class RequestBuilder {
 	/** @var string */
 	protected $defaultSelectAlias;
 
-
 	/**
 	 * Limit the request to the Id
 	 *
@@ -34,7 +33,6 @@ class RequestBuilder {
 	protected function limitToId(IQueryBuilder $qb, int $id) {
 		$this->limitToDBFieldInt($qb, 'id', $id);
 	}
-
 
 	/**
 	 * Limit the request to the Id (string)
@@ -46,7 +44,6 @@ class RequestBuilder {
 		$this->limitToDBField($qb, 'id', $id, false);
 	}
 
-
 	/**
 	 * Limit the request to the UserId
 	 *
@@ -56,7 +53,6 @@ class RequestBuilder {
 	protected function limitToUserId(IQueryBuilder $qb, string $userId) {
 		$this->limitToDBField($qb, 'user_id', $userId, false);
 	}
-
 
 	/**
 	 * Limit the request to the creation
@@ -73,7 +69,6 @@ class RequestBuilder {
 		$this->limitToDBFieldDateTime($qb, 'creation', $date, true);
 	}
 
-
 	/**
 	 * @param IQueryBuilder $qb
 	 * @param string $field
@@ -88,7 +83,6 @@ class RequestBuilder {
 		$qb->andWhere($expr);
 	}
 
-
 	/**
 	 * @param IQueryBuilder $qb
 	 * @param string $field
@@ -102,7 +96,6 @@ class RequestBuilder {
 		$expr = $this->exprLimitToDBField($qb, $field, $value, false, $cs, $alias);
 		$qb->andWhere($expr);
 	}
-
 
 	/**
 	 * @param IQueryBuilder $qb
@@ -141,7 +134,6 @@ class RequestBuilder {
 		}
 	}
 
-
 	/**
 	 * @param IQueryBuilder $qb
 	 * @param string $field
@@ -155,7 +147,6 @@ class RequestBuilder {
 		$qb->andWhere($expr);
 	}
 
-
 	/**
 	 * @param IQueryBuilder $qb
 	 * @param string $field
@@ -168,7 +159,6 @@ class RequestBuilder {
 		$expr = $this->exprLimitToDBFieldInt($qb, $field, $value, $alias, false);
 		$qb->andWhere($expr);
 	}
-
 
 	/**
 	 * @param IQueryBuilder $qb
@@ -199,7 +189,6 @@ class RequestBuilder {
 		return $expr->$comp($field, $qb->createNamedParameter($value));
 	}
 
-
 	/**
 	 * @param IQueryBuilder $qb
 	 * @param string $field
@@ -212,7 +201,6 @@ class RequestBuilder {
 		$qb->andWhere($expr->eq($field, $qb->createNamedParameter('')));
 	}
 
-
 	/**
 	 * @param IQueryBuilder $qb
 	 * @param string $field
@@ -224,7 +212,6 @@ class RequestBuilder {
 
 		$qb->andWhere($expr->neq($field, $qb->createNamedParameter('')));
 	}
-
 
 	/**
 	 * @param IQueryBuilder $qb
@@ -248,7 +235,6 @@ class RequestBuilder {
 		$qb->andWhere($expr->orX(...$conditions));
 	}
 
-
 	/**
 	 * @param IQueryBuilder $qb
 	 * @param int $timestamp
@@ -271,7 +257,6 @@ class RequestBuilder {
 		);
 	}
 
-
 	/**
 	 * @param IQueryBuilder $qb
 	 * @param string $field
@@ -289,7 +274,6 @@ class RequestBuilder {
 
 		$qb->andWhere($expr->orX(...$conditions));
 	}
-
 
 	/**
 	 * @param IQueryBuilder $qb

--- a/lib/Tools/Exceptions/ArrayNotFoundException.php
+++ b/lib/Tools/Exceptions/ArrayNotFoundException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/Tools/Exceptions/CacheItemNotFoundException.php
+++ b/lib/Tools/Exceptions/CacheItemNotFoundException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/Tools/Exceptions/DateTimeException.php
+++ b/lib/Tools/Exceptions/DateTimeException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/Tools/Exceptions/DependencyInjectionException.php
+++ b/lib/Tools/Exceptions/DependencyInjectionException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/Tools/Exceptions/InvalidItemException.php
+++ b/lib/Tools/Exceptions/InvalidItemException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/Tools/Exceptions/InvalidOriginException.php
+++ b/lib/Tools/Exceptions/InvalidOriginException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/Tools/Exceptions/ItemNotFoundException.php
+++ b/lib/Tools/Exceptions/ItemNotFoundException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/Tools/Exceptions/JsonNotRequestedException.php
+++ b/lib/Tools/Exceptions/JsonNotRequestedException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/Tools/Exceptions/MalformedArrayException.php
+++ b/lib/Tools/Exceptions/MalformedArrayException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/Tools/Exceptions/RequestContentException.php
+++ b/lib/Tools/Exceptions/RequestContentException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/Tools/Exceptions/RequestNetworkException.php
+++ b/lib/Tools/Exceptions/RequestNetworkException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/Tools/Exceptions/RequestResultNotJsonException.php
+++ b/lib/Tools/Exceptions/RequestResultNotJsonException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/Tools/Exceptions/RequestResultSizeException.php
+++ b/lib/Tools/Exceptions/RequestResultSizeException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/Tools/Exceptions/RequestServerException.php
+++ b/lib/Tools/Exceptions/RequestServerException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/Tools/Exceptions/RowNotFoundException.php
+++ b/lib/Tools/Exceptions/RowNotFoundException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/Tools/Exceptions/SignatoryException.php
+++ b/lib/Tools/Exceptions/SignatoryException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/Tools/Exceptions/SignatureException.php
+++ b/lib/Tools/Exceptions/SignatureException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/Tools/IExtendedQueryBuilder.php
+++ b/lib/Tools/IExtendedQueryBuilder.php
@@ -28,12 +28,10 @@ interface IExtendedQueryBuilder extends IQueryBuilder {
 	 */
 	public function setDefaultSelectAlias(string $alias): IExtendedQueryBuilder;
 
-
 	/**
 	 * @return string
 	 */
 	public function getDefaultSelectAlias(): string;
-
 
 	/**
 	 * Limit the request to the Id
@@ -44,7 +42,6 @@ interface IExtendedQueryBuilder extends IQueryBuilder {
 	 */
 	public function limitToId(int $id): IExtendedQueryBuilder;
 
-
 	/**
 	 * Limit the request to Ids
 	 *
@@ -53,7 +50,6 @@ interface IExtendedQueryBuilder extends IQueryBuilder {
 	 * @return IExtendedQueryBuilder
 	 */
 	public function limitToIds(array $ids): IExtendedQueryBuilder;
-
 
 	/**
 	 * Limit the request to the Id (string)
@@ -64,7 +60,6 @@ interface IExtendedQueryBuilder extends IQueryBuilder {
 	 */
 	public function limitToIdString(string $id): IExtendedQueryBuilder;
 
-
 	/**
 	 * Limit the request to the UserId
 	 *
@@ -73,7 +68,6 @@ interface IExtendedQueryBuilder extends IQueryBuilder {
 	 * @return IExtendedQueryBuilder
 	 */
 	public function limitToUserId(string $userId): IExtendedQueryBuilder;
-
 
 	/**
 	 * Limit the request to the creation
@@ -85,7 +79,6 @@ interface IExtendedQueryBuilder extends IQueryBuilder {
 	 */
 	public function limitToCreation(int $delay = 0): IExtendedQueryBuilder;
 
-
 	/**
 	 * @param string $field
 	 * @param string $value
@@ -94,7 +87,6 @@ interface IExtendedQueryBuilder extends IQueryBuilder {
 	 */
 	public function limitToDBField(string $field, string $value, bool $cs = true, string $alias = '',
 	);
-
 
 	/**
 	 * @param string $field
@@ -115,7 +107,6 @@ interface IExtendedQueryBuilder extends IQueryBuilder {
 		string $field, array $values, bool $cs = true, string $alias = '',
 	);
 
-
 	/**
 	 * @param string $field
 	 * @param string $value
@@ -127,7 +118,6 @@ interface IExtendedQueryBuilder extends IQueryBuilder {
 	public function filterDBFieldArray(
 		string $field, string $value, bool $cs = true, string $alias = '',
 	);
-
 
 	/**
 	 * @param string $field
@@ -142,14 +132,12 @@ interface IExtendedQueryBuilder extends IQueryBuilder {
 		string $field, array $values, bool $eq = true, bool $cs = true, string $alias = '',
 	): ICompositeExpression;
 
-
 	/**
 	 * @param string $field
 	 * @param int $value
 	 * @param string $alias
 	 */
 	public function limitToDBFieldInt(string $field, int $value, string $alias = '');
-
 
 	/**
 	 * @param string $field
@@ -160,7 +148,6 @@ interface IExtendedQueryBuilder extends IQueryBuilder {
 	 */
 	public function filterDBFieldInt(string $field, int $value, string $alias = '');
 
-
 	/**
 	 * @param string $field
 	 * @param int $value
@@ -168,12 +155,10 @@ interface IExtendedQueryBuilder extends IQueryBuilder {
 	 */
 	public function exprLimitToDBFieldInt(string $field, int $value, string $alias = ''): string;
 
-
 	/**
 	 * @param string $field
 	 */
 	public function limitToDBFieldEmpty(string $field);
-
 
 	/**
 	 * @param string $field
@@ -181,7 +166,6 @@ interface IExtendedQueryBuilder extends IQueryBuilder {
 	 * @return mixed
 	 */
 	public function filterDBFieldEmpty(string $field);
-
 
 	/**
 	 * @param string $field
@@ -191,13 +175,11 @@ interface IExtendedQueryBuilder extends IQueryBuilder {
 	public function limitToDBFieldDateTime(string $field, DateTime $date, bool $orNull = false,
 	);
 
-
 	/**
 	 * @param int $timestamp
 	 * @param string $field
 	 */
 	public function limitToSince(int $timestamp, string $field);
-
 
 	/**
 	 * @param string $field

--- a/lib/Tools/IInteractiveShellClient.php
+++ b/lib/Tools/IInteractiveShellClient.php
@@ -28,7 +28,6 @@ interface IInteractiveShellClient {
 	 */
 	public function fillCommandList(string $source, string $field): array;
 
-
 	/**
 	 * @param string $command
 	 *

--- a/lib/Tools/Model/Cache.php
+++ b/lib/Tools/Model/Cache.php
@@ -21,14 +21,11 @@ use OCA\Social\Tools\Traits\TArrayTools;
 class Cache implements JsonSerializable {
 	use TArrayTools;
 
-
 	/** @var CacheItem[] */
 	private $items = [];
 
-
 	public function __construct() {
 	}
-
 
 	/**
 	 * @return bool
@@ -70,7 +67,6 @@ class Cache implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @param string $url
 	 *
@@ -87,7 +83,6 @@ class Cache implements JsonSerializable {
 		throw new CacheItemNotFoundException();
 	}
 
-
 	/**
 	 * @param string $url
 	 *
@@ -102,7 +97,6 @@ class Cache implements JsonSerializable {
 			return false;
 		}
 	}
-
 
 	/**
 	 * @param string $url
@@ -155,7 +149,6 @@ class Cache implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @param array $data
 	 */
@@ -172,7 +165,6 @@ class Cache implements JsonSerializable {
 			$this->addItem($item);
 		}
 	}
-
 
 	/**
 	 * @return array

--- a/lib/Tools/Model/CacheItem.php
+++ b/lib/Tools/Model/CacheItem.php
@@ -20,7 +20,6 @@ use OCA\Social\Tools\Traits\TArrayTools;
 class CacheItem implements JsonSerializable {
 	use TArrayTools;
 
-
 	/** @var string */
 	private $url = '';
 
@@ -36,7 +35,6 @@ class CacheItem implements JsonSerializable {
 	/** @var int */
 	private $creation = 0;
 
-
 	/**
 	 * CacheItem constructor.
 	 *
@@ -45,7 +43,6 @@ class CacheItem implements JsonSerializable {
 	public function __construct(string $url) {
 		$this->url = $url;
 	}
-
 
 	/**
 	 * @return string
@@ -65,7 +62,6 @@ class CacheItem implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -84,7 +80,6 @@ class CacheItem implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return array
 	 */
@@ -97,7 +92,6 @@ class CacheItem implements JsonSerializable {
 
 		return [];
 	}
-
 
 	/**
 	 * @return int
@@ -140,7 +134,6 @@ class CacheItem implements JsonSerializable {
 		$this->error = $error;
 	}
 
-
 	/**
 	 * @return int
 	 */
@@ -159,7 +152,6 @@ class CacheItem implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @param array $data
 	 */
@@ -170,7 +162,6 @@ class CacheItem implements JsonSerializable {
 		$this->setError($this->getInt('error', $data, 0));
 		$this->setCreation($this->getInt('creation', $data, 0));
 	}
-
 
 	/**
 	 * @return array

--- a/lib/Tools/Model/Request.php
+++ b/lib/Tools/Model/Request.php
@@ -20,16 +20,13 @@ use OCA\Social\Tools\Traits\TArrayTools;
 class Request implements JsonSerializable {
 	use TArrayTools;
 
-
 	public const TYPE_GET = 0;
 	public const TYPE_POST = 1;
 	public const TYPE_PUT = 2;
 	public const TYPE_DELETE = 3;
 
-
 	public const QS_VAR_DUPLICATE = 1;
 	public const QS_VAR_ARRAY = 2;
-
 
 	/** @var string */
 	private $protocol = '';
@@ -91,7 +88,6 @@ class Request implements JsonSerializable {
 	/** @var string */
 	private $contentType = '';
 
-
 	/**
 	 * Request constructor.
 	 *
@@ -104,7 +100,6 @@ class Request implements JsonSerializable {
 		$this->type = $type;
 		$this->binary = $binary;
 	}
-
 
 	/**
 	 * @param string $protocol
@@ -153,7 +148,6 @@ class Request implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return string
 	 * @deprecated - 19 - use getHost();
@@ -192,7 +186,6 @@ class Request implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return int
 	 */
@@ -210,7 +203,6 @@ class Request implements JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @param string $instance
@@ -233,7 +225,6 @@ class Request implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -245,7 +236,6 @@ class Request implements JsonSerializable {
 
 		return $instance;
 	}
-
 
 	/**
 	 * @param string $url
@@ -304,7 +294,6 @@ class Request implements JsonSerializable {
 		return $this->binary;
 	}
 
-
 	/**
 	 * @param bool $verifyPeer
 	 *
@@ -322,7 +311,6 @@ class Request implements JsonSerializable {
 	public function isVerifyPeer(): bool {
 		return $this->verifyPeer;
 	}
-
 
 	/**
 	 * @param bool $httpErrorsAllowed
@@ -342,7 +330,6 @@ class Request implements JsonSerializable {
 		return $this->httpErrorsAllowed;
 	}
 
-
 	/**
 	 * @param bool $followLocation
 	 *
@@ -360,7 +347,6 @@ class Request implements JsonSerializable {
 	public function isFollowLocation(): bool {
 		return $this->followLocation;
 	}
-
 
 	/**
 	 * @return string
@@ -397,14 +383,12 @@ class Request implements JsonSerializable {
 		return $url;
 	}
 
-
 	/**
 	 * @return string
 	 */
 	public function getPath(): string {
 		return $this->baseUrl . $this->url;
 	}
-
 
 	/**
 	 * @return string
@@ -413,7 +397,6 @@ class Request implements JsonSerializable {
 	public function getUrl(): string {
 		return $this->getPath();
 	}
-
 
 	/**
 	 * @return string
@@ -424,14 +407,12 @@ class Request implements JsonSerializable {
 		return $this->getUsedProtocol() . '://' . $this->getHost() . $port . $this->getParametersUrl();
 	}
 
-
 	/**
 	 * @return int
 	 */
 	public function getType(): int {
 		return $this->type;
 	}
-
 
 	/**
 	 * @psalm-param string $key
@@ -467,7 +448,6 @@ class Request implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return array
 	 */
@@ -485,7 +465,6 @@ class Request implements JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @param int $queryStringType
@@ -505,14 +484,12 @@ class Request implements JsonSerializable {
 		return $this->queryStringType;
 	}
 
-
 	/**
 	 * @return array
 	 */
 	public function getData(): array {
 		return $this->data;
 	}
-
 
 	/**
 	 * @param array $data
@@ -525,7 +502,6 @@ class Request implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @param string $data
 	 *
@@ -537,7 +513,6 @@ class Request implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @param JsonSerializable $data
 	 *
@@ -548,7 +523,6 @@ class Request implements JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return array
@@ -568,7 +542,6 @@ class Request implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @param string $k
 	 * @param string $v
@@ -580,7 +553,6 @@ class Request implements JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @param string $k
@@ -594,7 +566,6 @@ class Request implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @param string $k
 	 * @param string $v
@@ -607,7 +578,6 @@ class Request implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @param string $k
 	 * @param int $v
@@ -619,7 +589,6 @@ class Request implements JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return string
@@ -656,7 +625,6 @@ class Request implements JsonSerializable {
 		);
 	}
 
-
 	/**
 	 * @param int $type
 	 *
@@ -670,7 +638,6 @@ class Request implements JsonSerializable {
 		switch ($this->getQueryStringType()) {
 			case self::QS_VAR_ARRAY:
 				return '?' . http_build_query($this->getParams());
-
 			case self::QS_VAR_DUPLICATE:
 			default:
 				return '?' . preg_replace(
@@ -678,7 +645,6 @@ class Request implements JsonSerializable {
 				);
 		}
 	}
-
 
 	/**
 	 * @return int
@@ -698,7 +664,6 @@ class Request implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -716,7 +681,6 @@ class Request implements JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return int
@@ -736,7 +700,6 @@ class Request implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @return string
 	 */
@@ -754,7 +717,6 @@ class Request implements JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @return array
@@ -779,7 +741,6 @@ class Request implements JsonSerializable {
 		];
 	}
 
-
 	/**
 	 * @param string $type
 	 *
@@ -799,7 +760,6 @@ class Request implements JsonSerializable {
 
 		return 0;
 	}
-
 
 	public static function method(int $type): string {
 		switch ($type) {

--- a/lib/Tools/Model/SimpleDataStore.php
+++ b/lib/Tools/Model/SimpleDataStore.php
@@ -22,10 +22,8 @@ use OCA\Social\Tools\Traits\TArrayTools;
 class SimpleDataStore implements JsonSerializable {
 	use TArrayTools;
 
-
 	/** @var array */
 	private $data;
-
 
 	/**
 	 * SimpleDataStore constructor.
@@ -40,14 +38,12 @@ class SimpleDataStore implements JsonSerializable {
 		$this->data = $data;
 	}
 
-
 	/**
 	 * @param array $default
 	 */
 	public function default(array $default = []) {
 		$this->data = array_merge($default, $this->data);
 	}
-
 
 	/**
 	 * @param string $key
@@ -86,7 +82,6 @@ class SimpleDataStore implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @param string $key
 	 * @param int $value
@@ -123,7 +118,6 @@ class SimpleDataStore implements JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @param string $key
@@ -162,7 +156,6 @@ class SimpleDataStore implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @param string $key
 	 * @param array $values
@@ -200,7 +193,6 @@ class SimpleDataStore implements JsonSerializable {
 		return $this;
 	}
 
-
 	/**
 	 * @param string $key
 	 * @param JsonSerializable $value
@@ -228,7 +220,6 @@ class SimpleDataStore implements JsonSerializable {
 
 		return $this;
 	}
-
 
 	/**
 	 * @param string $key
@@ -267,7 +258,6 @@ class SimpleDataStore implements JsonSerializable {
 		return new SimpleDataStore($this->getArray($key, $this->data));
 	}
 
-
 	/**
 	 * @param string $key
 	 *
@@ -281,7 +271,6 @@ class SimpleDataStore implements JsonSerializable {
 
 		return $this->data[$key];
 	}
-
 
 	/**
 	 * @return array
@@ -301,7 +290,6 @@ class SimpleDataStore implements JsonSerializable {
 		return $this;
 	}
 
-
 	public function keys(): array {
 		return array_keys($this->data);
 	}
@@ -314,7 +302,6 @@ class SimpleDataStore implements JsonSerializable {
 	public function hasKey(string $key): bool {
 		return (array_key_exists($key, $this->data));
 	}
-
 
 	/**
 	 * @param array $keys
@@ -338,7 +325,6 @@ class SimpleDataStore implements JsonSerializable {
 		return true;
 	}
 
-
 	/**
 	 * @param array $keys
 	 * @param bool $must
@@ -360,7 +346,6 @@ class SimpleDataStore implements JsonSerializable {
 	public function haveKey(string $key): bool {
 		return $this->hasKey($key);
 	}
-
 
 	/**
 	 * @return array

--- a/lib/Tools/Traits/TArrayTools.php
+++ b/lib/Tools/Traits/TArrayTools.php
@@ -220,7 +220,6 @@ trait TArrayTools {
 		return false;
 	}
 
-
 	/**
 	 * @param string $k
 	 * @param array $arr
@@ -247,7 +246,6 @@ trait TArrayTools {
 		return $r;
 	}
 
-
 	/**
 	 * @param string $k
 	 * @param string $value
@@ -269,7 +267,6 @@ trait TArrayTools {
 
 		throw new ArrayNotFoundException();
 	}
-
 
 	/**
 	 * @param string $key
@@ -326,7 +323,6 @@ trait TArrayTools {
 		throw new ItemNotFoundException();
 	}
 
-
 	/**
 	 * @param array $keys
 	 * @param array $arr
@@ -342,7 +338,6 @@ trait TArrayTools {
 			}
 		}
 	}
-
 
 	/**
 	 * @param array $arr

--- a/lib/Tools/Traits/TNCDataResponse.php
+++ b/lib/Tools/Traits/TNCDataResponse.php
@@ -49,7 +49,6 @@ trait TNCDataResponse {
 		return new DataResponse($data, $status);
 	}
 
-
 	/**
 	 * @param array $result
 	 * @param array $more

--- a/lib/Tools/Traits/TPathTools.php
+++ b/lib/Tools/Traits/TPathTools.php
@@ -28,7 +28,6 @@ trait TPathTools {
 		return trim($path);
 	}
 
-
 	/**
 	 * @param string $path
 	 * @param bool $force
@@ -51,7 +50,6 @@ trait TPathTools {
 		return trim($path);
 	}
 
-
 	/**
 	 * @param string $path
 	 *
@@ -63,7 +61,6 @@ trait TPathTools {
 
 		return trim($path);
 	}
-
 
 	/**
 	 * @param string $path
@@ -85,7 +82,6 @@ trait TPathTools {
 
 		return trim($path);
 	}
-
 
 	/**
 	 * @param string $path

--- a/lib/Tools/Traits/TRequest.php
+++ b/lib/Tools/Traits/TRequest.php
@@ -29,7 +29,6 @@ trait TRequest {
 		$this->maxDownloadSize = $size;
 	}
 
-
 	/**
 	 * @param Request $request
 	 *
@@ -55,7 +54,6 @@ trait TRequest {
 
 		throw new RequestResultNotJsonException();
 	}
-
 
 	/**
 	 * @param Request $request
@@ -101,7 +99,6 @@ trait TRequest {
 		return $result;
 	}
 
-
 	/**
 	 * @param Request $request
 	 *
@@ -145,7 +142,6 @@ trait TRequest {
 		return $curl;
 	}
 
-
 	/**
 	 * @param Request $request
 	 *
@@ -153,8 +149,8 @@ trait TRequest {
 	 */
 	private function generateCurlRequest(Request $request) {
 		$port = ($request->getPort() > 0) ? ':' . $request->getPort() : '';
-		$url =
-			$request->getUsedProtocol() . '://' . $request->getHost() . $port . $request->getParsedUrl();
+		$url
+			= $request->getUsedProtocol() . '://' . $request->getHost() . $port . $request->getParsedUrl();
 		if ($request->getType() !== Request::TYPE_GET) {
 			$curl = curl_init($url);
 		} else {
@@ -164,7 +160,6 @@ trait TRequest {
 		return $curl;
 	}
 
-
 	/**
 	 * @param Request $request
 	 */
@@ -173,7 +168,6 @@ trait TRequest {
 			return;
 		}
 	}
-
 
 	/**
 	 * @param resource $curl
@@ -221,7 +215,6 @@ trait TRequest {
 		curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
 	}
 
-
 	/**
 	 * @param resource $curl
 	 * @param Request $request
@@ -243,7 +236,6 @@ trait TRequest {
 		$this->parseRequestResultCode5xx($code, $request);
 	}
 
-
 	/**
 	 * @param resource $curl
 	 * @param Request $request
@@ -261,7 +253,6 @@ trait TRequest {
 		}
 	}
 
-
 	/**
 	 * @param int $code
 	 * @param Request $request
@@ -276,7 +267,6 @@ trait TRequest {
 		}
 	}
 
-
 	/**
 	 * @param int $code
 	 * @param Request $request
@@ -290,7 +280,6 @@ trait TRequest {
 			);
 		}
 	}
-
 
 	/**
 	 * @param int $code

--- a/lib/Tools/Traits/TStringTools.php
+++ b/lib/Tools/Traits/TStringTools.php
@@ -37,7 +37,6 @@ trait TStringTools {
 		return $str;
 	}
 
-
 	/**
 	 * Generate uuid: 2b5a7a87-8db1-445f-a17b-405790f91c80
 	 *
@@ -62,7 +61,6 @@ trait TStringTools {
 
 		return $uuid;
 	}
-
 
 	/**
 	 * @param string $str1
@@ -89,7 +87,6 @@ trait TStringTools {
 		return substr($str1, 0, $i);
 	}
 
-
 	/**
 	 * @param string $line
 	 * @param array $params
@@ -105,7 +102,6 @@ trait TStringTools {
 		return $line;
 	}
 
-
 	/**
 	 * @param int $words
 	 *
@@ -119,7 +115,6 @@ trait TStringTools {
 
 		return implode(' ', $sentence);
 	}
-
 
 	/**
 	 * @param int $length

--- a/lib/Traits/TDetails.php
+++ b/lib/Traits/TDetails.php
@@ -20,7 +20,6 @@ trait TDetails {
 	/** @var array */
 	private $details = [];
 
-
 	/**
 	 * @return array
 	 */
@@ -34,7 +33,6 @@ trait TDetails {
 	public function setDetailsAll(array $details) {
 		$this->details = $details;
 	}
-
 
 	/**
 	 * @param string $detail
@@ -76,7 +74,6 @@ trait TDetails {
 		$this->details[$detail] = $value;
 	}
 
-
 	/**
 	 * @param string $detail
 	 *
@@ -89,7 +86,6 @@ trait TDetails {
 
 		return $this->details[$detail];
 	}
-
 
 	public function getDetailInt(string $detail, int $default = 0): int {
 		return $this->details[$detail] ?? $default;
@@ -144,7 +140,6 @@ trait TDetails {
 
 		$this->details[$detail][] = $value;
 	}
-
 
 	/**
 	 * @param string $detail

--- a/lib/WellKnown/JrdResponse.php
+++ b/lib/WellKnown/JrdResponse.php
@@ -59,7 +59,6 @@ final class JrdResponse implements IResponse {
 		return $this;
 	}
 
-
 	public function setHttpCode(int $httpCode): self {
 		$this->httpCode = $httpCode;
 

--- a/lib/WellKnown/WebfingerHandler.php
+++ b/lib/WellKnown/WebfingerHandler.php
@@ -44,7 +44,6 @@ class WebfingerHandler implements IHandler {
 		$this->configService = $configService;
 	}
 
-
 	/**
 	 * @see https://docs.joinmastodon.org/spec/webfinger/
 	 *
@@ -86,7 +85,6 @@ class WebfingerHandler implements IHandler {
 
 		return $previousResponse;
 	}
-
 
 	/**
 	 * handle request on /.well-known/webfinger
@@ -171,7 +169,6 @@ class WebfingerHandler implements IHandler {
 		return $response;
 	}
 
-
 	/**
 	 * handle request on /.well-known/nodeinfo
 	 * returns Json
@@ -190,7 +187,6 @@ class WebfingerHandler implements IHandler {
 
 		return $response;
 	}
-
 
 	/**
 	 * handle request on /.well-known/host-meta

--- a/lib/WellKnown/XrdResponse.php
+++ b/lib/WellKnown/XrdResponse.php
@@ -38,7 +38,6 @@ final class XrdResponse implements IResponse {
 		return $this;
 	}
 
-
 	public function setHttpCode(int $httpCode): self {
 		$this->httpCode = $httpCode;
 
@@ -61,7 +60,6 @@ final class XrdResponse implements IResponse {
 
 		return $this;
 	}
-
 
 	public function toHttpResponse(): Response {
 		$data = [];

--- a/templates/main.php
+++ b/templates/main.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/tests/Controller/ActivityPubControllerTest.php
+++ b/tests/Controller/ActivityPubControllerTest.php
@@ -151,7 +151,6 @@ class ActivityPubControllerTest extends TestCase {
 		$this->assertArrayNotHasKey('message', $data);
 	}
 
-
 	// actor()
 
 	/** @return iterable<string, array{string}> */
@@ -215,7 +214,6 @@ class ActivityPubControllerTest extends TestCase {
 
 		$this->assertFailure($response, CacheActorDoesNotExistException::class, Http::STATUS_NOT_FOUND);
 	}
-
 
 	// sharedInbox() / inbox()
 
@@ -346,7 +344,6 @@ class ActivityPubControllerTest extends TestCase {
 		$this->assertSame(1, $response->getData()['status']);
 	}
 
-
 	// getInbox()
 
 	public function testGetInboxReturnsAnEmptyOrderedCollection(): void {
@@ -372,7 +369,6 @@ class ActivityPubControllerTest extends TestCase {
 		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
 		$this->assertSame([], $response->getData());
 	}
-
 
 	// outbox() / followers() / following()
 
@@ -431,7 +427,6 @@ class ActivityPubControllerTest extends TestCase {
 
 		$this->assertFailure($this->controller->followers('ghost'), CacheActorDoesNotExistException::class);
 	}
-
 
 	// displayPost()
 

--- a/tests/Controller/ApiControllerTest.php
+++ b/tests/Controller/ApiControllerTest.php
@@ -217,7 +217,6 @@ class ApiControllerTest extends TestCase {
 		};
 	}
 
-
 	// credentials
 
 	public function testAppsCredentialsRequiresAViewer(): void {
@@ -269,7 +268,6 @@ class ApiControllerTest extends TestCase {
 		$viewer->method('getId')->willReturn('https://cloud.example/apps/social/@' . $uid);
 		$this->cacheActorService->method('getFromLocalAccount')->with($uid)->willReturn($viewer);
 	}
-
 
 	// token scopes
 
@@ -399,7 +397,6 @@ class ApiControllerTest extends TestCase {
 		$this->assertSame([], $response->getData());
 	}
 
-
 	// instance / emojis
 
 	public function testInstanceReturnsTheLocalInstanceInLocalFormat(): void {
@@ -418,7 +415,6 @@ class ApiControllerTest extends TestCase {
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
 		$this->assertSame([], $response->getData());
 	}
-
 
 	// timelines
 
@@ -480,7 +476,6 @@ class ApiControllerTest extends TestCase {
 
 		$this->assertUnauthorized($this->controller()->timelines('home'), 'db down');
 	}
-
 
 	// statuses
 
@@ -559,7 +554,6 @@ class ApiControllerTest extends TestCase {
 
 		$this->assertUnauthorized($this->controller()->statusAction(12, 'favourite'));
 	}
-
 
 	// statusNew / statusUpdate
 
@@ -665,7 +659,6 @@ class ApiControllerTest extends TestCase {
 		$this->assertSame(['error' => 'gone'], $response->getData());
 	}
 
-
 	// relationships / accounts
 
 	public function testRelationshipsAreResolvedByFollowService(): void {
@@ -681,7 +674,6 @@ class ApiControllerTest extends TestCase {
 	public function testRelationshipsRequireAViewer(): void {
 		$this->assertUnauthorized($this->controller()->relationships([1]));
 	}
-
 
 	// blocking / muting
 
@@ -1141,7 +1133,6 @@ class ApiControllerTest extends TestCase {
 		$this->assertSame([], $response->getData());
 	}
 
-
 	public function testRemoteFollowerFanOutIsBoundedByMaxLimit(): void {
 		$this->localHosts();
 		$actor = $this->createMock(Person::class);
@@ -1170,7 +1161,6 @@ class ApiControllerTest extends TestCase {
 		$this->assertSame([], $response->getData());
 		$this->assertLessThanOrEqual(ProbeOptions::MAX_LIMIT, $calls, 'the fan-out walk must be bounded by MAX_LIMIT');
 	}
-
 
 	// favourites / notifications / tag
 
@@ -1222,7 +1212,6 @@ class ApiControllerTest extends TestCase {
 		$this->assertTrue($probe->isOnlyMedia());
 		$this->assertSame(6, $probe->getLimit());
 	}
-
 
 	// media
 

--- a/tests/Controller/LocalControllerTest.php
+++ b/tests/Controller/LocalControllerTest.php
@@ -165,7 +165,6 @@ class LocalControllerTest extends TestCase {
 		$this->assertFailure($response, AccountDoesNotExistException::class, 'User not logged in');
 	}
 
-
 	// postCreate()
 
 	public function testPostCreateBuildsThePostFromTheRequest(): void {
@@ -229,7 +228,6 @@ class LocalControllerTest extends TestCase {
 		$this->assertFailure($this->controller()->postCreate('x'), \RuntimeException::class, 'cannot post');
 	}
 
-
 	// postGet() / postReplies() / postDelete()
 
 	public function testPostGetReturnsTheStreamDirectly(): void {
@@ -291,7 +289,6 @@ class LocalControllerTest extends TestCase {
 		$this->assertNotLoggedIn($this->controller(null)->postDelete('https://x/n/1'));
 	}
 
-
 	// like / boost
 
 	/** @return iterable<string, array{string, string, string, string}> */
@@ -332,7 +329,6 @@ class LocalControllerTest extends TestCase {
 		$this->assertFailure($this->controller()->postLike('https://x/n/404'), StreamNotFoundException::class, 'no such post');
 	}
 
-
 	// follow / unfollow
 
 	public function testActionFollowFollowsAndRefreshesCounters(): void {
@@ -371,7 +367,6 @@ class LocalControllerTest extends TestCase {
 
 		$this->assertFailure($this->controller()->actionUnfollow('ghost'), CacheActorDoesNotExistException::class);
 	}
-
 
 	// stream*()
 
@@ -421,7 +416,6 @@ class LocalControllerTest extends TestCase {
 
 		$this->assertSuccess($this->controller(null)->streamAccount('bob@remote.example', 2, 6), ['p']);
 	}
-
 
 	// current* / account* / global*
 
@@ -582,7 +576,6 @@ class LocalControllerTest extends TestCase {
 		$this->assertFailure($this->controller(null)->globalActorInfo('https://x'), CacheActorDoesNotExistException::class);
 	}
 
-
 	// avatar / header
 
 	public function testGlobalActorAvatarServesTheCachedIcon(): void {
@@ -646,7 +639,6 @@ class LocalControllerTest extends TestCase {
 		);
 	}
 
-
 	// search
 
 	public function testGlobalAccountsSearchWithEmptyTermIsEmpty(): void {
@@ -701,7 +693,6 @@ class LocalControllerTest extends TestCase {
 			['accounts' => ['a'], 'hashtags' => ['h'], 'content' => ['c']]
 		);
 	}
-
 
 	// documents / uploads
 

--- a/tests/Controller/NavigationControllerTest.php
+++ b/tests/Controller/NavigationControllerTest.php
@@ -123,7 +123,6 @@ class NavigationControllerTest extends TestCase {
 		return $this->states['social']['serverData'];
 	}
 
-
 	// navigate()
 
 	public function testNavigateRendersTheAppForAReturningUser(): void {
@@ -267,7 +266,6 @@ class NavigationControllerTest extends TestCase {
 		$this->assertSame('main', $this->controller()->timeline('home')->getTemplateName());
 		$this->assertSame('main', $this->controller()->account('alice')->getTemplateName());
 	}
-
 
 	// documents
 

--- a/tests/Controller/OAuthControllerTest.php
+++ b/tests/Controller/OAuthControllerTest.php
@@ -93,7 +93,6 @@ class OAuthControllerTest extends TestCase {
 		return $client;
 	}
 
-
 	// nodeinfo2()
 
 	public function testNodeinfo2DescribesTheLocalInstance(): void {
@@ -126,7 +125,6 @@ class OAuthControllerTest extends TestCase {
 		$this->assertSame([], $data['usage']);
 		$this->assertFalse($data['openRegistrations']);
 	}
-
 
 	// apps()
 
@@ -165,7 +163,6 @@ class OAuthControllerTest extends TestCase {
 
 		$this->assertSame('read', $this->controller->apps('App', 'https://a/cb')->getData()['scopes']);
 	}
-
 
 	// authorize()
 
@@ -223,7 +220,6 @@ class OAuthControllerTest extends TestCase {
 		$this->controller->authorize('client-1', 'https://evil.example/steal', 'code', 'read');
 	}
 
-
 	// authorizing()
 
 	public function testAuthorizingIssuesACodeBoundToTheUser(): void {
@@ -276,7 +272,6 @@ class OAuthControllerTest extends TestCase {
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
 		$this->assertSame(['error' => 'wrong scopes'], $response->getData());
 	}
-
 
 	// token()
 
@@ -377,7 +372,6 @@ class OAuthControllerTest extends TestCase {
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
 		$this->assertSame(['error' => 'wrong client_secret'], $response->getData());
 	}
-
 
 	// revoke()
 

--- a/tests/Service/ActivityServiceTest.php
+++ b/tests/Service/ActivityServiceTest.php
@@ -190,7 +190,6 @@ class ActivityServiceTest extends TestCase {
 		$this->requestQueueService->method('getRequestFromToken')->willReturn([]);
 	}
 
-
 	// createActivity()
 
 	public function testCreateActivityWrapsItemSignsSavesAndQueuesIt(): void {
@@ -270,7 +269,6 @@ class ActivityServiceTest extends TestCase {
 		$this->assertSame($stream, $activity->getObject());
 	}
 
-
 	// updateActivity()
 
 	public function testUpdateActivityWrapsItemInSignedUpdateWithoutSavingIt(): void {
@@ -301,7 +299,6 @@ class ActivityServiceTest extends TestCase {
 		$this->assertSame($queued, $note->getParent());
 		$this->assertSame($alice, $queued->getActor());
 	}
-
 
 	// deleteActivity()
 
@@ -334,7 +331,6 @@ class ActivityServiceTest extends TestCase {
 		$this->assertSame(self::NOTE_ID, $queued->getObjectId());
 		$this->assertSame($queued, $queued->getObject()->getParent());
 	}
-
 
 	// request(): recipient resolution
 
@@ -426,7 +422,6 @@ class ActivityServiceTest extends TestCase {
 		$this->service->request($item);
 	}
 
-
 	// request(): queue lifecycle
 
 	public function testRequestWithoutAnyTargetNeedsNoToken(): void {
@@ -505,7 +500,6 @@ class ActivityServiceTest extends TestCase {
 
 		$this->assertSame(self::TOKEN, $this->service->request($note));
 	}
-
 
 	// manageRequest()
 

--- a/tests/Service/BoostServiceTest.php
+++ b/tests/Service/BoostServiceTest.php
@@ -173,7 +173,6 @@ class BoostServiceTest extends TestCase {
 		$this->fail('No instance path for ' . $uri . ' (type ' . $type . ', priority ' . $priority . ') in ' . json_encode($paths));
 	}
 
-
 	// create()
 
 	public function testCreateBuildsPublicAnnounceSavesFlagsAndFederatesIt(): void {
@@ -300,7 +299,6 @@ class BoostServiceTest extends TestCase {
 		$this->service->create($this->alice(), self::POST_ID);
 	}
 
-
 	// get()
 
 	public function testGetLooksUpAnnounceByBoostedObject(): void {
@@ -319,7 +317,6 @@ class BoostServiceTest extends TestCase {
 		$this->expectException(StreamNotFoundException::class);
 		$this->service->get(self::POST_ID);
 	}
-
 
 	// delete()
 

--- a/tests/Service/FollowServiceTest.php
+++ b/tests/Service/FollowServiceTest.php
@@ -120,7 +120,6 @@ class FollowServiceTest extends TestCase {
 		return $follow;
 	}
 
-
 	// followAccount()
 
 	public function testFollowAccountSavesFollowAndSendsItToTargetInbox(): void {
@@ -205,7 +204,6 @@ class FollowServiceTest extends TestCase {
 		$this->service->followAccount($this->alice(), 'nobody@remote.example');
 	}
 
-
 	// unfollowAccount()
 
 	public function testUnfollowAccountDeletesFollowAndSendsUndo(): void {
@@ -250,7 +248,6 @@ class FollowServiceTest extends TestCase {
 		$this->service->unfollowAccount($this->alice(), 'bob@remote.example');
 	}
 
-
 	// getLinksBetweenPersons()
 
 	/**
@@ -284,7 +281,6 @@ class FollowServiceTest extends TestCase {
 
 		$this->assertSame(['follower' => $follower, 'following' => $following], $links);
 	}
-
 
 	// followers / following
 
@@ -345,7 +341,6 @@ class FollowServiceTest extends TestCase {
 		$this->assertSame(0, $this->service->getFollowersCollection($this->alice())->getTotalItems());
 		$this->assertSame(0, $this->service->getFollowingCollection($this->alice())->getTotalItems());
 	}
-
 
 	// setViewer() / getRelationships()
 

--- a/tests/Service/LikeServiceTest.php
+++ b/tests/Service/LikeServiceTest.php
@@ -140,7 +140,6 @@ class LikeServiceTest extends TestCase {
 		return $like;
 	}
 
-
 	// create()
 
 	public function testCreateBuildsLikeSavesFlagsAndFederatesIt(): void {
@@ -237,7 +236,6 @@ class LikeServiceTest extends TestCase {
 		$this->expectException(ItemAlreadyExistsException::class);
 		$this->service->create($this->alice(), self::POST_ID);
 	}
-
 
 	// delete()
 

--- a/tests/Service/PostServiceTest.php
+++ b/tests/Service/PostServiceTest.php
@@ -124,7 +124,6 @@ class PostServiceTest extends TestCase {
 			});
 	}
 
-
 	// createPost()
 
 	public function testCreatePostBuildsNoteAndWrapsItInCreateActivity(): void {
@@ -315,7 +314,6 @@ class PostServiceTest extends TestCase {
 		$this->assertSame([$carol->getId(), self::BOB_ID], $note->getToArray());
 	}
 
-
 	// fixRecipientAndHashtags()
 
 	/**
@@ -357,7 +355,6 @@ class PostServiceTest extends TestCase {
 		$this->assertSame(['Existing', 'tag'], $post->getHashtags());
 	}
 
-
 	public function testCreatePostEscapesHtmlAndTurnsNewlinesIntoBreaks(): void {
 		$this->expectCreateActivity($note);
 
@@ -369,7 +366,6 @@ class PostServiceTest extends TestCase {
 			'user text is escaped first, then newlines become <br />'
 		);
 	}
-
 
 	// editPost()
 

--- a/tests/Service/RelationshipServiceTest.php
+++ b/tests/Service/RelationshipServiceTest.php
@@ -172,7 +172,6 @@ class RelationshipServiceTest extends TestCase {
 		$this->assertSame(InstancePath::PRIORITY_TOP, $paths[0]->getPriority());
 	}
 
-
 	// mute() / unmute()
 
 	/**
@@ -233,7 +232,6 @@ class RelationshipServiceTest extends TestCase {
 
 		$this->service->block($this->alice(), $this->alice());
 	}
-
 
 	// block()
 
@@ -362,7 +360,6 @@ class RelationshipServiceTest extends TestCase {
 		$this->service->block($this->alice(), $this->bob());
 	}
 
-
 	// unblock()
 
 	public function testUnblockOfARemoteAccountDeletesTheRowAndSendsAnUndoBlock(): void {
@@ -408,7 +405,6 @@ class RelationshipServiceTest extends TestCase {
 
 		$this->service->unblock($this->alice(), $this->person(self::CAROL_ID, true));
 	}
-
 
 	// getRelated()
 

--- a/tests/Service/StreamServiceTest.php
+++ b/tests/Service/StreamServiceTest.php
@@ -115,7 +115,6 @@ class StreamServiceTest extends TestCase {
 		$this->fail('No instance path for ' . $uri . ' (type ' . $type . ', priority ' . $priority . ') in ' . json_encode($paths));
 	}
 
-
 	// assignItem() / assignStream()
 
 	public function testAssignItemGeneratesIdFromActorAndMarksItemLocal(): void {
@@ -204,7 +203,6 @@ class StreamServiceTest extends TestCase {
 			$this->assertSame([], $note->getInstancePaths());
 		}
 	}
-
 
 	// detectType()
 
@@ -400,7 +398,6 @@ class StreamServiceTest extends TestCase {
 		$this->assertCount(2, $note->getInstancePaths());
 	}
 
-
 	// addHashtag() / addHashtags()
 
 	public function testAddHashtagAddsLowercasedTagLink(): void {
@@ -442,7 +439,6 @@ class StreamServiceTest extends TestCase {
 		$this->assertSame(['Nextcloud'], $note->getHashtags());
 		$this->assertSame([], $note->getTags());
 	}
-
 
 	// replyTo()
 
@@ -492,7 +488,6 @@ class StreamServiceTest extends TestCase {
 		}
 	}
 
-
 	// deleteLocalItem()
 
 	public function testDeleteLocalItemFederatesDeleteAndRemovesRow(): void {
@@ -540,7 +535,6 @@ class StreamServiceTest extends TestCase {
 
 		$this->assertSame('', $item->getActorId());
 	}
-
 
 	// lookups delegating to StreamRequest
 
@@ -646,7 +640,6 @@ class StreamServiceTest extends TestCase {
 		$this->assertSame([], $this->service->getStreamInternalTimeline(0, 20));
 	}
 
-
 	// getContextByNid()
 
 	public function testGetContextByNidCollectsAncestorsInThreadOrderAndDescendants(): void {
@@ -700,7 +693,6 @@ class StreamServiceTest extends TestCase {
 		$this->assertSame('https://social.example/@alice/8', $context['ancestors'][4]->getId());
 	}
 
-
 	// getAuthorFromPostId()
 
 	public function testGetAuthorFromPostIdResolvesAttributedActor(): void {
@@ -720,7 +712,6 @@ class StreamServiceTest extends TestCase {
 		$this->expectException(StreamNotFoundException::class);
 		$this->service->getAuthorFromPostId('https://remote.example/notes/missing');
 	}
-
 
 	// getOutboxCollection()
 
@@ -742,7 +733,6 @@ class StreamServiceTest extends TestCase {
 
 		$this->assertSame(0, $collection->getTotalItems());
 	}
-
 
 	// syncRemoteTimeline()
 

--- a/tests/SocialTest.php
+++ b/tests/SocialTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/tests/WellKnown/WebfingerHandlerTest.php
+++ b/tests/WellKnown/WebfingerHandlerTest.php
@@ -106,7 +106,6 @@ class WebfingerHandlerTest extends TestCase {
 		return $http->getData();
 	}
 
-
 	// handle() dispatch
 
 	public function testJailedInstanceLeavesThePreviousResponseUntouched(): void {
@@ -154,7 +153,6 @@ class WebfingerHandlerTest extends TestCase {
 
 		$this->assertSame($previous, $handler->handle('host-meta', $this->context, $previous));
 	}
-
 
 	// handleWebfinger()
 


### PR DESCRIPTION
Mechanical reformat after #2005 bumped nextcloud/coding-standard to 1.5.0 — without it, `php-cs` fails on every PR. No behaviour change; unit suite green (1727 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)