### PR TITLE
fix: backfill the visibility of remote statuses stored before estimation

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -20,7 +20,7 @@ What it does:
 - 🌐 Federation: signed delivery of ActivityPub activities, with a delivery queue processed by cron
 
 This is a partial implementation of ActivityPub and of the Mastodon client API. Blocking, muting and reporting (with a moderation panel in the administration settings) are supported, as are locked accounts with approvable follow requests. It does not offer polls, lists, or video and audio attachments.]]></description>
-	<version>0.11.4</version>
+	<version>0.11.5</version>
 	<licence>agpl</licence>
 	<author mail="benedikt.schaechner@web.de" homepage="https://benedikt.xn--schchner-2za.de">Benedikt Schächner</author>
 	<namespace>Social</namespace>
@@ -47,6 +47,7 @@ This is a partial implementation of ActivityPub and of the Mastodon client API. 
 			<step>OCA\Social\Migration\RenameDocumentLocalCopy</step>
 			<step>OCA\Social\Migration\EncryptPrivateKeys</step>
 			<step>OCA\Social\Migration\HashClientSecrets</step>
+			<step>OCA\Social\Migration\BackfillRemoteVisibility</step>
 		</post-migration>
 	</repair-steps>
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "nextcloud/social",
 	"description": "Social app",
 	"license": "AGPL-3.0-or-later",
-	"version": "0.11.4",
+	"version": "0.11.5",
 	"minimum-stability": "stable",
 	"authors": [
 		{

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -7,7 +7,7 @@ Nextcloud Social is a federated social networking app built on the W3C ActivityP
 **App ID:** `social`  
 **Namespace:** `OCA\Social`  
 **License:** AGPL-3.0-or-later  
-**App version:** 0.11.4  
+**App version:** 0.11.5  
 **Supported Nextcloud versions:** 28 – 35  
 **Supported PHP versions:** 8.1 – 8.5  
 
@@ -287,6 +287,9 @@ Views outside the router: `Dashboard.vue` (mounted by the dashboard entry), `OAu
 | Background Jobs | `Cron\Cache` | `appinfo/info.xml` | 12-minute interval: reaps deleted actors, refreshes local and remote actor caches, caches documents, recomputes hashtag trends, syncs remote timelines |
 | Background Jobs | `Cron\Queue` | `appinfo/info.xml` | 12-minute interval: drains the outbound request queue and the inbound stream queue |
 | Repair step | `Migration\RenameDocumentLocalCopy` | `appinfo/info.xml` | Post-migration repair of cached document paths |
+| Repair step | `Migration\EncryptPrivateKeys` | `appinfo/info.xml` | Seals legacy plaintext actor private keys with ICrypto, once |
+| Repair step | `Migration\HashClientSecrets` | `appinfo/info.xml` | Rewrites legacy plaintext client secrets/codes/tokens as sha256 digests, once |
+| Repair step | `Migration\BackfillRemoteVisibility` | `appinfo/info.xml` | Backfills the empty visibility of remote statuses stored before estimation landed (public/unlisted set-based, followers/direct per author), idempotent |
 
 Fourteen occ commands are registered in `appinfo/info.xml`. `lib/Command/` holds a fifteenth file, `ExtendedBase.php`, which is the abstract base the others extend and is not itself a command. See `docs/OCC-Commands.md`.
 

--- a/lib/Migration/BackfillRemoteVisibility.php
+++ b/lib/Migration/BackfillRemoteVisibility.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Migration;
+
+use OCA\Social\Db\CoreRequestBuilder;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Stream;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+/**
+ * Remote statuses stored before visibility estimation landed carry an empty
+ * visibility, so clients cannot tell a public post from a direct message.
+ * This backfills them once with the same addressing heuristic used for new
+ * arrivals: as:Public in `to` is public, in `cc` unlisted, the author's
+ * followers collection followers-only, anything else direct. Rows with a
+ * visibility are never touched, so re-runs are no-ops.
+ */
+class BackfillRemoteVisibility implements IRepairStep {
+	private const CHUNK = 1000;
+
+	public function __construct(
+		private IDBConnection $connection,
+	) {
+	}
+
+	public function getName(): string {
+		return 'Backfill the visibility of remote statuses stored before estimation landed';
+	}
+
+	public function run(IOutput $output): void {
+		$public = $this->bulkUpdatePublicAndUnlisted();
+		[$followers, $direct] = $this->classifyRemainder();
+
+		if ($public + $followers + $direct > 0) {
+			$output->info(sprintf(
+				'visibility backfilled: %d public/unlisted, %d followers, %d direct',
+				$public, $followers, $direct
+			));
+		}
+	}
+
+	/**
+	 * The two cases decidable without knowing the author: as:Public in the
+	 * `to` addressing is public, in `cc` unlisted. Set-based, one query each.
+	 */
+	private function bulkUpdatePublicAndUnlisted(): int {
+		$count = 0;
+		foreach ([
+			Stream::TYPE_PUBLIC => ['to', 'to_array'],
+			Stream::TYPE_UNLISTED => ['cc'],
+		] as $visibility => $fields) {
+			$qb = $this->connection->getQueryBuilder();
+			$qb->update(CoreRequestBuilder::TABLE_STREAM)
+				->set('visibility', $qb->createNamedParameter($visibility))
+				->where($qb->expr()->emptyString('visibility'))
+				->andWhere($qb->expr()->eq('local', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)));
+
+			$orX = $qb->expr()->orX();
+			foreach ($fields as $field) {
+				if ($field === 'to') {
+					$orX->add($qb->expr()->eq($field, $qb->createNamedParameter(ACore::CONTEXT_PUBLIC)));
+				} else {
+					$orX->add($qb->expr()->like(
+						$field,
+						$qb->createNamedParameter('%"' . $this->connection->escapeLikeParameter(ACore::CONTEXT_PUBLIC) . '"%')
+					));
+				}
+			}
+			$qb->andWhere($orX);
+
+			$count += $qb->executeStatement();
+		}
+
+		return $count;
+	}
+
+	/**
+	 * What is left is followers-only or direct, which needs the author's
+	 * followers collection: processed in chunks, updated in batches.
+	 *
+	 * @return array{int, int} [followers, direct]
+	 */
+	private function classifyRemainder(): array {
+		$followersTotal = 0;
+		$directTotal = 0;
+
+		while (true) {
+			$qb = $this->connection->getQueryBuilder();
+			$qb->select('id_prim', 'to', 'to_array', 'cc', 'attributed_to')
+				->from(CoreRequestBuilder::TABLE_STREAM)
+				->where($qb->expr()->emptyString('visibility'))
+				->andWhere($qb->expr()->eq('local', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)))
+				->setMaxResults(self::CHUNK);
+
+			$cursor = $qb->executeQuery();
+			$rows = $cursor->fetchAll();
+			$cursor->closeCursor();
+			if ($rows === []) {
+				break;
+			}
+
+			$followersOf = $this->followersCollectionsOf(
+				array_values(array_unique(array_column($rows, 'attributed_to')))
+			);
+
+			$followers = [];
+			$direct = [];
+			foreach ($rows as $row) {
+				$recipients = array_merge(
+					[(string)$row['to']],
+					json_decode((string)$row['to_array'], true) ?: [],
+					json_decode((string)$row['cc'], true) ?: []
+				);
+				$collection = $followersOf[(string)$row['attributed_to']] ?? '';
+				if ($collection !== '' && in_array($collection, $recipients, true)) {
+					$followers[] = (string)$row['id_prim'];
+				} else {
+					$direct[] = (string)$row['id_prim'];
+				}
+			}
+
+			$followersTotal += $this->updateByPrims($followers, Stream::TYPE_FOLLOWERS);
+			$directTotal += $this->updateByPrims($direct, Stream::TYPE_DIRECT);
+		}
+
+		return [$followersTotal, $directTotal];
+	}
+
+	/**
+	 * @param string[] $actorIds
+	 *
+	 * @return array<string, string> actor id => followers collection url
+	 */
+	private function followersCollectionsOf(array $actorIds): array {
+		if ($actorIds === []) {
+			return [];
+		}
+
+		$collections = [];
+		foreach (array_chunk($actorIds, 500) as $chunk) {
+			$qb = $this->connection->getQueryBuilder();
+			$qb->select('id', 'followers')
+				->from(CoreRequestBuilder::TABLE_CACHE_ACTORS)
+				->where($qb->expr()->in('id_prim', $qb->createNamedParameter(
+					array_map(fn (string $id): string => md5($id), $chunk),
+					IQueryBuilder::PARAM_STR_ARRAY
+				)));
+
+			$cursor = $qb->executeQuery();
+			while ($row = $cursor->fetch()) {
+				$collections[(string)$row['id']] = (string)$row['followers'];
+			}
+			$cursor->closeCursor();
+		}
+
+		return $collections;
+	}
+
+	/**
+	 * @param string[] $prims
+	 */
+	private function updateByPrims(array $prims, string $visibility): int {
+		$count = 0;
+		foreach (array_chunk($prims, 500) as $chunk) {
+			$qb = $this->connection->getQueryBuilder();
+			$qb->update(CoreRequestBuilder::TABLE_STREAM)
+				->set('visibility', $qb->createNamedParameter($visibility))
+				->where($qb->expr()->in('id_prim', $qb->createNamedParameter($chunk, IQueryBuilder::PARAM_STR_ARRAY)))
+				->andWhere($qb->expr()->emptyString('visibility'));
+
+			$count += $qb->executeStatement();
+		}
+
+		return $count;
+	}
+}

--- a/tests/Integration/Db/VisibilityBackfillTest.php
+++ b/tests/Integration/Db/VisibilityBackfillTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Integration\Db;
+
+use OCA\Social\Db\CacheActorsRequest;
+use OCA\Social\Db\StreamRequest;
+use OCA\Social\Migration\BackfillRemoteVisibility;
+use OCA\Social\Model\ActivityPub\ACore;
+use OCA\Social\Model\ActivityPub\Actor\Person;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Server;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The one-shot repair that classifies the visibility of remote statuses
+ * stored before estimation landed, against the real database: the set-based
+ * public/unlisted updates, the per-author followers/direct classification,
+ * and the guarantees that local rows and already-classified rows stay
+ * untouched (which also makes re-runs no-ops).
+ */
+class VisibilityBackfillTest extends TestCase {
+	private const BASE = 'https://cloud.example.org/visbf';
+	private const AUTHOR = 'https://remote.example/visbf/users/author';
+	private const AUTHOR_FOLLOWERS = self::AUTHOR . '/followers';
+	private const GHOST = 'https://gone.example/visbf/users/ghost';
+
+	private const SUFFIXES = ['public-to', 'public-toarray', 'unlisted', 'followers', 'direct', 'ghost', 'classified', 'local'];
+
+	private StreamRequest $streamRequest;
+	private CacheActorsRequest $cacheActorsRequest;
+	private BackfillRemoteVisibility $repair;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->streamRequest = Server::get(StreamRequest::class);
+		$this->cacheActorsRequest = Server::get(CacheActorsRequest::class);
+		$this->repair = Server::get(BackfillRemoteVisibility::class);
+		$this->cleanup();
+
+		$author = new Person();
+		$author->setId(self::AUTHOR)
+			->setPreferredUsername('author');
+		$author->setAccount('author@remote.example')
+			->setFollowers(self::AUTHOR_FOLLOWERS);
+		$this->cacheActorsRequest->save($author);
+	}
+
+	protected function tearDown(): void {
+		$this->cleanup();
+		parent::tearDown();
+	}
+
+	private function cleanup(): void {
+		foreach (self::SUFFIXES as $suffix) {
+			$this->streamRequest->deleteById(self::BASE . '/notes/' . $suffix, Note::TYPE);
+		}
+		$this->cacheActorsRequest->deleteCacheById(self::AUTHOR);
+	}
+
+	private function note(
+		string $suffix, string $to, array $cc = [], string $visibility = '',
+		bool $local = false, string $author = self::AUTHOR, array $toArray = [],
+	): Note {
+		$note = new Note();
+		$note->setId(self::BASE . '/notes/' . $suffix);
+		$note->setAttributedTo($author);
+		$note->setTo($to);
+		$note->setToArray($toArray);
+		$note->setCcArray($cc);
+		$note->setVisibility($visibility);
+		$note->setLocal($local);
+		$note->setContent($suffix);
+		$note->setPublishedTime(time());
+		$note->setPublished(gmdate('Y-m-d\TH:i:s\Z'));
+
+		$this->streamRequest->save($note);
+
+		return $note;
+	}
+
+	private function visibilityOf(string $suffix): string {
+		// read the column raw: getStreamById() inner-joins the author's cache
+		// row, which the ghost-author case deliberately does not have
+		$qb = Server::get(IDBConnection::class)->getQueryBuilder();
+		$qb->select('visibility')->from('social_stream')
+			->where($qb->expr()->eq('id_prim', $qb->createNamedParameter(md5(self::BASE . '/notes/' . $suffix))));
+		$cursor = $qb->executeQuery();
+		$row = $cursor->fetch();
+		$cursor->closeCursor();
+		$this->assertNotFalse($row, 'stream row ' . $suffix . ' exists');
+
+		return (string)$row['visibility'];
+	}
+
+	public function testBackfillClassifiesEveryAddressingShapeOnce(): void {
+		$this->note('public-to', ACore::CONTEXT_PUBLIC);
+		$this->note('public-toarray', self::BASE . '/users/someone', [], '', false, self::AUTHOR, [ACore::CONTEXT_PUBLIC]);
+		$this->note('unlisted', self::AUTHOR_FOLLOWERS, [ACore::CONTEXT_PUBLIC]);
+		$this->note('followers', self::AUTHOR_FOLLOWERS);
+		$this->note('direct', self::BASE . '/users/someone');
+		$this->note('ghost', self::GHOST . '/followers', [], '', false, self::GHOST);
+		$this->note('classified', ACore::CONTEXT_PUBLIC, [], 'unlisted');
+		$this->note('local', self::BASE . '/users/someone', [], '', true);
+
+		$output = $this->createMock(IOutput::class);
+		$this->repair->run($output);
+
+		$this->assertSame('public', $this->visibilityOf('public-to'));
+		$this->assertSame('public', $this->visibilityOf('public-toarray'), 'as:Public among several to recipients');
+		$this->assertSame('unlisted', $this->visibilityOf('unlisted'));
+		$this->assertSame('followers', $this->visibilityOf('followers'));
+		$this->assertSame('direct', $this->visibilityOf('direct'));
+		$this->assertSame('direct', $this->visibilityOf('ghost'), 'an uncached author degrades to direct');
+		$this->assertSame('unlisted', $this->visibilityOf('classified'), 'already-classified rows stay untouched');
+		$this->assertSame('', $this->visibilityOf('local'), 'local rows are never touched');
+
+		// idempotent: a second run changes nothing and reports nothing
+		$second = $this->createMock(IOutput::class);
+		$second->expects($this->never())->method('info');
+		$this->repair->run($second);
+		$this->assertSame('followers', $this->visibilityOf('followers'));
+	}
+}


### PR DESCRIPTION
Point 3 of the assessment follow-ups (1/6 in this series): #2050 gave *newly arriving* remote statuses a visibility, but rows stored before it keep an empty one, so clients can't tell a public post from a DM.

New idempotent repair step `BackfillRemoteVisibility` (version 0.11.5):

- **Set-based** for the author-independent cases: `as:Public` in `to`/`to_array` → `public`, in `cc` → `unlisted` — two UPDATE statements regardless of table size.
- **Chunked (1000/batch)** for the remainder: resolves each author's followers collection from `social_cache_actor` in bulk, classifies `followers` vs `direct`, updates per group. Unknown authors degrade to `direct` — erring private.
- Local rows and rows that already carry a visibility are never touched, which also makes re-runs no-ops.

Covered by a new integration test against the real database (every addressing shape, ghost author, already-classified and local rows untouched, idempotence) — green on devel (55 tests), where the upgrade also classified the real pre-existing rows correctly. Docs updated (repair-steps table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)