### PR TITLE
feat: retention for remote content

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ It is a partial implementation of ActivityPub and of the Mastodon client API —
 - 🖼️ **Profiles** — avatar, uploadable banner/header image and a profile description (`note`). Editable structured profile fields are *not* supported (see below).
 - 🌐 **Federation** — signed HTTP delivery of `Create`, `Update`, `Delete`, `Like`, `Announce`, `Follow`, `Accept` and `Undo` activities, an outbound request queue and a stream queue for resolving incoming objects, both drained by background jobs and by `occ social:queue:process`.
 - 🔎 **Discovery & search** — WebFinger lookups, remote actor resolution and caching, and search over known accounts and hashtags.
+- 🧹 **Retention** — remote statuses older than `retention_days` (default: disabled) that no local user interacted with are pruned together with their cached attachments, from cron or `occ social:stream:prune`; local content is never touched. Configurable in the Social section of the administration settings.
 - 🛡️ **Instance access list** — an allow-list or deny-list of remote hosts, enforced on incoming activities and outgoing requests. Managed with `occ social:fediverse`; see [docs/OCC-Commands.md](docs/OCC-Commands.md) for the details and its limits.
 - 🔑 **Mastodon-compatible API** — a subset of the Mastodon client API plus OAuth 2 authorization, so some third-party clients can talk to the app. See [docs/API.md](docs/API.md) for exactly which routes exist.
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -63,6 +63,7 @@ This is a partial implementation of ActivityPub and of the Mastodon client API. 
 		<command>OCA\Social\Command\NoteBoost</command>
 		<command>OCA\Social\Command\Reset</command>
 		<command>OCA\Social\Command\StreamDetails</command>
+		<command>OCA\Social\Command\StreamPrune</command>
 		<command>OCA\Social\Command\Timeline</command>
 		<command>OCA\Social\Command\QueueStatus</command>
 		<command>OCA\Social\Command\QueueProcess</command>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -120,6 +120,7 @@ return [
 		['name' => 'Moderation#reportResolve', 'url' => '/moderation/reports/{id}/resolve', 'verb' => 'POST'],
 		['name' => 'Moderation#fediverseAdd', 'url' => '/moderation/fediverse/add', 'verb' => 'POST'],
 		['name' => 'Moderation#fediverseRemove', 'url' => '/moderation/fediverse/remove', 'verb' => 'POST'],
-		['name' => 'Moderation#fediverseAccess', 'url' => '/moderation/fediverse/access', 'verb' => 'POST']
+		['name' => 'Moderation#fediverseAccess', 'url' => '/moderation/fediverse/access', 'verb' => 'POST'],
+		['name' => 'Moderation#retention', 'url' => '/moderation/retention', 'verb' => 'POST']
 	]
 ];

--- a/docs/API.md
+++ b/docs/API.md
@@ -212,6 +212,7 @@ Backing routes of the Social section in the administration settings. All of them
 | POST | `/moderation/fediverse/add` | admin, csrf | `address` (required) | Adds an instance to the Fediverse access list (the list `occ social:fediverse` manages). Invalid addresses are a 422. Returns `{"list": [...]}`. |
 | POST | `/moderation/fediverse/remove` | admin, csrf | `address` (required) | Removes an instance from the access list. Returns `{"list": [...]}`. |
 | POST | `/moderation/fediverse/access` | admin, csrf | `type` (required) | Switches the access mode: `all_but` (blocklist) or `none_but` (allowlist). Anything else is a 422. Returns `{"accessType": "..."}`. |
+| POST | `/moderation/retention` | admin, csrf | `days` (required, 0–3650) | Sets the `retention_days` app setting: remote statuses older than this that no local user cares about are pruned (0 disables). Returns `{"retentionDays": n}`. |
 
 ---
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -114,6 +114,7 @@ The business logic lives in `lib/Service/`.
 - **PostService** — Creates posts (text, attachments, reply-to, mentions, hashtags) and edits existing local posts, delegating federation to `ActivityService`
 - **FollowService** — Follow/unfollow flows, follower/following collections, and relationship lookups
 - **LikeService** — Creates and undoes Like activities
+- **StreamPruneService** — Retention: deletes remote statuses older than `retention_days` (default 0 = disabled) that no local user interacted with, whose author nobody follows, that no local status replies to or boosts, and that are not DMs — together with their dest/action/tag rows and cached attachments. Runs bounded in the Cache cron and unbounded via `occ social:stream:prune`
 - **BoostService** — Creates and undoes Announce (boost/reblog) activities
 - **ActionService** — Dispatcher for the Mastodon-style status actions. favourite/unfavourite create and delete a Like, reblog/unreblog an Announce, and bookmark/unbookmark toggle the viewer's local `bookmarked` flag (never federated, served by `/api/v1/bookmarks`). `translate` returns the status unchanged, and the unimplemented `mute`, `unmute`, `pin` and `unpin` are refused with `InvalidActionException` instead of silently doing nothing
 - **HashtagService** — Recomputes hashtag trends over 1h/12h/1d/3d/10d windows and searches hashtags
@@ -284,14 +285,14 @@ Views outside the router: `Dashboard.vue` (mounted by the dashboard entry), `OAu
 | User Events | `UserAccountListener` | `Application::register()` (on `UserUpdatedEvent`) | Re-caches the local actor when the NC account changes |
 | WebFinger / NodeInfo / host-meta | `WebfingerHandler` | `Application::register()` | ActivityPub discovery at the server root |
 | Contacts Menu | `ContactsMenuProvider` | `appinfo/info.xml` | "Follow %s on Social" entry linking to the actor page |
-| Background Jobs | `Cron\Cache` | `appinfo/info.xml` | 12-minute interval: reaps deleted actors, refreshes local and remote actor caches, caches documents, recomputes hashtag trends, syncs remote timelines |
+| Background Jobs | `Cron\Cache` | `appinfo/info.xml` | 12-minute interval: reaps deleted actors, refreshes local and remote actor caches, caches documents, recomputes hashtag trends, prunes remote statuses past retention (bounded to 5000 per run), syncs remote timelines |
 | Background Jobs | `Cron\Queue` | `appinfo/info.xml` | 12-minute interval: drains the outbound request queue and the inbound stream queue |
 | Repair step | `Migration\RenameDocumentLocalCopy` | `appinfo/info.xml` | Post-migration repair of cached document paths |
 | Repair step | `Migration\EncryptPrivateKeys` | `appinfo/info.xml` | Seals legacy plaintext actor private keys with ICrypto, once |
 | Repair step | `Migration\HashClientSecrets` | `appinfo/info.xml` | Rewrites legacy plaintext client secrets/codes/tokens as sha256 digests, once |
 | Repair step | `Migration\BackfillRemoteVisibility` | `appinfo/info.xml` | Backfills the empty visibility of remote statuses stored before estimation landed (public/unlisted set-based, followers/direct per author), idempotent |
 
-Fourteen occ commands are registered in `appinfo/info.xml`. `lib/Command/` holds a fifteenth file, `ExtendedBase.php`, which is the abstract base the others extend and is not itself a command. See `docs/OCC-Commands.md`.
+Fifteen occ commands are registered in `appinfo/info.xml`. `lib/Command/` also holds `ExtendedBase.php`, which is the abstract base the others extend and is not itself a command. See `docs/OCC-Commands.md`.
 
 ---
 

--- a/docs/OCC-Commands.md
+++ b/docs/OCC-Commands.md
@@ -217,6 +217,28 @@ the class is `OCA\Social\Command\StreamDetails`.
 
 ---
 
+### `social:stream:prune`
+
+Deletes remote statuses older than the retention period, together with their
+recipient/action/tag rows and cached attachments.
+
+```bash
+php occ social:stream:prune [-d|--days DAYS] [--dry-run]
+```
+
+- Without `--days`, the `retention_days` app setting decides the period; `0`
+  (the default) disables retention and the command exits without touching
+  anything.
+- `--dry-run` only counts what would be deleted.
+- A status is kept when a local user liked, boosted, replied to or bookmarked
+  it, when a local user follows its author, when a local status replies to it
+  or boosts it, or when it is a direct message. Local content is never touched.
+- The same pruning runs from the `Cron\Cache` background job (bounded to 5000
+  statuses per run) whenever `retention_days` is greater than 0; the admin can
+  change the period in the Social section of the administration settings.
+
+---
+
 ## Queue Management
 
 ### `social:queue:process`

--- a/js/social-adminSettings.js
+++ b/js/social-adminSettings.js
@@ -86,9 +86,23 @@
 			.catch(() => OC.Notification.showTemporary(t('social', 'Could not change the access mode')))
 	}
 
+	function onSaveRetention() {
+		const days = parseInt(document.getElementById('social-retention-days').value, 10)
+		if (isNaN(days) || days < 0) {
+			return
+		}
+		post('/retention', { days })
+			.catch(() => OC.Notification.showTemporary(t('social', 'Could not change the retention period')))
+	}
+
 	document.addEventListener('DOMContentLoaded', () => {
 		document.querySelectorAll('.social-report-toggle')
 			.forEach((button) => button.addEventListener('click', onToggleReport))
+
+		const retentionSave = document.getElementById('social-retention-save')
+		if (retentionSave) {
+			retentionSave.addEventListener('click', onSaveRetention)
+		}
 
 		const accessType = document.getElementById('social-access-type')
 		if (accessType) {

--- a/lib/Command/StreamPrune.php
+++ b/lib/Command/StreamPrune.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Command;
+
+use OC\Core\Command\Base;
+use OCA\Social\Service\StreamPruneService;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class StreamPrune extends Base {
+	public function __construct(
+		private StreamPruneService $streamPruneService,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure() {
+		parent::configure();
+		$this->setName('social:stream:prune')
+			->setDescription(
+				'Delete remote statuses older than the retention period that no local user '
+				. 'interacted with (see the retention_days app setting; local content is never touched)'
+			)
+			->addOption(
+				'days', 'd', InputOption::VALUE_REQUIRED,
+				'override the configured retention period (days)'
+			)
+			->addOption('dry-run', '', InputOption::VALUE_NONE, 'only count what would be deleted');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$days = $input->getOption('days');
+		$days = ($days === null) ? null : (int)$days;
+		$dryRun = (bool)$input->getOption('dry-run');
+
+		if (($days ?? $this->streamPruneService->getRetentionDays()) <= 0) {
+			$output->writeln(
+				'retention is disabled: set the retention_days app setting or pass --days'
+			);
+
+			return 0;
+		}
+
+		$result = $this->streamPruneService->prune($days, $dryRun);
+
+		if ($dryRun) {
+			$output->writeln(sprintf('%d statuses would be pruned', $result['streams']));
+		} else {
+			$output->writeln(sprintf(
+				'%d statuses pruned, %d cached documents removed',
+				$result['streams'], $result['documents']
+			));
+		}
+
+		return 0;
+	}
+}

--- a/lib/Controller/ModerationController.php
+++ b/lib/Controller/ModerationController.php
@@ -12,6 +12,7 @@ namespace OCA\Social\Controller;
 use Exception;
 use OCA\Social\AppInfo\Application;
 use OCA\Social\Exceptions\ReportNotFoundException;
+use OCA\Social\Service\ConfigService;
 use OCA\Social\Service\FediverseService;
 use OCA\Social\Service\ReportService;
 use OCP\AppFramework\Controller;
@@ -29,6 +30,7 @@ class ModerationController extends Controller {
 		IRequest $request,
 		private ReportService $reportService,
 		private FediverseService $fediverseService,
+		private ConfigService $configService,
 	) {
 		parent::__construct(Application::APP_ID, $request);
 	}
@@ -56,6 +58,16 @@ class ModerationController extends Controller {
 		$this->fediverseService->removeAddress(strtolower(trim($address)));
 
 		return new DataResponse(['list' => $this->fediverseService->getListedAddresses()]);
+	}
+
+	public function retention(int $days): DataResponse {
+		if ($days < 0 || $days > 3650) {
+			return new DataResponse(['error' => 'invalid retention period'], Http::STATUS_UNPROCESSABLE_ENTITY);
+		}
+
+		$this->configService->setAppValue(ConfigService::SOCIAL_RETENTION_DAYS, (string)$days);
+
+		return new DataResponse(['retentionDays' => $days]);
 	}
 
 	public function fediverseAccess(string $type): DataResponse {

--- a/lib/Cron/Cache.php
+++ b/lib/Cron/Cache.php
@@ -15,6 +15,7 @@ use OCA\Social\Service\AccountService;
 use OCA\Social\Service\CacheActorService;
 use OCA\Social\Service\DocumentService;
 use OCA\Social\Service\HashtagService;
+use OCA\Social\Service\StreamPruneService;
 use OCA\Social\Service\StreamService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
@@ -26,6 +27,7 @@ class Cache extends TimedJob {
 	private DocumentService $documentService;
 	private HashtagService $hashtagService;
 	private StreamService $streamService;
+	private StreamPruneService $streamPruneService;
 	private CacheActorsRequest $cacheActorsRequest;
 	private LoggerInterface $logger;
 
@@ -36,6 +38,7 @@ class Cache extends TimedJob {
 		DocumentService $documentService,
 		HashtagService $hashtagService,
 		StreamService $streamService,
+		StreamPruneService $streamPruneService,
 		CacheActorsRequest $cacheActorsRequest,
 		LoggerInterface $logger,
 	) {
@@ -46,6 +49,7 @@ class Cache extends TimedJob {
 		$this->documentService = $documentService;
 		$this->hashtagService = $hashtagService;
 		$this->streamService = $streamService;
+		$this->streamPruneService = $streamPruneService;
 		$this->cacheActorsRequest = $cacheActorsRequest;
 		$this->logger = $logger;
 	}
@@ -83,6 +87,13 @@ class Cache extends TimedJob {
 
 		try {
 			$this->hashtagService->manageHashtags();
+		} catch (\Throwable $e) {
+			$this->logger->debug('[Cron\\Cache] step failed', ['exception' => $e]);
+		}
+
+		try {
+			// bounded per run so retention never dominates a cron slot
+			$this->streamPruneService->prune(null, false, 5000);
 		} catch (\Throwable $e) {
 			$this->logger->debug('[Cron\\Cache] step failed', ['exception' => $e]);
 		}

--- a/lib/Service/CacheDocumentService.php
+++ b/lib/Service/CacheDocumentService.php
@@ -222,6 +222,24 @@ class CacheDocumentService {
 	 * @throws CacheContentException
 	 * @throws CacheDocumentDoesNotExistException
 	 */
+	/**
+	 * Removes a cached copy from appdata; a missing or empty filename (or the
+	 * 'avatar' placeholder) is a no-op — retention must never abort on a file
+	 * that is already gone.
+	 */
+	public function removeFromCache(string $filename): void {
+		if ($filename === '' || $filename === 'avatar') {
+			return;
+		}
+
+		try {
+			$this->appData->getFolder($this->generatePath($filename))
+				->getFile($filename)
+				->delete();
+		} catch (Exception $e) {
+		}
+	}
+
 	public function getContentFromCache(string $filename): ISimpleFile {
 		if ($filename === '') {
 			throw new CacheDocumentDoesNotExistException();

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -43,6 +43,9 @@ class ConfigService {
 	/** incoming inbox requests allowed per origin host per minute; 0 disables */
 	public const SOCIAL_INBOX_THROTTLE = 'inbox_throttle';
 
+	/** days to keep remote statuses nobody local cares about; 0 disables */
+	public const SOCIAL_RETENTION_DAYS = 'retention_days';
+
 	public const BACKGROUND_CRON = 1;
 	public const BACKGROUND_ASYNC = 2;
 	public const BACKGROUND_SERVICE = 3;
@@ -57,7 +60,8 @@ class ConfigService {
 		self::SOCIAL_ACCESS_TYPE => 'all_but',
 		self::SOCIAL_ACCESS_LIST => '[]',
 		self::SOCIAL_SELF_SIGNED => '0',
-		self::SOCIAL_INBOX_THROTTLE => '300'
+		self::SOCIAL_INBOX_THROTTLE => '300',
+		self::SOCIAL_RETENTION_DAYS => '0'
 	];
 
 	public array $accessTypeList = [

--- a/lib/Service/StreamPruneService.php
+++ b/lib/Service/StreamPruneService.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Service;
+
+use DateTime;
+use OCA\Social\Db\CoreRequestBuilder;
+use OCA\Social\Model\ActivityPub\Object\Announce;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Model\ActivityPub\Stream;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Retention for federated content: remote statuses older than the configured
+ * number of days are deleted together with their dest/action/tag rows and
+ * cached attachments — unless someone local still cares about them.
+ *
+ * A remote status is protected when:
+ *  - a local user interacted with it (like/boost/reply/bookmark flags, or a
+ *    Like/Announce action row),
+ *  - its author is followed by a local user,
+ *  - a local status replies to it (threads under local posts stay readable),
+ *  - a local stream row references it as its object (a local boost),
+ *  - it is a direct message.
+ *
+ * Local content is never touched. Disabled by default (`retention_days` = 0).
+ */
+class StreamPruneService {
+	public const CHUNK = 500;
+
+	public function __construct(
+		private IDBConnection $connection,
+		private ConfigService $configService,
+		private CacheDocumentService $cacheDocumentService,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	public function getRetentionDays(): int {
+		return (int)$this->configService->getAppValue(ConfigService::SOCIAL_RETENTION_DAYS);
+	}
+
+	/**
+	 * @return array{streams: int, documents: int} what was (or would be) removed
+	 */
+	public function prune(?int $days = null, bool $dryRun = false, int $max = 0): array {
+		$days ??= $this->getRetentionDays();
+		if ($days <= 0) {
+			return ['streams' => 0, 'documents' => 0];
+		}
+
+		$cutoff = new DateTime($days . ' days ago');
+		if ($dryRun) {
+			return ['streams' => $this->countPrunable($cutoff), 'documents' => 0];
+		}
+
+		$streams = 0;
+		$documents = 0;
+		while (true) {
+			$limit = self::CHUNK;
+			if ($max > 0) {
+				$limit = min($limit, $max - $streams);
+				if ($limit <= 0) {
+					break;
+				}
+			}
+
+			$prims = $this->selectPrunable($cutoff, $limit);
+			if ($prims === []) {
+				break;
+			}
+
+			$streams += count($prims);
+			$documents += $this->deleteDocumentsOf($prims);
+			$this->deleteRelated($prims);
+			$this->deleteStreams($prims);
+		}
+
+		if ($streams > 0) {
+			$this->logger->info('stream retention pruned rows', [
+				'days' => $days, 'streams' => $streams, 'documents' => $documents,
+			]);
+		}
+
+		return ['streams' => $streams, 'documents' => $documents];
+	}
+
+	private function countPrunable(DateTime $cutoff): int {
+		$qb = $this->prunableQuery($cutoff);
+		$qb->selectAlias($qb->createFunction('COUNT(*)'), 'count');
+
+		$cursor = $qb->executeQuery();
+		$row = $cursor->fetch();
+		$cursor->closeCursor();
+
+		return (int)($row['count'] ?? 0);
+	}
+
+	/**
+	 * @return string[] id_prim of prunable remote streams, oldest first
+	 */
+	private function selectPrunable(DateTime $cutoff, int $limit): array {
+		$qb = $this->prunableQuery($cutoff);
+		$qb->select('s.id_prim')
+			->orderBy('s.creation', 'asc')
+			->setMaxResults($limit);
+
+		$cursor = $qb->executeQuery();
+		$prims = array_map(static fn (array $row): string => (string)$row['id_prim'], $cursor->fetchAll());
+		$cursor->closeCursor();
+
+		return $prims;
+	}
+
+	/**
+	 * The conditions that make a remote stream prunable; see the class doc for
+	 * the protection rules.
+	 */
+	private function prunableQuery(DateTime $cutoff): IQueryBuilder {
+		$qb = $this->connection->getQueryBuilder();
+		$expr = $qb->expr();
+
+		$qb->from(CoreRequestBuilder::TABLE_STREAM, 's')
+			->where($expr->eq('s.local', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)))
+			->andWhere($expr->in('s.type', $qb->createNamedParameter(
+				[Note::TYPE, Announce::TYPE], IQueryBuilder::PARAM_STR_ARRAY
+			)))
+			->andWhere($expr->lt('s.creation', $qb->createNamedParameter($cutoff, IQueryBuilder::PARAM_DATE)))
+			->andWhere($expr->neq('s.visibility', $qb->createNamedParameter(Stream::TYPE_DIRECT)));
+
+		// a local interaction flag on the status
+		$act = $this->connection->getQueryBuilder();
+		$act->select($act->createFunction('1'))
+			->from(CoreRequestBuilder::TABLE_STREAM_ACTIONS, 'sa')
+			->where('sa.stream_id_prim = s.id_prim')
+			->andWhere('(sa.liked = 1 OR sa.boosted = 1 OR sa.replied = 1 OR sa.bookmarked = 1)');
+		$qb->andWhere('NOT EXISTS (' . $act->getSQL() . ')');
+
+		// a Like/Announce action row pointing at the status
+		$action = $this->connection->getQueryBuilder();
+		$action->select($action->createFunction('1'))
+			->from(CoreRequestBuilder::TABLE_ACTIONS, 'a')
+			->where('a.object_id_prim = s.id_prim');
+		$qb->andWhere('NOT EXISTS (' . $action->getSQL() . ')');
+
+		// its author is followed by a local user
+		$follow = $this->connection->getQueryBuilder();
+		$follow->select($follow->createFunction('1'))
+			->from(CoreRequestBuilder::TABLE_FOLLOWS, 'f')
+			->where('f.object_id_prim = s.attributed_to_prim')
+			->andWhere('f.accepted = 1');
+		$qb->andWhere('NOT EXISTS (' . $follow->getSQL() . ')');
+
+		// a local status replies to it, or a local stream (a boost) references it
+		$local = $this->connection->getQueryBuilder();
+		$local->select($local->createFunction('1'))
+			->from(CoreRequestBuilder::TABLE_STREAM, 's2')
+			->where('s2.local = 1')
+			->andWhere('(s2.in_reply_to_prim = s.id_prim OR s2.object_id_prim = s.id_prim)');
+		$qb->andWhere('NOT EXISTS (' . $local->getSQL() . ')');
+
+		return $qb;
+	}
+
+	/**
+	 * @param string[] $prims
+	 */
+	private function deleteDocumentsOf(array $prims): int {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select('id_prim', 'local_copy', 'resized_copy')
+			->from(CoreRequestBuilder::TABLE_CACHE_DOCUMENTS)
+			->where($qb->expr()->in('parent_id_prim', $qb->createNamedParameter($prims, IQueryBuilder::PARAM_STR_ARRAY)));
+
+		$cursor = $qb->executeQuery();
+		$rows = $cursor->fetchAll();
+		$cursor->closeCursor();
+		if ($rows === []) {
+			return 0;
+		}
+
+		foreach ($rows as $row) {
+			$this->cacheDocumentService->removeFromCache((string)$row['local_copy']);
+			$this->cacheDocumentService->removeFromCache((string)$row['resized_copy']);
+		}
+
+		$delete = $this->connection->getQueryBuilder();
+		$delete->delete(CoreRequestBuilder::TABLE_CACHE_DOCUMENTS)
+			->where($delete->expr()->in('id_prim', $delete->createNamedParameter(
+				array_map(static fn (array $row): string => (string)$row['id_prim'], $rows),
+				IQueryBuilder::PARAM_STR_ARRAY
+			)));
+
+		return $delete->executeStatement();
+	}
+
+	/**
+	 * dest, action-flag and tag rows key their stream by its prim
+	 *
+	 * @param string[] $prims
+	 */
+	private function deleteRelated(array $prims): void {
+		foreach ([
+			[CoreRequestBuilder::TABLE_STREAM_DEST, 'stream_id'],
+			[CoreRequestBuilder::TABLE_STREAM_ACTIONS, 'stream_id_prim'],
+			[CoreRequestBuilder::TABLE_STREAM_TAGS, 'stream_id'],
+		] as [$table, $field]) {
+			$qb = $this->connection->getQueryBuilder();
+			$qb->delete($table)
+				->where($qb->expr()->in($field, $qb->createNamedParameter($prims, IQueryBuilder::PARAM_STR_ARRAY)));
+			$qb->executeStatement();
+		}
+	}
+
+	/**
+	 * @param string[] $prims
+	 */
+	private function deleteStreams(array $prims): void {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->delete(CoreRequestBuilder::TABLE_STREAM)
+			->where($qb->expr()->in('id_prim', $qb->createNamedParameter($prims, IQueryBuilder::PARAM_STR_ARRAY)));
+		$qb->executeStatement();
+	}
+}

--- a/lib/Service/StreamPruneService.php
+++ b/lib/Service/StreamPruneService.php
@@ -141,7 +141,8 @@ class StreamPruneService {
 		$act->select($act->createFunction('1'))
 			->from(CoreRequestBuilder::TABLE_STREAM_ACTIONS, 'sa')
 			->where('sa.stream_id_prim = s.id_prim')
-			->andWhere('(sa.liked = 1 OR sa.boosted = 1 OR sa.replied = 1 OR sa.bookmarked = 1)');
+			// quoted literals: these are boolean columns on PostgreSQL, ints elsewhere
+			->andWhere("(sa.liked = '1' OR sa.boosted = '1' OR sa.replied = '1' OR sa.bookmarked = '1')");
 		$qb->andWhere('NOT EXISTS (' . $act->getSQL() . ')');
 
 		// a Like/Announce action row pointing at the status
@@ -156,14 +157,14 @@ class StreamPruneService {
 		$follow->select($follow->createFunction('1'))
 			->from(CoreRequestBuilder::TABLE_FOLLOWS, 'f')
 			->where('f.object_id_prim = s.attributed_to_prim')
-			->andWhere('f.accepted = 1');
+			->andWhere("f.accepted = '1'");
 		$qb->andWhere('NOT EXISTS (' . $follow->getSQL() . ')');
 
 		// a local status replies to it, or a local stream (a boost) references it
 		$local = $this->connection->getQueryBuilder();
 		$local->select($local->createFunction('1'))
 			->from(CoreRequestBuilder::TABLE_STREAM, 's2')
-			->where('s2.local = 1')
+			->where("s2.local = '1'")
 			->andWhere('(s2.in_reply_to_prim = s.id_prim OR s2.object_id_prim = s.id_prim)');
 		$qb->andWhere('NOT EXISTS (' . $local->getSQL() . ')');
 

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\Social\Settings;
 
+use OCA\Social\Service\ConfigService;
 use OCA\Social\Service\FediverseService;
 use OCA\Social\Service\ReportService;
 use OCP\AppFramework\Http\TemplateResponse;
@@ -23,6 +24,7 @@ class AdminSettings implements ISettings {
 	public function __construct(
 		private ReportService $reportService,
 		private FediverseService $fediverseService,
+		private ConfigService $configService,
 	) {
 	}
 
@@ -33,6 +35,7 @@ class AdminSettings implements ISettings {
 			'reports' => $this->reportService->getReports(true),
 			'accessType' => $this->fediverseService->getAccessType(),
 			'accessList' => $this->fediverseService->getListedAddresses(),
+			'retentionDays' => (int)$this->configService->getAppValue(ConfigService::SOCIAL_RETENTION_DAYS),
 		]);
 	}
 

--- a/templates/settings/admin.php
+++ b/templates/settings/admin.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 $reports = $_['reports'];
 $accessType = $_['accessType'];
 $accessList = $_['accessList'];
+$retentionDays = $_['retentionDays'];
 ?>
 
 <div id="social-moderation" class="section">
@@ -83,6 +84,19 @@ $accessList = $_['accessList'];
 			</tbody>
 		</table>
 	<?php endif; ?>
+</div>
+
+<div id="social-retention" class="section">
+	<h2><?php p($l->t('Retention')); ?></h2>
+	<p class="settings-hint">
+		<?php p($l->t('Remote statuses older than this many days are deleted, unless a local user interacted with them, follows their author, or replied below them. Local content is never touched. 0 disables retention.')); ?>
+	</p>
+	<p>
+		<label for="social-retention-days"><?php p($l->t('Keep remote statuses for (days)')); ?></label>
+		<input type="number" id="social-retention-days" min="0" max="3650"
+			value="<?php p((string)$retentionDays); ?>">
+		<button type="button" id="social-retention-save"><?php p($l->t('Save')); ?></button>
+	</p>
 </div>
 
 <div id="social-access" class="section">

--- a/tests/Controller/ModerationControllerTest.php
+++ b/tests/Controller/ModerationControllerTest.php
@@ -12,6 +12,7 @@ namespace OCA\Social\Tests\Controller;
 use OCA\Social\Controller\ModerationController;
 use OCA\Social\Exceptions\ReportNotFoundException;
 use OCA\Social\Model\Report;
+use OCA\Social\Service\ConfigService;
 use OCA\Social\Service\FediverseService;
 use OCA\Social\Service\ReportService;
 use OCP\AppFramework\Http;
@@ -22,15 +23,18 @@ use PHPUnit\Framework\TestCase;
 class ModerationControllerTest extends TestCase {
 	private ReportService|MockObject $reportService;
 	private FediverseService|MockObject $fediverseService;
+	private ConfigService|MockObject $configService;
 	private ModerationController $controller;
 
 	protected function setUp(): void {
 		$this->reportService = $this->createMock(ReportService::class);
 		$this->fediverseService = $this->createMock(FediverseService::class);
+		$this->configService = $this->createMock(ConfigService::class);
 		$this->controller = new ModerationController(
 			$this->createMock(IRequest::class),
 			$this->reportService,
-			$this->fediverseService
+			$this->fediverseService,
+			$this->configService
 		);
 	}
 
@@ -113,6 +117,23 @@ class ModerationControllerTest extends TestCase {
 		$response = $this->controller->fediverseRemove('evil.example');
 
 		$this->assertSame(['list' => []], $response->getData());
+	}
+
+	public function testRetentionStoresTheConfiguredPeriod(): void {
+		$this->configService->expects($this->once())
+			->method('setAppValue')->with(ConfigService::SOCIAL_RETENTION_DAYS, '90');
+
+		$response = $this->controller->retention(90);
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['retentionDays' => 90], $response->getData());
+	}
+
+	public function testRetentionRefusesAnInvalidPeriod(): void {
+		$this->configService->expects($this->never())->method('setAppValue');
+
+		$this->assertSame(Http::STATUS_UNPROCESSABLE_ENTITY, $this->controller->retention(-1)->getStatus());
+		$this->assertSame(Http::STATUS_UNPROCESSABLE_ENTITY, $this->controller->retention(99999)->getStatus());
 	}
 
 	public function testFediverseAccessRejectsAnUnknownType(): void {

--- a/tests/Cron/CacheTest.php
+++ b/tests/Cron/CacheTest.php
@@ -16,6 +16,7 @@ use OCA\Social\Service\AccountService;
 use OCA\Social\Service\CacheActorService;
 use OCA\Social\Service\DocumentService;
 use OCA\Social\Service\HashtagService;
+use OCA\Social\Service\StreamPruneService;
 use OCA\Social\Service\StreamService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
@@ -37,6 +38,7 @@ class CacheTest extends TestCase {
 	private $hashtagService;
 	/** @var StreamService&MockObject */
 	private $streamService;
+	private $streamPruneService;
 	/** @var CacheActorsRequest&MockObject */
 	private $cacheActorsRequest;
 	/** @var IJobList&MockObject */
@@ -53,6 +55,7 @@ class CacheTest extends TestCase {
 		$this->documentService = $this->createMock(DocumentService::class);
 		$this->hashtagService = $this->createMock(HashtagService::class);
 		$this->streamService = $this->createMock(StreamService::class);
+		$this->streamPruneService = $this->createMock(StreamPruneService::class);
 		$this->cacheActorsRequest = $this->createMock(CacheActorsRequest::class);
 		$this->jobList = $this->createMock(IJobList::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
@@ -64,6 +67,7 @@ class CacheTest extends TestCase {
 			$this->documentService,
 			$this->hashtagService,
 			$this->streamService,
+			$this->streamPruneService,
 			$this->cacheActorsRequest,
 			$this->logger
 		);

--- a/tests/Integration/Db/StreamPruneTest.php
+++ b/tests/Integration/Db/StreamPruneTest.php
@@ -216,6 +216,7 @@ class StreamPruneTest extends TestCase {
 			'type' => 'Document', 'parent_id' => $this->id('stale'), 'parent_id_prim' => $prim,
 			'media_type' => 'image/png', 'mime_type' => 'image/png', 'url' => 'https://remote.example/doc.png',
 			'local_copy' => '', 'resized_copy' => '', 'account' => '', 'error' => 0,
+			'meta' => '', 'blurhash' => '', 'description' => '',
 		]);
 
 		$result = $this->service->prune(90);

--- a/tests/Integration/Db/StreamPruneTest.php
+++ b/tests/Integration/Db/StreamPruneTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Social\Tests\Integration\Db;
+
+use DateTime;
+use OCA\Social\Db\CoreRequestBuilder;
+use OCA\Social\Db\FollowsRequest;
+use OCA\Social\Db\StreamRequest;
+use OCA\Social\Model\ActivityPub\Object\Follow;
+use OCA\Social\Model\ActivityPub\Object\Note;
+use OCA\Social\Service\StreamPruneService;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\Server;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Retention against the real database: every protection rule of
+ * StreamPruneService, the cascade over dest/act/tag/document rows, the
+ * dry-run counter, and the guarantee that local and recent rows survive.
+ */
+class StreamPruneTest extends TestCase {
+	private const BASE = 'https://cloud.example.org/prune';
+	private const AUTHOR = 'https://remote.example/prune/users/author';
+	private const FOLLOWED = 'https://remote.example/prune/users/followed';
+	private const VIEWER = self::BASE . '/users/viewer';
+
+	private const SUFFIXES = [
+		'stale', 'fresh', 'local', 'liked', 'actioned', 'followed-author',
+		'parent-of-local', 'local-reply', 'direct', 'boosted-object', 'local-boost',
+	];
+
+	private StreamRequest $streamRequest;
+	private FollowsRequest $followsRequest;
+	private StreamPruneService $service;
+	private IDBConnection $connection;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->streamRequest = Server::get(StreamRequest::class);
+		$this->followsRequest = Server::get(FollowsRequest::class);
+		$this->service = Server::get(StreamPruneService::class);
+		$this->connection = Server::get(IDBConnection::class);
+		$this->cleanup();
+	}
+
+	protected function tearDown(): void {
+		$this->cleanup();
+		parent::tearDown();
+	}
+
+	private function cleanup(): void {
+		foreach (self::SUFFIXES as $suffix) {
+			$this->streamRequest->deleteById($this->id($suffix), Note::TYPE);
+		}
+		foreach ([self::AUTHOR, self::FOLLOWED, self::VIEWER] as $actor) {
+			$this->followsRequest->deleteRelatedId($actor);
+		}
+		foreach ([CoreRequestBuilder::TABLE_STREAM_ACTIONS => 'stream_id_prim',
+			CoreRequestBuilder::TABLE_STREAM_DEST => 'stream_id',
+			CoreRequestBuilder::TABLE_STREAM_TAGS => 'stream_id',
+			CoreRequestBuilder::TABLE_CACHE_DOCUMENTS => 'parent_id_prim',
+			CoreRequestBuilder::TABLE_ACTIONS => 'object_id_prim'] as $table => $field) {
+			$qb = $this->connection->getQueryBuilder();
+			$qb->delete($table)->where($qb->expr()->in(
+				$field,
+				$qb->createNamedParameter(array_map(
+					fn (string $suffix): string => md5($this->id($suffix)), self::SUFFIXES
+				), IQueryBuilder::PARAM_STR_ARRAY)
+			));
+			$qb->executeStatement();
+		}
+	}
+
+	private function id(string $suffix): string {
+		return self::BASE . '/notes/' . $suffix;
+	}
+
+	private function note(
+		string $suffix, bool $old = true, bool $local = false,
+		string $author = self::AUTHOR, string $visibility = 'public',
+		string $inReplyTo = '', string $objectId = '',
+	): Note {
+		$note = new Note();
+		$note->setId($this->id($suffix));
+		$note->setAttributedTo($author);
+		$note->setTo('https://www.w3.org/ns/activitystreams#Public');
+		$note->setVisibility($visibility);
+		$note->setLocal($local);
+		$note->setInReplyTo($inReplyTo);
+		$note->setObjectId($objectId);
+		$note->setContent($suffix);
+		$note->setPublishedTime(time() - 200 * 86400);
+		$note->setPublished(gmdate('Y-m-d\TH:i:s\Z'));
+		$this->streamRequest->save($note);
+
+		if ($old) {
+			$qb = $this->connection->getQueryBuilder();
+			$qb->update(CoreRequestBuilder::TABLE_STREAM)
+				->set('creation', $qb->createNamedParameter(new DateTime('200 days ago'), IQueryBuilder::PARAM_DATE))
+				->where($qb->expr()->eq('id_prim', $qb->createNamedParameter(md5($note->getId()))));
+			$qb->executeStatement();
+		}
+
+		return $note;
+	}
+
+	private function exists(string $suffix): bool {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select('id_prim')->from(CoreRequestBuilder::TABLE_STREAM)
+			->where($qb->expr()->eq('id_prim', $qb->createNamedParameter(md5($this->id($suffix)))));
+		$cursor = $qb->executeQuery();
+		$found = $cursor->fetch() !== false;
+		$cursor->closeCursor();
+
+		return $found;
+	}
+
+	private function insert(string $table, array $values): void {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->insert($table);
+		foreach ($values as $field => $value) {
+			$qb->setValue($field, $qb->createNamedParameter($value));
+		}
+		$qb->executeStatement();
+	}
+
+	private function countRows(string $table, string $field, string $suffix): int {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->selectAlias($qb->createFunction('COUNT(*)'), 'count')->from($table)
+			->where($qb->expr()->eq($field, $qb->createNamedParameter(md5($this->id($suffix)))));
+		$cursor = $qb->executeQuery();
+		$count = (int)($cursor->fetch()['count'] ?? 0);
+		$cursor->closeCursor();
+
+		return $count;
+	}
+
+	public function testPruneRemovesOnlyStaleUnprotectedRemoteStatuses(): void {
+		$this->note('stale');
+		$this->note('fresh', false);
+		$this->note('local', true, true, self::VIEWER);
+		$this->note('direct', true, false, self::AUTHOR, 'direct');
+
+		// liked via the per-viewer flags
+		$this->note('liked');
+		$this->insert(CoreRequestBuilder::TABLE_STREAM_ACTIONS, [
+			'actor_id' => self::VIEWER, 'actor_id_prim' => md5(self::VIEWER),
+			'stream_id' => $this->id('liked'), 'stream_id_prim' => md5($this->id('liked')),
+			'liked' => 1, 'boosted' => 0, 'replied' => 0, 'bookmarked' => 0, 'values' => '[]',
+		]);
+
+		// liked via a Like action row
+		$this->note('actioned');
+		$this->insert(CoreRequestBuilder::TABLE_ACTIONS, [
+			'id' => $this->id('actioned') . '/like', 'id_prim' => md5($this->id('actioned') . '/like'),
+			'type' => 'Like', 'actor_id' => self::VIEWER, 'actor_id_prim' => md5(self::VIEWER),
+			'object_id' => $this->id('actioned'), 'object_id_prim' => md5($this->id('actioned')),
+		]);
+
+		// author followed by a local user
+		$this->note('followed-author', true, false, self::FOLLOWED);
+		$follow = new Follow();
+		$follow->setId(self::BASE . '/follows/1');
+		$follow->setActorId(self::VIEWER);
+		$follow->setObjectId(self::FOLLOWED);
+		$follow->setFollowId(self::FOLLOWED . '/followers');
+		$follow->setAccepted(true);
+		$this->followsRequest->save($follow);
+
+		// a local reply protects its remote parent
+		$this->note('parent-of-local');
+		$this->note('local-reply', true, true, self::VIEWER, 'public', $this->id('parent-of-local'));
+
+		// a local boost protects the boosted remote object
+		$this->note('boosted-object');
+		$this->note('local-boost', true, true, self::VIEWER, 'public', '', $this->id('boosted-object'));
+
+		// >= : a shared database may hold other stale remote rows
+		$dry = $this->service->prune(90, true);
+		$this->assertGreaterThanOrEqual(1, $dry['streams'], 'dry-run counts the stale row');
+		$this->assertTrue($this->exists('stale'), 'dry-run deletes nothing');
+
+		$result = $this->service->prune(90);
+
+		$this->assertGreaterThanOrEqual(1, $result['streams']);
+		$this->assertFalse($this->exists('stale'));
+		foreach (['fresh', 'local', 'direct', 'liked', 'actioned', 'followed-author',
+			'parent-of-local', 'local-reply', 'boosted-object', 'local-boost'] as $kept) {
+			$this->assertTrue($this->exists($kept), $kept . ' must survive');
+		}
+
+		// idempotent
+		$again = $this->service->prune(90);
+		$this->assertSame(0, $again['streams'], 'a second run finds nothing left');
+	}
+
+	public function testPruneCascadesOverRelatedRowsAndDocuments(): void {
+		$this->note('stale');
+		$prim = md5($this->id('stale'));
+		$this->insert(CoreRequestBuilder::TABLE_STREAM_DEST, [
+			'stream_id' => $prim, 'actor_id' => md5(self::VIEWER), 'type' => 'recipient', 'subtype' => 'to',
+		]);
+		$this->insert(CoreRequestBuilder::TABLE_STREAM_TAGS, [
+			'stream_id' => $prim, 'hashtag' => 'prunetag',
+		]);
+		$this->insert(CoreRequestBuilder::TABLE_CACHE_DOCUMENTS, [
+			'id' => $this->id('stale') . '/doc', 'id_prim' => md5($this->id('stale') . '/doc'),
+			'type' => 'Document', 'parent_id' => $this->id('stale'), 'parent_id_prim' => $prim,
+			'media_type' => 'image/png', 'mime_type' => 'image/png', 'url' => 'https://remote.example/doc.png',
+			'local_copy' => '', 'resized_copy' => '', 'account' => '', 'error' => 0,
+		]);
+
+		$result = $this->service->prune(90);
+
+		$this->assertGreaterThanOrEqual(1, $result['streams']);
+		$this->assertGreaterThanOrEqual(1, $result['documents']);
+		$this->assertSame(0, $this->countRows(CoreRequestBuilder::TABLE_STREAM_DEST, 'stream_id', 'stale'));
+		$this->assertSame(0, $this->countRows(CoreRequestBuilder::TABLE_STREAM_TAGS, 'stream_id', 'stale'));
+		$this->assertSame(0, $this->countRows(CoreRequestBuilder::TABLE_CACHE_DOCUMENTS, 'parent_id_prim', 'stale'));
+	}
+
+	public function testDisabledRetentionPrunesNothing(): void {
+		$this->note('stale');
+
+		$this->assertSame(['streams' => 0, 'documents' => 0], $this->service->prune(0));
+		$this->assertSame(['streams' => 0, 'documents' => 0], $this->service->prune());
+		$this->assertTrue($this->exists('stale'));
+	}
+}


### PR DESCRIPTION
Point 1 of the assessment follow-ups (3/6 in this series) — the scalability keystone: nothing ever pruned `social_stream`, so every remote status seen (home feeds, hashtag syncs, boosts) accumulated forever together with its dest rows and cached attachments.

## What it does

`StreamPruneService` deletes remote statuses older than **`retention_days`** (app setting, **default 0 = disabled**) — *unless someone local still cares*:

| kept when |
|---|
| a local user liked / boosted / replied / bookmarked it (per-viewer flag **or** Like/Announce action row) |
| a local user follows its author |
| a local status replies to it or boosts it (threads under local posts stay readable) |
| it is a direct message |
| it is local content (never touched, regardless of age) |

Deletion cascades over `social_stream_dest`, `social_stream_act`, `social_stream_tags`, and `social_cache_doc` rows including their appdata files (new `CacheDocumentService::removeFromCache()`). Selection is one query with four `NOT EXISTS` guards, processed oldest-first in chunks of 500.

## Where it runs
- **Cron**: bounded to 5000 statuses per run in `Cron\Cache`, so retention never dominates a cron slot.
- **occ**: `social:stream:prune [--days N] [--dry-run]` (documented in OCC-Commands.md).
- **Admin settings**: a Retention field in the Social section (new `POST /moderation/retention`, admin + CSRF, 0–3650 days).

## Tests
- Integration (real DB): the full protection matrix (each rule one seeded row), cascade over related rows and documents, dry-run counts without deleting, idempotence, disabled-by-default — green on devel (57 tests).
- Unit: moderation endpoint (validation + config write), cron wiring.
- Exercised over occ on devel: dry-run/enable/prune/disable round trip.

Docs updated: API.md, Architecture.md (service, cron, command count), OCC-Commands.md, README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)