### PR TITLE
ci: fix reuse workflow startup failure

### DIFF
--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -14,9 +14,6 @@ permissions:
 
 on: [pull_request]
 
-permissions:
-  contents: read
-
 jobs:
   reuse-compliance-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Follow-up to #2052: the runner-label revert left **two top-level `permissions:` keys** in reuse.yml. Duplicate mapping keys are invalid YAML, so GitHub cannot parse the workflow and every run since has been a startup failure with zero jobs (visible on each master merge). Removing the duplicate lets the REUSE check actually run again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
