### PR TITLE
perf: read a timeline in two queries instead of one wide DISTINCT

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -20,7 +20,7 @@ What it does:
 - 🌐 Federation: signed delivery of ActivityPub activities, with a delivery queue processed by cron
 
 You can pin your own posts to the top of your profile, bookmark any post, and see which hashtags the instance is using most. This is a partial implementation of ActivityPub and of the Mastodon client API. Blocking, muting and reporting (with a moderation panel in the administration settings) are supported, as are locked accounts with approvable follow requests. Polls are fully supported: create your own, and view and vote on federated ones. Profiles carry an avatar, a banner image and up to four profile metadata fields. Posts that link somewhere get a link preview card. Image (JPEG, PNG, GIF, WebP), video (MP4, WebM, QuickTime) and audio attachments are supported. It does not offer lists.]]></description>
-	<version>0.11.40</version>
+	<version>0.11.44</version>
 	<licence>agpl</licence>
 	<author mail="benedikt.schaechner@web.de" homepage="https://benedikt.xn--schchner-2za.de">Benedikt Schächner</author>
 	<namespace>Social</namespace>

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "nextcloud/social",
 	"description": "Social app",
 	"license": "AGPL-3.0-or-later",
-	"version": "0.11.40",
+	"version": "0.11.44",
 	"minimum-stability": "stable",
 	"authors": [
 		{

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -230,6 +230,27 @@ All three return the previous handler's response untouched when `FediverseServic
 
 ---
 
+### Reading a timeline
+
+A timeline is read in two queries rather than one.
+
+The first decides *which* posts belong in the page: it carries all the joins
+and filters (recipients, follows, hidden actors, duplicate suppression) but
+projects a single column, `s.nid`. The second fetches the rows for exactly
+those ids, joining only what is needed to render them.
+
+The reason is `SELECT DISTINCT`. Joining the recipients and follows tables can
+return a stream more than once, so the query has always been `DISTINCT` — over
+eighty columns, several of them TEXT. A database cannot deduplicate that
+without building and sorting the entire matching set first, which is why a
+timeline used to cost the same whether twenty rows were asked for or a hundred.
+Deduplicating one integer is cheap; the wide read is then a primary-key lookup
+of twenty rows.
+
+Measured with `occ social:benchmark` on 20 000 notes: the home timeline went
+from 219 ms to 89 ms and the public timeline from 121 ms to 29 ms, returning
+the same rows in the same order.
+
 ## Frontend Architecture
 
 The user interface is a **Vue 3** front end using Vue Router, Vuex, `@nextcloud/vue` components, `@nextcloud/axios`, DOMPurify (via `src/utils/sanitizeHtml.js`), linkifyjs, and twemoji.

--- a/lib/Db/StreamRequest.php
+++ b/lib/Db/StreamRequest.php
@@ -475,19 +475,42 @@ class StreamRequest extends StreamRequestBuilder {
 	 * @return Stream[]
 	 */
 	private function getTimelineHome(ProbeOptions $options): array {
+		// which posts, decided over one column, then what they say
+		$page = $this->getStreamNidsSelectSql();
+		$this->homeTimelineFilters($page, $options);
+		$nids = $this->getNidsFromRequest($page);
+
+		if ($nids === []) {
+			return [];
+		}
+
 		$qb = $this->getStreamSelectSql($options->getFormat());
+		$qb->andWhere(
+			$qb->expr()->in('s.nid', $qb->createNamedParameter($nids, IQueryBuilder::PARAM_INT_ARRAY))
+		);
+		$qb->orderBy('s.nid', $options->isInverted() ? 'asc' : 'desc');
 
-		$qb->filterType(SocialAppNotification::TYPE);
-		$qb->paginate($options);
-
-		$qb->limitToViewer('sd', 'f', false);
-		$this->timelineHomeLinkCacheActor($qb, 'ca', 'f');
-
+		// the author, for the row; the follows table stays out of this query
+		// because the page has already decided what belongs in it
+		$qb->linkToCacheActors('ca', 's.attributed_to_prim');
 		$qb->leftJoinStreamAction('sa');
 		$qb->leftJoinObjectStatus();
-		$qb->filterDuplicate();
 
 		return $this->getStreamsFromRequest($qb);
+	}
+
+	/**
+	 * Everything that decides whether a post belongs in the viewer's home
+	 * timeline. Applied to the query that picks the page; the query that reads
+	 * the rows afterwards needs none of it, because the page already said which.
+	 */
+	private function homeTimelineFilters(SocialQueryBuilder $qb, ProbeOptions $options): void {
+		$qb->filterType(SocialAppNotification::TYPE);
+		$qb->paginate($options);
+		$qb->limitToViewer('sd', 'f', false);
+		// a filter, not a join: it constrains on the follow's type
+		$this->timelineHomeLinkCacheActor($qb, 'ca', 'f');
+		$qb->filterDuplicate();
 	}
 
 	/**
@@ -804,22 +827,30 @@ class StreamRequest extends StreamRequestBuilder {
 	 * @return Stream[]
 	 */
 	private function getTimelinePublic(ProbeOptions $options): array {
-		$qb = $this->getStreamSelectSql($options->getFormat());
-		$qb->paginate($options);
+		$page = $this->getStreamNidsSelectSql();
+		$page->paginate($options);
 
 		if ($options->isLocal()) {
-			$qb->limitToLocal(true);
+			$page->limitToLocal(true);
 		}
-		$qb->limitToStatusTypes();
+		$page->limitToStatusTypes();
+		$page->selectDestFollowing('sd', '');
+		$page->innerJoinStreamDest('recipient', 'id_prim', 'sd', 's');
+		$page->limitToDest(ACore::CONTEXT_PUBLIC, 'recipient', 'to', 'sd');
+		$page->filterHiddenActors();
 
+		$nids = $this->getNidsFromRequest($page);
+		if ($nids === []) {
+			return [];
+		}
+
+		$qb = $this->getStreamSelectSql($options->getFormat());
+		$qb->andWhere(
+			$qb->expr()->in('s.nid', $qb->createNamedParameter($nids, IQueryBuilder::PARAM_INT_ARRAY))
+		);
+		$qb->orderBy('s.nid', $options->isInverted() ? 'asc' : 'desc');
 		$qb->linkToCacheActors('ca', 's.attributed_to_prim');
 		$qb->leftJoinStreamAction();
-
-		$qb->selectDestFollowing('sd', '');
-		$qb->innerJoinStreamDest('recipient', 'id_prim', 'sd', 's');
-		$qb->limitToDest(ACore::CONTEXT_PUBLIC, 'recipient', 'to', 'sd');
-
-		$qb->filterHiddenActors();
 
 		return $this->getStreamsFromRequest($qb);
 	}

--- a/lib/Db/StreamRequestBuilder.php
+++ b/lib/Db/StreamRequestBuilder.php
@@ -80,6 +80,43 @@ class StreamRequestBuilder extends CoreRequestBuilder {
 	}
 
 	/**
+	 * The same query, projecting one column.
+	 *
+	 * A timeline reads DISTINCT over eighty columns, several of them TEXT,
+	 * because joining the recipients and follows tables can return a stream
+	 * more than once. The database cannot deduplicate that without building
+	 * and sorting the whole matching set first, which is why a timeline used
+	 * to cost the same whether twenty rows were asked for or a hundred.
+	 *
+	 * Deduplicating one integer instead is cheap, so the page is chosen here
+	 * and the rows are fetched afterwards by id.
+	 */
+	protected function getStreamNidsSelectSql(): SocialQueryBuilder {
+		$qb = $this->getQueryBuilder();
+		$qb->selectDistinct('s.nid')
+			->from(self::TABLE_STREAM, 's');
+		$qb->setDefaultSelectAlias('s');
+
+		return $qb;
+	}
+
+	/**
+	 * @param SocialQueryBuilder $qb a query projecting s.nid
+	 *
+	 * @return int[] the ids of the page, in the order the query put them
+	 */
+	protected function getNidsFromRequest(SocialQueryBuilder $qb): array {
+		$nids = [];
+		$cursor = $qb->executeQuery();
+		while ($row = $cursor->fetch()) {
+			$nids[] = (int)$row['nid'];
+		}
+		$cursor->closeCursor();
+
+		return $nids;
+	}
+
+	/**
 	 * Base of the Sql Select request for Shares
 	 *
 	 * @return SocialQueryBuilder


### PR DESCRIPTION
## What I set out to do, and why it isn't here

The plan carried over from the benchmarking work in #2077 was a denormalised sort key on `social_stream_dest` — the theory being that timelines were slow because "newest first" lived on a different table from "addressed to me".

I built it: column, index, backfill repair step, a config flag so an instance part-way through the backfill stayed correct rather than losing posts.

**It made no difference.** 219 ms before, 219 ms after. And ordering by the copied key turned out to be *slower* than ordering by the original (124 ms vs 89 ms once the rest of this change was in place). None of that machinery is in this PR.

## What the problem actually was

Dumping the generated SQL:

```sql
SELECT DISTINCT `s`.`id`, `s`.`nid`, … `s`.`content`, `s`.`source`, `s`.`cache`,
                `ca`.…, `sa`.…, `os`.…   -- ~80 columns, several of them TEXT
```

The `DISTINCT` is there because joining recipients and follows can return one stream several times. No index can help with it: the database has to materialise the entire matching set and sort it before it can throw duplicates away.

That is exactly why the benchmark found the cost independent of page size — asking for 100 rows cost the same as asking for 20. The sort was never the issue; the *deduplication of wide rows* was.

## The fix

A timeline is now read in two queries:

1. **Which posts** — all the joins and filters, projecting one column (`s.nid`). Deduplicating an integer is cheap.
2. **What they say** — the wide read, restricted to those ids. A primary-key lookup of twenty rows.

The filters move to the first query, where they belong; the second joins only what it takes to render a row. `timelineHomeLinkCacheActor()` moved with them, since despite the name it constrains on the follow's type rather than merely joining.

## Measured

`occ social:benchmark`, 20 000 notes, on the instance I develop against:

| timeline | before | after |
|---|---:|---:|
| home (limit 20) | 219 ms | **89 ms** |
| public (limit 20) | 121 ms | **29 ms** |

At 5 000 notes: home 30 ms, public 11 ms.

**Same rows, same order.** Verified by running the old and new code against the same instance and diffing the returned ids for both timelines — identical.

## Verification

1909 unit tests, 91 integration tests against a real database.

## Still true

The timelines remain linear in the size of the table; this makes the constant several times smaller rather than changing the shape. Whether that is worth pursuing further is a question for someone with a production-sized instance to look at — I would not guess again without measuring, which is rather the lesson of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)