### PR TITLE
fix(psalm): clear the eight errors static analysis reports on master

### DIFF
--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -313,7 +313,7 @@ class ApiController extends Controller {
 			// name is — see the note in docs/API.md.
 			$header = $_FILES['header'] ?? [];
 			if ($header !== [] && ($header['error'] ?? UPLOAD_ERR_NO_FILE) === UPLOAD_ERR_OK) {
-				$this->bannerService->setFromTempFile($this->currentSession(), (string)$header['tmp_name']);
+				$this->bannerService->setFromTempFile($this->currentSession(), $header['tmp_name']);
 				$changed = true;
 			}
 

--- a/lib/Model/ActivityPub/Item.php
+++ b/lib/Model/ActivityPub/Item.php
@@ -50,7 +50,7 @@ class Item {
 		return $this->id;
 	}
 
-	public function setId(string $id): Item {
+	public function setId(string $id): static {
 		$this->id = $id;
 
 		return $this;
@@ -90,7 +90,7 @@ class Item {
 		return $this->url;
 	}
 
-	public function setUrl(string $url): Item {
+	public function setUrl(string $url): static {
 		$this->url = $url;
 
 		return $this;

--- a/lib/Model/ActivityPub/Stream.php
+++ b/lib/Model/ActivityPub/Stream.php
@@ -1256,7 +1256,7 @@ class Stream extends ACore implements IQueryRow, JsonSerializable {
 
 		$allowed = $this->isQuotable()
 			? [self::CONTEXT_PUBLIC]
-			: array_values(array_filter([$this->getAttributedTo()]));
+			: array_filter([$this->getAttributedTo()]);
 
 		return ['interactionPolicy' => ['canQuote' => ['automaticApproval' => $allowed]]];
 	}

--- a/lib/Model/Client/Options/CoreOptions.php
+++ b/lib/Model/Client/Options/CoreOptions.php
@@ -26,12 +26,7 @@ class CoreOptions {
 		return $this->format;
 	}
 
-	/**
-	 * @param int $format
-	 *
-	 * @return CoreOptions
-	 */
-	public function setFormat(int $format): self {
+	public function setFormat(int $format): static {
 		$this->format = $format;
 
 		return $this;

--- a/lib/Service/DomainBlockService.php
+++ b/lib/Service/DomainBlockService.php
@@ -183,7 +183,7 @@ class DomainBlockService {
 	private function isLocal(string $domain): bool {
 		return in_array(
 			$domain,
-			[strtolower($this->configService->getSocialAddress()), strtolower((string)$this->configService->getCloudHost())],
+			[strtolower($this->configService->getSocialAddress()), strtolower($this->configService->getCloudHost())],
 			true
 		);
 	}

--- a/lib/Service/DomainPurgeService.php
+++ b/lib/Service/DomainPurgeService.php
@@ -203,7 +203,7 @@ class DomainPurgeService {
 
 		$local = array_filter([
 			strtolower($this->configService->getSocialAddress()),
-			strtolower((string)$this->configService->getCloudHost()),
+			strtolower($this->configService->getCloudHost()),
 		]);
 		if (in_array($domain, $local, true)) {
 			throw new InvalidResourceException('cannot purge this instance');

--- a/lib/Service/FilterService.php
+++ b/lib/Service/FilterService.php
@@ -263,7 +263,7 @@ class FilterService {
 			return '';
 		}
 
-		return (string)$found[0];
+		return $found[0];
 	}
 
 	/**

--- a/lib/UserMigration/SocialMigrator.php
+++ b/lib/UserMigration/SocialMigrator.php
@@ -359,7 +359,7 @@ class SocialMigrator implements IMigrator, ISizeEstimationMigrator {
 				ProbeOptions::FAVOURITES => self::PATH_LIKES,
 			] as $probe => $path) {
 				$urls = [];
-				foreach ($this->posts($actor, (string)$probe) as $post) {
+				foreach ($this->posts($actor, $probe) as $post) {
 					$urls[] = $post->getId();
 				}
 


### PR DESCRIPTION
Psalm runs only on pull requests, never on pushes to master, so eight errors accumulated on master unnoticed. The effect is that `static-psalm-analysis` is red on **every** open pull request regardless of what that pull request changes — all ten open dependabot bumps included.

### What was wrong

Six are redundant operations psalm can prove are no-ops:

| File | Issue |
| --- | --- |
| `lib/Controller/ApiController.php:316` | cast to string on a value already string |
| `lib/Service/DomainBlockService.php:186` | same |
| `lib/Service/DomainPurgeService.php:206` | same |
| `lib/Service/FilterService.php:266` | same |
| `lib/UserMigration/SocialMigrator.php:362` | same |
| `lib/Model/ActivityPub/Stream.php:1259` | `array_values()` on a one-element array that is already a list |

The other two are fluent chains that lose the subtype:

- `InstanceActorService::getActor()` chains `setId()->setUrl()->setPreferredUsername()`. `Item::setId()` and `Item::setUrl()` declared `Item` as their return type, so by the third call psalm sees an `Item`, which has no `setPreferredUsername()`.
- `SocialMigrator::posts()` chains `setFormat()->setProbe()`. `CoreOptions::setFormat()` declared `self`, which in PHP means the declaring class literally, so psalm sees a `CoreOptions`, which has no `setProbe()`.

Declaring all three `static` keeps the caller's type through the chain.

### Safety

All three setters already `return $this`, so runtime behaviour is unchanged — `static` only describes what was always returned. No subclass overrides any of them: the other `setId()`/`setUrl()` definitions in `lib/` belong to classes outside the `Item` hierarchy, and `ProbeOptions` is the only subclass of `CoreOptions` and does not override `setFormat()`.

Verified locally with `php -l` on each changed file and `php-cs-fixer` (0 of 708 files need fixing). Psalm itself cannot run on this machine — 5.26.1 crashes on PHP 8.5 — so CI is the check that matters here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)