### PR TITLE
Re-verify the performance survey against master

### DIFF
--- a/docs/Performance.md
+++ b/docs/Performance.md
@@ -4,7 +4,8 @@ A survey of the query and scalability behaviour of this app: what costs what,
 what is bounded, and what is still known to be wrong. Every claim below was
 checked against the code rather than carried over from a previous survey.
 
-**Verified against:** app version 0.15.1, 2026-09-12.
+**Verified against:** app version 0.16.0, `master`, 2026-09-12 — re-checked
+after the federation, compatibility and dependency waves landed.
 
 This file is **not** enforced by `tests/DocumentationTest.php` — its claims are
 about behaviour rather than about routes or schema rows, and a test that tried
@@ -16,12 +17,29 @@ same change as any work on a read path.
 
 ### Unbounded work
 
-| Where | What happens |
-|-------|--------------|
-| `CacheDocumentsRequest::getNotCachedDocuments()` | No `setMaxResults`. `DocumentService::manageCacheDocuments()` loops the whole set with one outbound HTTP fetch per row, so a backlog of uncached avatars is attempted in a single cron slot. Its two siblings are capped — `CacheActorsRequest::getRemoteActorsToUpdateDetails()` at `SYNC_BATCH`, `StreamQueueRequest::getStandby()` at `STANDBY_BATCH` — and this one was missed. |
-| `FollowsRequest::getFollowersByActorId()` | Takes `$limit`, but the delivery fan-out (`FollowService::getFollowers()`, and `MigrationService`) calls it with no limit. A popular local actor's every post loads its whole follower set into PHP memory before the queue sees it. |
-| `PersonInterface::deleteStreamFromActor()` | An incoming `Delete` for a remote actor walks `getRelatedToActor()` — itself unbounded — and issues a `getStream()` and possibly an `update()` per row, inline in the HTTP request the peer is waiting on. |
-| `HashtagsRequest::getAll()` | Takes an optional limit; whoever calls it without one reads the whole table. |
+| Where | What happens | Cost grows with |
+|-------|--------------|-----------------|
+| `CacheDocumentsRequest::getNotCachedDocuments()` | No `setMaxResults`. `DocumentService::manageCacheDocuments()` loops the whole set with one outbound HTTP fetch per row, so a backlog of uncached avatars is attempted in a single cron slot. Its two siblings are capped — `CacheActorsRequest::getRemoteActorsToUpdateDetails()` at `SYNC_BATCH`, `StreamQueueRequest::getStandby()` at `STANDBY_BATCH` — and this one was missed. **The last unbounded cron loop.** | uncached remote media |
+| `PersonInterface::deleteStreamFromActor()` | An incoming `Delete` for a remote actor walks `StreamDestRequest::getRelatedToActor()` — which takes a `$limit` and is called without one — and issues a `getStream()` and possibly an `update()` per row, inline in the HTTP request the peer is waiting on. The peer times out and re-sends, and the work starts again. | posts that ever addressed that actor |
+| `FollowService::getFollowers()` | Returns every follower row, hydrated with its `Person` and details, for `LocalController::followers()`. The delivery path no longer goes near it (see below); this is the web UI's own list, and it has no paging at all. | one account's followers |
+| `HashtagsRequest::getAll()` | `HashtagService::manageHashtags()` calls it with no limit on every cron run, reading the whole hashtag table into memory to diff it against five aggregates. | distinct hashtags ever used |
+
+### One query per row on two read paths
+
+- **`GET /api/v1/accounts/search?following=true`** filters the candidates by
+  calling `FollowService::getRelationshipWith()` once per account, and each of
+  those is its own `social_follow` lookup plus the block, mute and note reads
+  behind a `Relationship`. Bounded — the candidate list is sliced to `limit`
+  first, at most 80 — but it is still up to 80 round trips to answer one
+  autocomplete keystroke, and clients call this on every keystroke.
+- **`FollowService::getRelationships()`**, which `/api/v1/accounts/relationships`
+  uses, resolves the actors in one batch and then builds each relationship the
+  same one-at-a-time way. A client asking about a page of 40 accounts pays 40
+  times.
+
+Both want the same thing: one query that reads the viewer's follow, block, mute
+and note rows for a *set* of actor ids. The join already exists per row; it is
+the loop around it that is the cost.
 
 ### No transactions, anywhere
 
@@ -45,11 +63,12 @@ visible:
 ### Wide `SELECT DISTINCT`
 
 `getStreamNidsSelectSql()` exists precisely to avoid deduplicating over every
-column — it selects nids, then hydrates. Five read paths use it: two branches of
-`getTimeline()` (home and public), the marked timelines (favourites and
+column — it selects nids, then hydrates. Seven call sites use it: the home and
+public branches of `getTimeline()`, the marked timelines (favourites and
 bookmarks), the list timeline in `ListsRequest`, and the deprecated direct
-timeline. Sixteen call sites still go through `getStreamSelectSql()`, which pairs `selectDistinct('s.id')` with the
-full stream column set plus, on some paths, a second `os_*` stream set and two
+timeline. **Eighteen** call sites in `StreamRequest` still go through
+`getStreamSelectSql()`, which pairs `selectDistinct('s.id')` with the full
+stream column set plus, on some paths, a second `os_*` stream set and two
 cached-actor and cached-document sets. The database sorts or hashes all of it —
 including `content`, `source`, `details`, `cache` and `to_array` — to
 deduplicate. Direct messages, account timelines, hashtag timelines,
@@ -68,7 +87,8 @@ webfinger both land there.
 
 - `social_follow`'s unique indexes `afoa` and `aoa` both **lead with the
   `accepted` boolean**, so `(object_id_prim, actor_id_prim)` is not unique: one
-  accepted and one pending row for the same pair can coexist.
+  accepted and one pending row for the same pair can coexist. This is the one
+  schema item on this list that is a correctness risk rather than a cost.
 - Several indexes from the 2022 migration are unnamed, so Doctrine names them
   per install and a later `hasIndex()`/`dropIndex()` cannot refer to them. Index
   names from that era are also not app-prefixed (`sa`, `ts`, `aoa`, …) and live
@@ -103,15 +123,42 @@ here so a reader who finds that report knows why the code no longer matches it.
 | `filterSilencedActors()` was dead code, so a silenced account was not silenced | Called from the three read paths that need it |
 | `HashtagService::manageHashtags()` ran five hydrated wide queries and one write per hashtag, and reported the same number for every window | `StreamRequest::countHashtagsSince()` is a grouped aggregate |
 | `CacheActorsRequest::getSharedInboxes()` returned `''` for actors with no shared inbox, which the caller turned into a delivery to the host `''` | Empty values and local actors are excluded in SQL |
+| The delivery fan-out hydrated every follower into a `Follow` with a `Person` and its details to read one string off each | `ActivityService::generateInstancePathsFollowers()` asks `FollowsRequest::getFollowerInboxes()` for one row per distinct inbox, resolved in the database — the number of *instances*, not of followers |
+| `MigrationService` re-followed on behalf of every local follower from one unbounded read | Paged at `REFOLLOW_PAGE`, bounded at `REFOLLOW_MAX` |
+| `social_actor.user_id` had no index, and it is what resolves the logged-in user's actor on every authenticated request | `Version1000Date20260912000001` adds `social_a_uid`, and the four `social_hashtag` trend columns got theirs |
+| `ReportService` and the account entity leaked `source` on every read, so every Account query carried `follow_requests_count` | `source` is built by the two credentials routes only; nothing else asks the database for it |
 
-## Rough order of value
+## What to do next
 
-1. Cap `getNotCachedDocuments()` — one line, and it is the last unbounded cron
-   loop.
-2. Bound the follower fan-out, which is the one unbounded read on the posting
-   path.
-3. Move the remaining sixteen read paths onto `getStreamNidsSelectSql()`.
-4. Wrap `StreamRequest::save()` in a transaction, and give
-   `StreamActionService::saveAction()` the insert-then-catch shape its
-   neighbours already use.
-5. The schema items, next time a migration touches those tables.
+Ordered by what it buys against what it costs, not by severity. The first three
+are an afternoon each; the fourth is the one that changes how the app scales.
+
+1. **Cap `getNotCachedDocuments()`.** One line, and it is the last unbounded
+   cron loop in the app. An instance that has been offline for a day currently
+   tries to fetch its whole media backlog in one slot.
+2. **Bound `deleteStreamFromActor()`.** It is the only unbounded read left on an
+   *inbound request* path, and the failure mode is the bad one: the peer times
+   out, re-sends the `Delete`, and the work starts over. Page it, or move it to
+   the stream queue where the rest of the inbox work already lives.
+3. **One query for a set of relationships.** Kills the N+1 behind
+   `accounts/search?following=true` and `accounts/relationships` at once, and
+   those are the two routes a client calls most often per keystroke and per
+   page.
+4. **Move the eighteen read paths onto `getStreamNidsSelectSql()`.** This is the
+   big one: every timeline that is not home or public still makes the database
+   sort or hash `content`, `source`, `details`, `cache` and `to_array` to
+   deduplicate a page of twenty rows. It is also the most mechanical — the
+   pattern exists, it is proven on five paths, and each move is
+   independently testable. Do notifications first: it carries two full stream
+   column sets, two cached-actor sets and two cached-document sets, and it is
+   polled by every client on a timer.
+5. **A transaction around `StreamRequest::save()`**, and the
+   insert-then-catch-unique shape for `StreamActionService::saveAction()` that
+   `ActorRelationRequest` and `StreamCardsRequest` already use. This is
+   correctness rather than speed: today a partial save leaves a post that exists
+   and is in nobody's timeline, invisibly.
+6. **`FollowService::getFollowers()`** needs paging before an instance has an
+   account with tens of thousands of followers, not after.
+7. The schema items, next time a migration touches those tables. The
+   `social_follow` index order is the one worth doing deliberately: it is the
+   reason a duplicate accepted/pending pair can exist at all.


### PR DESCRIPTION
Three waves have landed since `docs/Performance.md` was written, and it had started disagreeing with the code **in both directions** — claiming problems that are fixed, and missing ones that are real. Every line was re-checked against the code rather than carried over.

### Fixed, and removed from the open list

- **The delivery fan-out.** It no longer hydrates every follower into a `Follow` with a `Person` and its details to read one inbox string off each: `ActivityService::generateInstancePathsFollowers()` asks `FollowsRequest::getFollowerInboxes()` for one row per distinct inbox, resolved in the database. The cost is now the number of *instances*, not of followers.
- **`MigrationService`** pages its re-follows (`REFOLLOW_PAGE`, bounded by `REFOLLOW_MAX`).
- **`social_actor.user_id` has an index** — it is what resolves the logged-in user's actor on every authenticated request, and it had none.

### Real, and newly listed

- **`PersonInterface::deleteStreamFromActor()`** is the only unbounded read left on an *inbound request* path, and its failure mode is the bad one: it walks `getRelatedToActor()` (which takes a `$limit` and is called without one) inline in the HTTP request a peer is waiting on. The peer times out, re-sends the `Delete`, and the work starts over.
- **`HashtagsRequest::getAll()`** reads the whole hashtag table into memory on every cron run, to diff it against five aggregates.
- **One query per row on the two hottest client routes.** `accounts/search?following=true` builds a `Relationship` per candidate — up to eighty round trips to answer a single autocomplete keystroke — and `accounts/relationships` does the same per account in a page. Both want one query that reads the viewer's follow, block, mute and note rows for a *set* of ids.

### Counted rather than remembered

The wide-`SELECT DISTINCT` figure was wrong: it is **eighteen** call sites still on `getStreamSelectSql()` against seven on the nid-based path.

## The suggestion

The "Rough order of value" section is replaced by **"What to do next"**, which says what each item buys against what it costs:

1. Cap `getNotCachedDocuments()` — one line, the last unbounded cron loop.
2. Bound `deleteStreamFromActor()` — the only unbounded read on an inbound path, and the one that makes a peer retry.
3. One query for a set of relationships — kills both N+1s at once.
4. **Move the eighteen read paths onto `getStreamNidsSelectSql()`** — the one that changes how the app scales, and the most mechanical: the pattern is proven on seven paths and each move is independently testable. Start with notifications, which carries two full stream column sets, two cached-actor sets and two cached-document sets, and is polled by every client on a timer.
5. A transaction around `StreamRequest::save()` — correctness, not speed: today a partial save leaves a post that exists and is in nobody's timeline, invisibly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
