### PR TITLE
fix(cache): the cache cron passes over a streamed file

### DIFF
--- a/lib/Service/DocumentService.php
+++ b/lib/Service/DocumentService.php
@@ -441,7 +441,16 @@ class DocumentService {
 
 		$count = 0;
 		foreach ($update as $item) {
-			if ($item->getLocalCopy() === 'avatar' || $item->getLocalCopy() === 'header') {
+			// None of these three should reach here at all: the query asks for
+			// an *empty* `local_copy` and all three name theirs before the row
+			// is written. They are checked anyway because the cost of the
+			// invariant breaking is not symmetric -- a missed avatar is a
+			// wasted request, while a streamed file is a PeerTube video, and
+			// fetching one would spend hundreds of megabytes of disk to hand
+			// back exactly the bytes the publishing instance already streams.
+			if ($item->getLocalCopy() === 'avatar'
+				|| $item->getLocalCopy() === 'header'
+				|| $item->isStreamed()) {
 				continue;
 			}
 

--- a/tests/Service/DocumentServiceTest.php
+++ b/tests/Service/DocumentServiceTest.php
@@ -512,6 +512,27 @@ class DocumentServiceTest extends TestCase {
 		$this->assertSame(1, $this->service->manageCacheDocuments());
 	}
 
+	/**
+	 * A streamed file is played from the instance that published it, and the
+	 * cache job passes over it the way it passes over an avatar.
+	 *
+	 * Belt and braces, and deliberately so: such a row should never reach the
+	 * loop, because `getNotCachedDocuments()` asks for an empty `local_copy`
+	 * and `PeerTubeService` names it `stream` before the row is written. This
+	 * pins the guard that holds if either of those ever changes, because the
+	 * cost is not symmetric -- the file on the other side of it is a video of
+	 * hundreds of megabytes.
+	 */
+	public function testManageCacheDocumentsDoesNotDownloadAStreamedFile(): void {
+		$streamed = $this->document(Document::COPY_STREAMED);
+		$streamed->setId('https://peertube.example/videos/watch/abc');
+		$this->cacheDocumentsRequest->method('getNotCachedDocuments')->willReturn([$streamed]);
+		$this->cacheDocumentsRequest->expects($this->never())->method('getById');
+		$this->cacheService->expects($this->never())->method('saveRemoteFileToCache');
+
+		$this->assertSame(0, $this->service->manageCacheDocuments());
+	}
+
 	private function alice(int $avatarVersion): Person {
 		$alice = new Person();
 		$alice->setId('https://cloud.example.com/apps/social/@alice');


### PR DESCRIPTION
This PR opened as a rescue of PeerTube work from the devel box. **#2143 then merged the same work, done more fully**, so I rebased onto master and nearly all of it turned out to be already there:

- `PeerTubeService`, `StreamedRemoteResponse`, both tests — identical or subsumed (master's `PeerTubeService` is 171 lines larger and carries the outbound `asVideo()` half)
- `only_video` — `ProbeOptions`, `limitToVideo()`, the `filterMedia()` precedence, the route param: master has all of it, and its `filterMedia()` is byte-identical in code to what I had written. Master's docs also cover the tag and list timelines, which mine did not.
- `Document::COPY_STREAMED` — master's, and note its value is `stream` where mine was `streamed`

What is left is one thing master does not have.

### The change

`manageCacheDocuments()` skips an avatar and a header because both name their `local_copy` rather than holding a file. A streamed document is the same kind of thing — a PeerTube video played from the instance that published it — and was not in the list.

It should never reach that loop either way: `getNotCachedDocuments()` asks for an *empty* `local_copy`, and `PeerTubeService` sets `stream` before the row is written. So this is belt and braces, exactly as the two conditions beside it are, and for the same reason: the cost is not symmetric. A missed avatar is one wasted request; the file behind this one is a video of hundreds of megabytes, fetched to hand back exactly the bytes the remote instance is already built to stream.

The test pins the guard rather than the invariant — it fails if the condition is removed.

### Verification

psalm clean · `cs:check` 0 of 790 · 4465 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)