### PR TITLE
[master] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "social",
-	"version": "0.17.0",
+	"version": "0.19.12",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "social",
-			"version": "0.17.0",
+			"version": "0.19.12",
 			"license": "agpl",
 			"dependencies": {
 				"@nextcloud/auth": "^2.0.0",
@@ -5709,9 +5709,9 @@
 			"license": "MIT"
 		},
 		"node_modules/body-parser": {
-			"version": "1.20.5",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-			"integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+			"version": "1.20.8",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.8.tgz",
+			"integrity": "sha512-JNcyFQ64OiijEkPzUBTCe+hyPXUD/3LEldGQ6iF5LR1w00mx9o7xtDWHXBY2iItjdCFGoilOLNQbH943ut7pHA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5723,7 +5723,7 @@
 				"http-errors": "~2.0.1",
 				"iconv-lite": "~0.4.24",
 				"on-finished": "~2.4.1",
-				"qs": "~6.15.1",
+				"qs": "~6.16.0",
 				"raw-body": "~2.5.3",
 				"type-is": "~1.6.18",
 				"unpipe": "~1.0.0"
@@ -5749,6 +5749,23 @@
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/body-parser/node_modules/qs": {
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+			"integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"es-define-property": "^1.0.1",
+				"side-channel": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/bonjour-service": {
 			"version": "1.4.1",
@@ -7975,15 +7992,15 @@
 			}
 		},
 		"node_modules/express": {
-			"version": "4.22.2",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
-			"integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+			"integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"accepts": "~1.3.8",
 				"array-flatten": "1.1.1",
-				"body-parser": "~1.20.5",
+				"body-parser": "~1.20.3",
 				"content-disposition": "~0.5.4",
 				"content-type": "~1.0.4",
 				"cookie": "~0.7.1",
@@ -8002,7 +8019,7 @@
 				"parseurl": "~1.3.3",
 				"path-to-regexp": "~0.1.12",
 				"proxy-addr": "~2.0.7",
-				"qs": "~6.15.1",
+				"qs": "~6.14.0",
 				"range-parser": "~1.2.1",
 				"safe-buffer": "5.2.1",
 				"send": "~0.19.0",
@@ -8037,6 +8054,22 @@
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/express/node_modules/qs": {
+			"version": "6.14.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/exsolve": {
 			"version": "1.1.1",
@@ -13120,13 +13153,14 @@
 			"license": "MIT"
 		},
 		"node_modules/qs": {
-			"version": "6.15.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-			"integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+			"version": "6.15.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+			"integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"side-channel": "^1.1.0"
+				"es-define-property": "^1.0.1",
+				"side-channel": "^1.1.1"
 			},
 			"engines": {
 				"node": ">=0.6"


### PR DESCRIPTION
# Audit report

This audit fix resolves 9 of the total 9 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/webpack-vue-config](#user-content-\@nextcloud\/webpack-vue-config)
* [body-parser](#user-content-body-parser)
* [browserify-sign](#user-content-browserify-sign)
* [create-ecdh](#user-content-create-ecdh)
* [crypto-browserify](#user-content-crypto-browserify)
* [elliptic](#user-content-elliptic)
* [express](#user-content-express)
* [node-polyfill-webpack-plugin](#user-content-node-polyfill-webpack-plugin)
* [qs](#user-content-qs)
## Fixed vulnerabilities

### @nextcloud/webpack-vue-config <a href="#user-content-\@nextcloud\/webpack-vue-config" id="\@nextcloud\/webpack-vue-config">#</a>
* Caused by vulnerable dependency:
  * [node-polyfill-webpack-plugin](#user-content-node-polyfill-webpack-plugin)
* Affected versions: >=4.0.1
* Package usage:
  * `node_modules/@nextcloud/webpack-vue-config`

### body-parser <a href="#user-content-body-parser" id="body-parser">#</a>
* body-parser vulnerable to denial of service when invalid limit value silently disables size enforcement
* Severity: **low** (CVSS 3.7)
* Reference: [https://github.com/advisories/GHSA-v422-hmwv-36x6](https://github.com/advisories/GHSA-v422-hmwv-36x6)
* Affected versions: <=1.20.6
* Package usage:
  * `node_modules/body-parser`

### browserify-sign <a href="#user-content-browserify-sign" id="browserify-sign">#</a>
* Caused by vulnerable dependency:
  * [elliptic](#user-content-elliptic)
* Affected versions: >=2.4.0
* Package usage:
  * `node_modules/browserify-sign`

### create-ecdh <a href="#user-content-create-ecdh" id="create-ecdh">#</a>
* Caused by vulnerable dependency:
  * [elliptic](#user-content-elliptic)
* Affected versions: *
* Package usage:
  * `node_modules/create-ecdh`

### crypto-browserify <a href="#user-content-crypto-browserify" id="crypto-browserify">#</a>
* Caused by vulnerable dependency:
  * [browserify-sign](#user-content-browserify-sign)
  * [create-ecdh](#user-content-create-ecdh)
* Affected versions: >=3.4.0
* Package usage:
  * `node_modules/crypto-browserify`

### elliptic <a href="#user-content-elliptic" id="elliptic">#</a>
* Elliptic Uses a Cryptographic Primitive with a Risky Implementation
* Severity: **low** (CVSS 5.6)
* Reference: [https://github.com/advisories/GHSA-848j-6mx2-7j84](https://github.com/advisories/GHSA-848j-6mx2-7j84)
* Affected versions: *
* Package usage:
  * `node_modules/elliptic`

### express <a href="#user-content-express" id="express">#</a>
* Caused by vulnerable dependency:
  * [qs](#user-content-qs)
* Affected versions: 4.22.2
* Package usage:
  * `node_modules/express`

### node-polyfill-webpack-plugin <a href="#user-content-node-polyfill-webpack-plugin" id="node-polyfill-webpack-plugin">#</a>
* Caused by vulnerable dependency:
  * [crypto-browserify](#user-content-crypto-browserify)
* Affected versions: <=4.0.0
* Package usage:
  * `node_modules/node-polyfill-webpack-plugin`

### qs <a href="#user-content-qs" id="qs">#</a>
* qs array-limit bypass via bracket-key comma parsing
* Severity: **moderate** (CVSS 3.7)
* Reference: [https://github.com/advisories/GHSA-x5fp-wj9c-mxmx](https://github.com/advisories/GHSA-x5fp-wj9c-mxmx)
* Affected versions: 2.2.5 - 6.15.3
* Package usage:
  * `node_modules/qs`